### PR TITLE
[puppeteer-har] Fix "module.exports, export = " error, tighten page type from any to …

### DIFF
--- a/types/puppeteer-har/index.d.ts
+++ b/types/puppeteer-har/index.d.ts
@@ -1,14 +1,16 @@
 import type { Frame, Page } from "puppeteer";
 
-export interface PuppeteerHarOptions {
-    path?: string;
-    saveResponse?: boolean;
-    captureMimeTypes?: boolean;
+declare namespace PuppeteerHar {
+    interface PuppeteerHarOptions {
+        path?: string;
+        saveResponse?: boolean;
+        captureMimeTypes?: boolean;
+    }
 }
 
-export class PuppeteerHar {
-    constructor(page: any, options?: PuppeteerHarOptions);
-    start(options?: PuppeteerHarOptions): Promise<void>;
+declare class PuppeteerHar {
+    constructor(page: Page, options?: PuppeteerHar.PuppeteerHarOptions);
+    start(options?: PuppeteerHar.PuppeteerHarOptions): Promise<void>;
     stop(): Promise<PuppeteerHar | undefined>;
     cleanUp(): Promise<void>;
 
@@ -16,3 +18,5 @@ export class PuppeteerHar {
     page: Page;
     mainFrame: Frame;
 }
+
+export = PuppeteerHar

--- a/types/puppeteer-har/puppeteer-har-tests.ts
+++ b/types/puppeteer-har/puppeteer-har-tests.ts
@@ -2,7 +2,7 @@
 
 // Import only for type-checking purposes
 import { Frame, Page } from "puppeteer";
-import { PuppeteerHar, PuppeteerHarOptions } from "puppeteer-har";
+import PuppeteerHar from "puppeteer-har";
 
 // Define a mock Page interface just for type-checking
 
@@ -14,13 +14,13 @@ const mockPage: any = {
 };
 
 // Check if the PuppeteerHar class is correctly typed
-const page: Page = mockPage as any; // Type assertion to use Page
+const page: Page = mockPage as any as Page; // Type assertion to use Page
 
 const har = new PuppeteerHar(page, {
     path: "",
     saveResponse: true,
     captureMimeTypes: true,
-} as PuppeteerHarOptions);
+} as PuppeteerHar.PuppeteerHarOptions);
 
 // Type-check the methods of PuppeteerHar
 const startPromise: Promise<void> = har.start();


### PR DESCRIPTION
…Page

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- Changed 'export class PupeeteerHar' to 'export = PuppeteerHar' to work with 'module.exports = PuppeteerHar'
- Tightened the type definition for PuppeteerHar.page to puppeteer.Page