### PR TITLE
[heic-decode] Fix HasBuffer.buffer type (TS2322 on @types/node ≥24)

### DIFF
--- a/types/heic-decode/heic-decode-tests.ts
+++ b/types/heic-decode/heic-decode-tests.ts
@@ -2,7 +2,23 @@ import decode = require("heic-decode");
 const { all } = decode;
 
 // $ExpectType Promise<DecodedImage>
-decode({ buffer: new ArrayBuffer(10) });
+decode({ buffer: new Uint8Array(10) });
+
+decode({ buffer: new Uint8Array(10) }).then((image) => {
+    // $ExpectType number
+    image.width;
+    // $ExpectType number
+    image.height;
+    const data: Uint8ClampedArray = image.data;
+    data;
+});
 
 // $ExpectType Promise<Decodable[]>
-all({ buffer: new ArrayBuffer(10) });
+all({ buffer: new Uint8Array(10) });
+
+all({ buffer: new Uint8Array(10) }).then((images) => {
+    images[0].decode().then((image) => {
+        const data: Uint8ClampedArray = image.data;
+        data;
+    });
+});

--- a/types/heic-decode/index.d.ts
+++ b/types/heic-decode/index.d.ts
@@ -1,5 +1,5 @@
 interface HasBuffer {
-    buffer: ArrayBufferLike;
+    buffer: Uint8Array;
 }
 
 interface DecodedImage {

--- a/types/heic-decode/package.json
+++ b/types/heic-decode/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/heic-decode",
-    "version": "1.1.9999",
+    "version": "2.0.9999",
     "projects": [
         "https://github.com/catdad-experiments/heic-decode"
     ],


### PR DESCRIPTION
## What
                                                                                                                                                                                                                                        
`HasBuffer.buffer`: `ArrayBufferLike` → `Uint8Array`
                                                                                                                                                                                                                                        
## Why                                                                                                                                                                                                                                    

After bumping `@types/node` to `^24` (Node 24 LTS), TypeScript reports:                                                                                                                                                                   
```
image.ts:85:7 - error TS2322: Type 'Uint8Array' is not assignable to type 'ArrayBufferLike'.                                                                                                                                  
Type 'Uint8Array' is missing the following properties from type 'SharedArrayBuffer': growable, maxByteLength, grow
                                                                                                                                                                                                                                        
85       buffer: fileContent,                                                                                                                                                                                                             
        ~~~~~~                                                                                                                                                                                                                           
                                                                                                                                                                                                                                        
node_modules/@types/heic-decode/index.d.ts:2:5       
    2     buffer: ArrayBufferLike;
        ~~~~~~                                                                                                                                                                                                                            
    The expected type comes from property 'buffer' which is declared here on type 'HasBuffer'
 ```                                                                                                                                                                                                                                     
`@types/node ^24` made `Uint8Array` generic (`Uint8Array<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike>`), so a `Uint8Array` is no longer structurally assignable to `ArrayBufferLike`.
                                                                                                                                                                                                                                        
The previous `ArrayBufferLike` typing never reflected the runtime contract anyway. `heic-decode` consumes `buffer` as a `Uint8Array`:                                                                                                     
                                                                                                                                                                                                                                        
https://github.com/catdad-experiments/heic-decode/blob/47773f7b17acc22bfb8bb7869b6ef087d24c0ca9/lib.js#L1-L9                                                                                                                              
                                                        
```js                                                                                                                                                                                                                                     
const uint8ArrayUtf8ByteString = (array, start, end) => {
return String.fromCharCode(...array.slice(start, end));
};                                                                                                                                                                                                                                        

const isHeic = (buffer) => {                                                                                                                                                                                                              
const brandMajor = uint8ArrayUtf8ByteString(buffer, 8, 12)...

String.fromCharCode(...array.slice(...)) requires an iterable typed array. Passing a raw ArrayBuffer would throw at runtime — it just happened that no caller ever did. 
```
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/catdad-experiments/heic-decode/blob/47773f7b17acc22bfb8bb7869b6ef087d24c0ca9/lib.js#L1-L9   
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
