### PR TITLE
[preview-email] Fix returnHtml casing to match runtime

### DIFF
--- a/types/preview-email/index.d.ts
+++ b/types/preview-email/index.d.ts
@@ -53,7 +53,7 @@ declare namespace previewEmail {
          * whether or not to return HTML only – and subsequently not write nor open the file preview file
          * @default false
          */
-        returnHtml?: boolean | undefined;
+        returnHTML?: boolean | undefined;
         /**
          * whether or not to render a "Download Original" button to download via base64 inline onclick JavaScript.
          * @default true

--- a/types/preview-email/preview-email-tests.ts
+++ b/types/preview-email/preview-email-tests.ts
@@ -19,7 +19,7 @@ previewEmail(message, {
     template: "./dir/template.pug",
     urlTransform: path => `./dir/${path}`,
     openSimulator: true,
-    returnHtml: true,
+    returnHTML: true,
     hasDownloadOriginalButton: true,
 });
 


### PR DESCRIPTION
The runtime option is \`returnHTML\` (uppercase), but the current type declares \`returnHtml\` (lowercase). Anyone passing \`returnHtml: true\` via the typed API gets a silent no-op — the actual library never reads that key.

Verified against [\`preview-email@3.1.3\` source](https://github.com/forwardemail/preview-email/blob/master/index.js):

\`\`\`js
// index.js
const previewEmail = async (message, options) => {
  options = {
    // ...
    returnHTML: false,  // line 39
    // ...
  };
  // ...
  if (!options.returnHTML) {  // line 80
    // ...
  }
  return options.returnHTML ? html : url;  // line 243
};
\`\`\`

The test file is updated to match.

- [x] Checked that there's not already an `@types/preview-email` package published by the library
- [x] Types match the JSDoc describing `returnHTML` in index.d.ts
- [x] Test file exercises the renamed property