### PR TITLE
[oojs-ui]: add `inline` config option for ProgressBarWidget

### DIFF
--- a/types/oojs-ui/ProgressBarWidget.d.ts
+++ b/types/oojs-ui/ProgressBarWidget.d.ts
@@ -47,6 +47,10 @@ declare namespace OO.ui {
              * By default, the progress bar is indeterminate.
              */
             progress?: number | false;
+            /**
+             * Use a smaller inline variant on the progress bar
+             */
+            inline?: boolean;
         }
 
         type Static = Widget.Static;

--- a/types/oojs-ui/oojs-ui-tests.ts
+++ b/types/oojs-ui/oojs-ui-tests.ts
@@ -3103,6 +3103,14 @@
         progress: true,
     });
 
+    const instance3 = new OO.ui.ProgressBarWidget({
+        inline: true,
+    });
+
+    const instance4 = new OO.ui.ProgressBarWidget({
+        inline: false,
+    });
+
     instance.getProgress(); // $ExpectType number | false
 
     instance.setProgress(100); // $ExpectType void
@@ -3111,6 +3119,12 @@
 
     // @ts-expect-error
     instance.setProgress(true);
+
+    // @ts-expect-error
+    instance.setInline(true);
+
+    // @ts-expect-error
+    instance.setInline(false);
 }
 // #endregion
 

--- a/types/oojs-ui/package.json
+++ b/types/oojs-ui/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/oojs-ui",
-    "version": "0.49.9999",
+    "version": "0.50.9999",
     "projects": [
         "https://www.mediawiki.org/wiki/OOUI"
     ],


### PR DESCRIPTION
Added in v0.50.1: https://w.wiki/Ltwj

This appears to be the only relevant change for v0.50.x for oojs-ui, with no other apparent type changes [according to the `History.md`](https://gerrit.wikimedia.org/r/plugins/gitiles/oojs/ui/+/refs/heads/master/History.md#v0_50_0-2024_06_11). As a result, I've bumped the version to `v0.50.9999` to reflect this change.

`setInline` does not exist as a function for this class, so I've added it as a negative test.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [Gerrit change](https://w.wiki/Ltwj)
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.