### PR TITLE
[chrome] Add IOS to runtime.PlatformOs enum

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -8886,6 +8886,8 @@ declare namespace chrome {
             OPENBSD = "openbsd",
             /** Specifies the Fuchsia operating system. */
             FUCHSIA = "fuchsia",
+            /** Specifies the iOS operating system. */
+            IOS = "ios",
         }
 
         /**

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -804,6 +804,7 @@ function testRuntime() {
     chrome.runtime.PlatformOs.ANDROID === "android";
     chrome.runtime.PlatformOs.CROS === "cros";
     chrome.runtime.PlatformOs.FUCHSIA === "fuchsia";
+    chrome.runtime.PlatformOs.IOS === "ios";
     chrome.runtime.PlatformOs.LINUX === "linux";
     chrome.runtime.PlatformOs.MAC === "mac";
     chrome.runtime.PlatformOs.OPENBSD === "openbsd";

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -868,7 +868,7 @@ function testRuntime() {
     chrome.runtime.getPlatformInfo((platformInfo) => { // $ExpectType void
         platformInfo.arch; // $ExpectType "arm" | "arm64" | "x86-32" | "x86-64" | "mips" | "mips64" | "riscv64"
         platformInfo.nacl_arch; // $ExpectType "arm" | "mips" | "mips64" | "x86-32" | "x86-64" | undefined
-        platformInfo.os; // $ExpectType "android" | "cros" | "fuchsia" | "linux" | "mac" | "openbsd" | "win"
+        platformInfo.os; // $ExpectType "android" | "cros" | "fuchsia" | "ios" | "linux" | "mac" | "openbsd" | "win"
     });
     // @ts-expect-error
     chrome.runtime.getPlatformInfo(() => {}).then(() => {});


### PR DESCRIPTION
## Summary

Add `IOS = "ios"` to `chrome.runtime.PlatformOs` enum.

Safari on iOS/iPadOS reports `runtime.getPlatformInfo().os` as `"ios"`, but the type definition was missing this value, causing TypeScript errors when comparing against it.

## Reference

- [MDN: runtime.PlatformOs - ios](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/PlatformOs#ios)

🤖 Generated with [Claude Code](https://claude.com/claude-code)