### PR TITLE
[dogapi] Allow numeric timestamps in metric points

### DIFF
--- a/types/dogapi/dogapi-tests.ts
+++ b/types/dogapi/dogapi-tests.ts
@@ -66,8 +66,8 @@ dogapi.metric.send_all(
         {
             metric: "metricName",
             points: [
-                ["123", 500],
-                ["124", 600],
+                [123, 500],
+                [124, 600],
             ],
             metric_type: "type",
         },

--- a/types/dogapi/index.d.ts
+++ b/types/dogapi/index.d.ts
@@ -49,7 +49,7 @@ interface metric {
     send_all(
         metrics: Array<{
             metric: string;
-            points: number | number[] | Array<[string, number]>;
+            points: number | number[] | Array<[number, number]>;
             tags?: string[] | undefined;
             type?: string | undefined;
             metric_type?: string | undefined;


### PR DESCRIPTION
Update metric send_all points tuples to use numeric POSIX timestamps (Array<[number, number]>) and adjust tests accordingly.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/brettlangdon/node-dogapi/blob/54f6164f584b763ceb612f744f6b285034725375/lib/api/metric.js#L121-L122
  - https://github.com/brettlangdon/node-dogapi/blob/54f6164f584b763ceb612f744f6b285034725375/lib/api/metric.js#L32-L33
  - https://docs.datadoghq.com/api/latest/metrics/#submit-metrics
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

