### PR TITLE
[vscode] Update for VS Code 1.118

### DIFF
--- a/types/vscode/index.d.ts
+++ b/types/vscode/index.d.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 /**
- * Type Definition for Visual Studio Code 1.116 Extension API
+ * Type Definition for Visual Studio Code 1.118 Extension API
  * See https://code.visualstudio.com/api for more information
  */
 
@@ -135,7 +135,7 @@ declare module 'vscode' {
 		 * 'iso88597', 'windows1255', 'iso88598', 'iso885910', 'iso885916', 'windows1254',
 		 * 'iso88599', 'windows1258', 'gbk', 'gb18030', 'cp950', 'big5hkscs', 'shiftjis',
 		 * 'eucjp', 'euckr', 'windows874', 'iso885911', 'koi8ru', 'koi8t', 'gb2312',
-		 * 'cp865', 'cp850'.
+		 * 'cp865', 'cp850', 'cp857'.
 		 */
 		readonly encoding: string;
 

--- a/types/vscode/package.json
+++ b/types/vscode/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/vscode",
-    "version": "1.116.9999",
+    "version": "1.118.9999",
     "nonNpm": "conflict",
     "nonNpmDescription": "TypeScript definitions for the Visual Studio Code Extension API",
     "projects": [


### PR DESCRIPTION
Updates `@types/vscode` for the VS Code 1.118 release.

- Bumps `version` in `types/vscode/package.json` from `1.116.9999` to `1.118.9999`.
- Replaces `types/vscode/index.d.ts` with `vscode.d.ts` from the [`release/1.118`](https://github.com/microsoft/vscode/blob/release/1.118/src/vscode-dts/vscode.d.ts) branch (header updated to 1.118).

Effective API change since the last published `@types/vscode` (1.116):

- Added `'cp857'` (Turkish DOS) to the list of supported encodings in the `TextDocument.encoding` doc comment, via [microsoft/vscode#300114](https://github.com/microsoft/vscode/pull/300114).

[`vscode.d.ts` diff between release/1.117 and release/1.118](https://github.com/microsoft/vscode/compare/release/1.117...release/1.118#diff-0a75aed19c118603eb96332bc0b9c2d7867f4182346d16d18b7fc31b6ceeb321)

Note: 1.117 was not published to `@types/vscode`; this PR jumps directly from 1.116 → 1.118.

Following the [Publish vscode types](https://github.com/microsoft/vscode/wiki/Publish-vscode-types) wiki.
