### PR TITLE
[facebook-js-sdk] Add xfbml.ready event and fix xfbml.render typo

### DIFF
--- a/types/facebook-js-sdk/facebook-js-sdk-tests.ts
+++ b/types/facebook-js-sdk/facebook-js-sdk-tests.ts
@@ -214,6 +214,18 @@ FB.Event.subscribe("auth.authResponseChange", response => {
 
 FB.Event.unsubscribe("auth.authResponseChange", () => {});
 
+FB.Event.subscribe("xfbml.render", () => {
+    console.log("all plugins rendered");
+});
+
+FB.Event.subscribe("xfbml.ready", message => {
+    console.log(message.type);
+    console.log(message.id);
+    console.log(message.instance);
+});
+
+FB.Event.unsubscribe("xfbml.ready", () => {});
+
 FB.api("/me", response => {});
 FB.api("/me", "get", { fields: ["last_name"] }, response => {});
 FB.api("/me", { fields: ["last_name", "age_range"] }, response => {

--- a/types/facebook-js-sdk/index.d.ts
+++ b/types/facebook-js-sdk/index.d.ts
@@ -18,7 +18,7 @@ declare namespace facebook {
 
     type FacebookEventCallback<
         TEvent extends FacebookEventType,
-    > = TEvent extends "xfbl.render" ? () => void
+    > = TEvent extends "xfbml.render" ? () => void
         : (response: StatusResponse) => void;
 
     type UserField =

--- a/types/facebook-js-sdk/index.d.ts
+++ b/types/facebook-js-sdk/index.d.ts
@@ -8,7 +8,21 @@ declare namespace facebook {
         | "auth.logout"
         | "auth.login"
         | "auth.statusChange"
+        | "xfbml.ready"
         | "xfbml.render";
+
+    /**
+     * Payload delivered to `xfbml.ready` subscribers when a social plugin
+     * finishes rendering. The `instance` shape varies by plugin `type`
+     * (e.g. video instances expose `play`/`pause`/`subscribe`).
+     *
+     * https://developers.facebook.com/docs/javascript/howto/#tracking-xfbml-rendering
+     */
+    interface XfbmlReadyMessage {
+        type: string;
+        id: string;
+        instance: unknown;
+    }
 
     type LoginStatus =
         | "authorization_expired"
@@ -19,6 +33,7 @@ declare namespace facebook {
     type FacebookEventCallback<
         TEvent extends FacebookEventType,
     > = TEvent extends "xfbml.render" ? () => void
+        : TEvent extends "xfbml.ready" ? (message: XfbmlReadyMessage) => void
         : (response: StatusResponse) => void;
 
     type UserField =


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.facebook.com/docs/reference/javascript/FB.Event.subscribe/v25.0

## Summary

Two related fixes to `@types/facebook-js-sdk` event typings, split into separate commits:

### 1. Fix `xfbml.render` typo

`FacebookEventCallback` had a dead conditional branch:

```ts
TEvent extends "xfbl.render" ? () => void : (response: StatusResponse) => void;
```

Note `"xfbl.render"` — missing the `m`. This meant subscribers to the actual `"xfbml.render"` event were typed as `(response: StatusResponse) => void`, even though Meta's docs show the event fires with no arguments.

### 2. Add `xfbml.ready` event

`xfbml.ready` fires once per social plugin as it finishes rendering. It's a real, documented event that was missing from the `FacebookEventType` union. Its callback receives a message with `type`, `id`, and a plugin-specific `instance` (e.g. the `FB.VideoPlayer` object for video plugins). Since the `instance` shape varies by plugin type, it's typed as `unknown` rather than a specific interface.

Reference: https://developers.facebook.com/docs/reference/javascript/FB.Event.subscribe/v25.0

## Test plan

- [x] Ran `pnpm test types/facebook-js-sdk` locally — passes with exit 0.
- [x] Verified the type fix against real usage: this was discovered while wiring `FB.Event.subscribe('xfbml.ready', …)` in a downstream project; with these types the call now typechecks without casts.