### PR TITLE
[tabulator-tables] Fix placeholder callback return type

### DIFF
--- a/types/tabulator-tables/index.d.ts
+++ b/types/tabulator-tables/index.d.ts
@@ -843,7 +843,7 @@ export interface OptionsGeneral {
     renderVerticalBuffer?: boolean | number | undefined;
 
     /** placeholder element to display on empty table. */
-    placeholder?: string | HTMLElement | ((this: Tabulator | TabulatorFull) => string) | undefined;
+    placeholder?: string | HTMLElement | ((this: Tabulator | TabulatorFull) => string | HTMLElement) | undefined;
     placeholderHeaderFilter?: string | HTMLElement | ((this: Tabulator | TabulatorFull) => string) | undefined;
 
     /** Footer  element to display for the table. */

--- a/types/tabulator-tables/tabulator-tables-tests.ts
+++ b/types/tabulator-tables/tabulator-tables-tests.ts
@@ -1508,7 +1508,7 @@ table = new Tabulator("#test", {
     ],
     dataTreeChildColumnCalcs: true,
     placeholder() {
-        return this.getHeaderFilters().length ? "No Matching Data" : "No Data";
+        return this.getHeaderFilters().length ? "No Matching Data" : new HTMLDivElement();
     },
     placeholderHeaderFilter: "No Matching Data",
     persistence: {


### PR DESCRIPTION
This PR adds a missing type (`HTMLElement`) in the definition of the callback of the placeholder option. Although it is not explicit in the Tabulator documentation, an HTML element can be returned from the callback (I validated it interactively), and it is quite logical given that the option is already defined as a `string`, `HTMLElement` or a callback.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [Empty Table Placeholders](https://tabulator.info/docs/6.4/layout#placeholder)](https://tabulator.info/docs/6.4/layout#placeholder)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

