### PR TITLE
[mjml-core] Update mjml2html to return Promise<MJMLParseResults> for v5

### DIFF
--- a/types/mjml-browser/mjml-browser-tests.ts
+++ b/types/mjml-browser/mjml-browser-tests.ts
@@ -1,19 +1,21 @@
 import mjml2html = require("mjml-browser");
 
-const simple_test = mjml2html("<mjml>");
-const html = simple_test.html;
-const errors = simple_test.errors;
-let formattedMessage = errors[0].formattedMessage;
-formattedMessage = "force string test";
+async function tests() {
+    const simple_test = await mjml2html("<mjml>");
+    const html = simple_test.html;
+    const errors = simple_test.errors;
+    let formattedMessage = errors[0].formattedMessage;
+    formattedMessage = "force string test";
 
-const minimalOptionsTest = mjml2html("<mjml>", { beautify: true });
-const validationLevelTest = mjml2html("<mjml>", { validationLevel: "strict" });
-const filePathTest = mjml2html("<mjml>", { filePath: "." });
+    const minimalOptionsTest = await mjml2html("<mjml>", { beautify: true });
+    const validationLevelTest = await mjml2html("<mjml>", { validationLevel: "strict" });
+    const filePathTest = await mjml2html("<mjml>", { filePath: "." });
 
-const jsonObject = { tagName: "mjml", attributes: { width: "100px" }, content: "test content" };
-const jsonObjectTest = mjml2html(jsonObject);
+    const jsonObject = { tagName: "mjml", attributes: { width: "100px" }, content: "test content" };
+    const jsonObjectTest = await mjml2html(jsonObject);
 
-const minifyTest = mjml2html("<mjml", { minifyOptions: { minifyCSS: true } });
-const minifyAllTest = mjml2html("<mjml", {
-    minifyOptions: { minifyCSS: true, collapseWhitespace: true, removeEmptyAttributes: true },
-});
+    const minifyTest = await mjml2html("<mjml", { minifyOptions: { minifyCSS: true } });
+    const minifyAllTest = await mjml2html("<mjml", {
+        minifyOptions: { minifyCSS: true, collapseWhitespace: true, removeEmptyAttributes: true },
+    });
+}

--- a/types/mjml-browser/package.json
+++ b/types/mjml-browser/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/mjml-browser",
-    "version": "4.15.9999",
+    "version": "5.0.9999",
     "projects": [
         "https://github.com/mjmlio/mjml",
         "https://mjml.io"

--- a/types/mjml-core/index.d.ts
+++ b/types/mjml-core/index.d.ts
@@ -2,7 +2,7 @@
  * The main parser for MJML.
  * This version doesn't contain any of the core components registered in the 'mjml' package.
  */
-export default function mjml2html(input: string | MJMLJsonObject, options?: MJMLParsingOptions): MJMLParseResults;
+export default function mjml2html(input: string | MJMLJsonObject, options?: MJMLParsingOptions): Promise<MJMLParseResults>;
 
 /**
  * Options passed as an object to the mjml2html function

--- a/types/mjml-core/index.d.ts
+++ b/types/mjml-core/index.d.ts
@@ -2,7 +2,10 @@
  * The main parser for MJML.
  * This version doesn't contain any of the core components registered in the 'mjml' package.
  */
-export default function mjml2html(input: string | MJMLJsonObject, options?: MJMLParsingOptions): Promise<MJMLParseResults>;
+export default function mjml2html(
+    input: string | MJMLJsonObject,
+    options?: MJMLParsingOptions,
+): Promise<MJMLParseResults>;
 
 /**
  * Options passed as an object to the mjml2html function

--- a/types/mjml-core/index.d.ts
+++ b/types/mjml-core/index.d.ts
@@ -117,7 +117,7 @@ export interface MJMLMinifyOptions {
      * Accepts false (disable), true/'lite' (use lite preset), or a cssnano options object.
      * @see https://cssnano.co/docs/presets
      */
-    minifyCss?: boolean | "lite" | { preset?: "lite" | object | [object, object] } | object | undefined;
+    minifyCss?: boolean | "lite" | { preset?: any; plugins?: any[]; configFile?: string } | undefined;
     /** @deprecated use minifyCss instead */
     minifyCSS?: boolean | undefined;
     removeEmptyAttributes?: boolean | undefined;

--- a/types/mjml-core/index.d.ts
+++ b/types/mjml-core/index.d.ts
@@ -28,28 +28,24 @@ export interface MJMLParsingOptions {
     keepComments?: boolean | undefined;
 
     /**
-     * @deprecated use js-beautify directly after processing the MJML
-     *
-     * Option to beautify the HTML output
+     * Beautify the HTML output using prettier (parser: 'html', printWidth: 240).
+     * Mutually exclusive with minify — if minify is true, beautify is skipped.
+     * Note: the CLI defaults this to true; the programmatic API defaults to false.
      * default: false
      */
     beautify?: boolean | undefined;
 
     /**
-     * @deprecated use html-minifier directly after processing the MJML
-     *
-     * Option to minify the HTML output
-     *
+     * Minify the HTML output using htmlnano (with cssnano-preset-lite for CSS).
+     * Takes priority over beautify when both are true.
      * default: false
      */
     minify?: boolean | undefined;
+
     /**
-     * @deprecated @see minify
-     *
-     * Options for html minifier, see mjml-cli documentation for more info
-     * Passed directly to html-minifier as options
-     *
-     * default: @see htmlMinify usage in mjml-core/src/index.js
+     * Options passed to htmlnano when minify is true.
+     * The minifyCss field accepts false, true, 'lite', or a cssnano options object.
+     * All htmlnano v3 options are accepted.
      */
     minifyOptions?: MJMLMinifyOptions | undefined;
 
@@ -116,8 +112,17 @@ export interface MJMLParsingOptions {
 
 export interface MJMLMinifyOptions {
     collapseWhitespace?: boolean | undefined;
+    /**
+     * CSS minification options passed to cssnano-preset-lite.
+     * Accepts false (disable), true/'lite' (use lite preset), or a cssnano options object.
+     * @see https://cssnano.co/docs/presets
+     */
+    minifyCss?: boolean | "lite" | { preset?: "lite" | object | [object, object] } | object | undefined;
+    /** @deprecated use minifyCss instead */
     minifyCSS?: boolean | undefined;
     removeEmptyAttributes?: boolean | undefined;
+    minifyJs?: boolean | undefined;
+    removeComments?: false | "safe" | "all" | undefined;
 }
 
 export interface MJMLParseResults {

--- a/types/mjml-core/mjml-core-tests.ts
+++ b/types/mjml-core/mjml-core-tests.ts
@@ -1,22 +1,24 @@
 import mjml2html, { BodyComponent, Component, HeadComponent, MJMLJsonObject, registerComponent } from "mjml-core";
 
-const simple_test = mjml2html("<mjml>");
-const html = simple_test.html;
-const errors = simple_test.errors;
-let formattedMessage = errors[0].formattedMessage;
-formattedMessage = "force string test";
+async function tests() {
+    const simple_test = await mjml2html("<mjml>");
+    const html = simple_test.html;
+    const errors = simple_test.errors;
+    let formattedMessage = errors[0].formattedMessage;
+    formattedMessage = "force string test";
 
-const minimal_opts_test = mjml2html("<mjml>", { beautify: true });
-const validation_level_test = mjml2html("<mjml>", { validationLevel: "strict" });
-const filePath_test = mjml2html("<mjml>", { filePath: "." });
+    const minimal_opts_test = await mjml2html("<mjml>", { beautify: true });
+    const validation_level_test = await mjml2html("<mjml>", { validationLevel: "strict" });
+    const filePath_test = await mjml2html("<mjml>", { filePath: "." });
 
-const jsonObject = { tagName: "mjml", attributes: { width: "100px" }, content: "test content" };
-const jsonObject_test = mjml2html(jsonObject);
+    const jsonObject = { tagName: "mjml", attributes: { width: "100px" }, content: "test content" };
+    const jsonObject_test = await mjml2html(jsonObject);
 
-const minify_opts_test = mjml2html("<mjml", { minifyOptions: { minifyCSS: true } });
-const minify_opts_all_test = mjml2html("<mjml", {
-    minifyOptions: { minifyCSS: true, collapseWhitespace: true, removeEmptyAttributes: true },
-});
+    const minify_opts_test = await mjml2html("<mjml", { minifyOptions: { minifyCSS: true } });
+    const minify_opts_all_test = await mjml2html("<mjml", {
+        minifyOptions: { minifyCSS: true, collapseWhitespace: true, removeEmptyAttributes: true },
+    });
+}
 
 class NewBodyComponent extends BodyComponent {
     render() {

--- a/types/mjml-core/package.json
+++ b/types/mjml-core/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/mjml-core",
-    "version": "4.15.9999",
+    "version": "5.0.9999",
     "projects": [
         "https://mjml.io"
     ],

--- a/types/mjml/mjml-tests.ts
+++ b/types/mjml/mjml-tests.ts
@@ -1,19 +1,21 @@
 import mjml2html = require("mjml");
 
-const simple_test = mjml2html("<mjml>");
-const html = simple_test.html;
-const errors = simple_test.errors;
-let formattedMessage = errors[0].formattedMessage;
-formattedMessage = "force string test";
+async function tests() {
+    const simple_test = await mjml2html("<mjml>");
+    const html = simple_test.html;
+    const errors = simple_test.errors;
+    let formattedMessage = errors[0].formattedMessage;
+    formattedMessage = "force string test";
 
-const minimal_opts_test = mjml2html("<mjml>", { beautify: true });
-const validation_level_test = mjml2html("<mjml>", { validationLevel: "strict" });
-const filePath_test = mjml2html("<mjml>", { filePath: "." });
+    const minimal_opts_test = await mjml2html("<mjml>", { beautify: true });
+    const validation_level_test = await mjml2html("<mjml>", { validationLevel: "strict" });
+    const filePath_test = await mjml2html("<mjml>", { filePath: "." });
 
-const jsonObject = { tagName: "mjml", attributes: { width: "100px" }, content: "test content" };
-const jsonObject_test = mjml2html(jsonObject);
+    const jsonObject = { tagName: "mjml", attributes: { width: "100px" }, content: "test content" };
+    const jsonObject_test = await mjml2html(jsonObject);
 
-const minify_opts_test = mjml2html("<mjml", { minifyOptions: { minifyCSS: true } });
-const minify_opts_all_test = mjml2html("<mjml", {
-    minifyOptions: { minifyCSS: true, collapseWhitespace: true, removeEmptyAttributes: true },
-});
+    const minify_opts_test = await mjml2html("<mjml", { minifyOptions: { minifyCSS: true } });
+    const minify_opts_all_test = await mjml2html("<mjml", {
+        minifyOptions: { minifyCSS: true, collapseWhitespace: true, removeEmptyAttributes: true },
+    });
+}

--- a/types/mjml/package.json
+++ b/types/mjml/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/mjml",
-    "version": "4.7.9999",
+    "version": "5.0.9999",
     "projects": [
         "https://github.com/mjmlio/mjml",
         "https://mjml.io"


### PR DESCRIPTION
## Description

mjml v5 changed `mjml2html` from a synchronous to an asynchronous function. It now `await`s `htmlnano` (for the `minify` option) and `prettier` (for the `beautify` option) internally.

**Source reference:** `mjml-core@5.0.0/lib/index.js` — the function is declared `async function mjml2html(...)`.

## Changes

- `types/mjml-core/index.d.ts`: Change return type of `mjml2html` from `MJMLParseResults` to `Promise<MJMLParseResults>`
- `types/mjml-core/package.json`: Bump version from `4.15.9999` to `5.0.9999`
- `types/mjml/package.json`: Bump version from `4.7.9999` to `5.0.9999`
- `types/mjml-core/mjml-core-tests.ts`: Wrap `mjml2html` call sites in an `async function`
- `types/mjml/mjml-tests.ts`: Same

`types/mjml/index.d.ts` requires no change — it re-exports `mjml2html` from `mjml-core` and inherits the updated return type automatically.