### PR TITLE
[chrome] Fix the types for chrome.runtime message handlers

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -9748,12 +9748,20 @@ declare namespace chrome {
 
         /** Fired when a message is sent from either {@link runtime.sendMessage} or {@link tabs.sendMessage}. */
         export const onMessage: events.Event<
-            (message: any, sender: MessageSender, sendResponse: (response?: any) => void) => void
+            (
+                message: any,
+                sender: MessageSender,
+                sendResponse: (response?: any) => void,
+            ) => boolean | Promise<any> | undefined
         >;
 
         /** Fired when a message is sent from another extension (by {@link runtime.sendMessage}). Cannot be used in a content script. */
         export const onMessageExternal: events.Event<
-            (message: any, sender: MessageSender, sendResponse: (response?: any) => void) => void
+            (
+                message: any,
+                sender: MessageSender,
+                sendResponse: (response?: any) => void,
+            ) => boolean | Promise<any> | undefined
         >;
 
         /** Fired when an app or the device that it runs on needs to be restarted. The app should close all its windows at its earliest convenient time to let the restart to happen. If the app does nothing, a restart will be enforced after a 24-hour grace period has passed. Currently, this event is only fired for Chrome OS kiosk apps. */

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -986,12 +986,30 @@ function testRuntime() {
         message; // $ExpectType any
         sender; // $ExpectType MessageSender
         sendResponse(); // $ExpectType void
+        return undefined;
+    });
+
+    chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+        return true;
+    });
+
+    chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+        return Promise.resolve("Test response");
+    });
+
+    chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+        return undefined;
     });
 
     checkChromeEvent(chrome.runtime.onMessageExternal, (message, sender, sendResponse) => {
         message; // $ExpectType any
         sender; // $ExpectType MessageSender
         sendResponse(); // $ExpectType void
+        return undefined;
+    });
+
+    chrome.runtime.onMessageExternal.addListener((message, sender, sendResponse) => {
+        return true;
     });
 
     checkChromeEvent(chrome.runtime.onRestartRequired, (reason) => {

--- a/types/naver-whale/test/index.ts
+++ b/types/naver-whale/test/index.ts
@@ -14,6 +14,7 @@ function MessageExample() {
         if (message === `How are you?`) {
             sendResponse(`I'm fine thank you and you?`);
         }
+        return undefined;
     });
 
     // contentScript
@@ -54,6 +55,7 @@ function MessageExample() {
         // 그러므로 sidebarAction.show() 의 콜백에서 보내는 메시지는 이곳에 도달하지 않습니다.
         whale.runtime.onMessage.addListener(message => {
             console.log(message);
+            return undefined;
         });
     });
 }


### PR DESCRIPTION
### Description

The return types for `chrome.runtime` message handlers are defined as void, which is incorrect. The correct type is `boolean | Promise<any> | undefined` as listed here:

https://developer.chrome.com/docs/extensions/reference/api/runtime#event-onMessage https://developer.chrome.com/docs/extensions/reference/api/runtime#event-onMessageExternal

### Changes

- Update `types/chrome/index.d.ts` to fix return type to `boolean | Promise<any> | undefined`
- Update tests to check `onMessage` return types
- Update the naver-whale return type tests to match.