### PR TITLE
node: v25.8

### DIFF
--- a/types/node/node-tests/sqlite.ts
+++ b/types/node/node-tests/sqlite.ts
@@ -1,4 +1,4 @@
-import { backup, constants, DatabaseSync, StatementSync } from "node:sqlite";
+import { backup, constants, DatabaseLimits, DatabaseSync, StatementSync } from "node:sqlite";
 import { TextEncoder } from "node:util";
 
 {
@@ -188,4 +188,14 @@ import { TextEncoder } from "node:util";
         }
         return constants.SQLITE_OK;
     });
+}
+
+{
+    const db = new DatabaseSync(":memory:", {
+        limits: { attach: 10, column: 2000, compoundSelect: 500 },
+    });
+
+    let k!: keyof DatabaseLimits;
+    db.limits[k]; // $ExpectType number
+    db.limits[k] = 100;
 }

--- a/types/node/node-tests/test.ts
+++ b/types/node/node-tests/test.ts
@@ -175,6 +175,8 @@ test(undefined, undefined, t => {
     t.error;
     // $ExpectType number
     t.attempt;
+    // $ExpectType number | undefined
+    t.workerId;
 });
 
 // Test the subtest approach.

--- a/types/node/node-tests/test.ts
+++ b/types/node/node-tests/test.ts
@@ -382,6 +382,13 @@ it.expectFailure("x", {
     timeout: Infinity,
 });
 
+// expectFailure predicates
+test({ expectFailure: "message" });
+test({ expectFailure: Error });
+test({ expectFailure: /error/ });
+test({ expectFailure: { code: "ERR_INVALID_ARG_TYPE" } });
+test({ expectFailure: (err) => err instanceof TypeError });
+
 // Test with suite context
 describe(s => {
     // $ExpectType SuiteContext

--- a/types/node/package.json
+++ b/types/node/package.json
@@ -18,7 +18,7 @@
         }
     },
     "dependencies": {
-        "undici-types": "~7.21.0"
+        "undici-types": ">=7.24.0 <7.24.7"
     },
     "devDependencies": {
         "@types/node": "workspace:."

--- a/types/node/package.json
+++ b/types/node/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/node",
-    "version": "25.7.9999",
+    "version": "25.8.9999",
     "nonNpm": "conflict",
     "nonNpmDescription": "Node.js",
     "projects": [

--- a/types/node/sqlite.d.ts
+++ b/types/node/sqlite.d.ts
@@ -311,18 +311,17 @@ declare module "node:sqlite" {
          * @since v22.13.0
          * @param name The name of the SQLite function to create.
          * @param options Optional configuration settings for the function.
-         * @param func The JavaScript function to call when the SQLite
-         * function is invoked. The return value of this function should be a valid
-         * SQLite data type: see
-         * [Type conversion between JavaScript and SQLite](https://nodejs.org/docs/latest-v25.x/api/sqlite.html#type-conversion-between-javascript-and-sqlite).
-         * The result defaults to `NULL` if the return value is `undefined`.
+         * @param fn The JavaScript function to call when the SQLite function is
+         * invoked. The return value of this function should be a valid SQLite data type:
+         * see [Type conversion between JavaScript and SQLite](https://nodejs.org/docs/latest-v25.x/api/sqlite.html#type-conversion-between-javascript-and-sqlite). The result defaults to
+         * `NULL` if the return value is `undefined`.
          */
         function(
             name: string,
             options: FunctionOptions,
-            func: (...args: SQLOutputValue[]) => SQLInputValue,
+            fn: (...args: SQLOutputValue[]) => SQLInputValue,
         ): void;
-        function(name: string, func: (...args: SQLOutputValue[]) => SQLInputValue): void;
+        function(name: string, fn: (...args: SQLOutputValue[]) => SQLInputValue): void;
         /**
          * Sets an authorizer callback that SQLite will invoke whenever it attempts to
          * access data or modify the database schema through prepared statements.

--- a/types/node/sqlite.d.ts
+++ b/types/node/sqlite.d.ts
@@ -87,6 +87,29 @@ declare module "node:sqlite" {
          * @default true
          */
         defensive?: boolean | undefined;
+        /**
+         * Configuration for various SQLite limits. These limits
+         * can be used to prevent excessive resource consumption when handling
+         * potentially malicious input. See [Run-Time Limits](https://www.sqlite.org/c3ref/c_limit_attached.html) and [Limit Constants](https://www.sqlite.org/c3ref/limit.html)
+         * in the SQLite documentation for details. Default values are determined by
+         * SQLite's compile-time defaults and may vary depending on how SQLite was
+         * built. The following properties are supported:
+         * @since v25.8.0
+         */
+        limits?: NodeJS.PartialOptions<DatabaseLimits> | undefined;
+    }
+    interface DatabaseLimits {
+        length: number;
+        sqlLength: number;
+        column: number;
+        exprDepth: number;
+        compoundSelect: number;
+        vdbeOp: number;
+        functionArg: number;
+        attach: number;
+        likePatternLength: number;
+        variableNumber: number;
+        triggerDepth: number;
     }
     interface CreateSessionOptions {
         /**
@@ -391,6 +414,31 @@ declare module "node:sqlite" {
          * @since v24.0.0
          */
         readonly isTransaction: boolean;
+        /**
+         * An object for getting and setting SQLite database limits at runtime.
+         * Each property corresponds to an SQLite limit and can be read or written.
+         *
+         * ```js
+         * const db = new DatabaseSync(':memory:');
+         *
+         * // Read current limit
+         * console.log(db.limits.length);
+         *
+         * // Set a new limit
+         * db.limits.sqlLength = 100000;
+         *
+         * // Reset a limit to its compile-time maximum
+         * db.limits.sqlLength = Infinity;
+         * ```
+         *
+         * Available properties: `length`, `sqlLength`, `column`, `exprDepth`,
+         * `compoundSelect`, `vdbeOp`, `functionArg`, `attach`, `likePatternLength`,
+         * `variableNumber`, `triggerDepth`.
+         *
+         * Setting a property to `Infinity` resets the limit to its compile-time maximum value.
+         * @since v25.8.0
+         */
+        readonly limits: DatabaseLimits;
         /**
          * Opens the database specified in the `path` argument of the `DatabaseSync`constructor. This method should only be used when the database is not opened via
          * the constructor. An exception is thrown if the database is already open.

--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -1,5 +1,5 @@
 declare module "node:test" {
-    import { AssertMethodNames } from "node:assert";
+    import { AssertMethodNames, AssertPredicate } from "node:assert";
     import { Readable, ReadableEventMap } from "node:stream";
     import { TestEvent } from "node:test/reporters";
     import { URL } from "node:url";
@@ -111,7 +111,12 @@ declare module "node:test" {
             function only(name?: string, fn?: SuiteFn): Promise<void>;
             function only(options?: TestOptions, fn?: SuiteFn): Promise<void>;
             function only(fn?: SuiteFn): Promise<void>;
-            // added in v25.5.0, undocumented
+            /**
+             * This flips the pass/fail reporting for a specific test or suite: a flagged test
+             * case must throw in order to pass, and a flagged test case that does not throw
+             * fails.
+             * @since v25.5.0
+             */
             function expectFailure(name?: string, options?: TestOptions, fn?: SuiteFn): Promise<void>;
             function expectFailure(name?: string, fn?: SuiteFn): Promise<void>;
             function expectFailure(options?: TestOptions, fn?: SuiteFn): Promise<void>;
@@ -1301,6 +1306,17 @@ declare module "node:test" {
              */
             concurrency?: number | boolean | undefined;
             /**
+             * If truthy, the test is expected to fail. If a non-empty string is provided, that string is displayed
+             * in the test results as the reason why the test is expected to fail. If a
+             * `RegExp`, `Function`, `Object`, or `Error` is provided directly (without wrapping in `{ match: … }`), the test passes
+             * only if the thrown error matches, following the behavior of
+             * `assert.throws`. To provide both a reason and validation, pass an object
+             * with `label` (string) and `match` (RegExp, Function, Object, or Error).
+             * @since v25.5.0
+             * @default false
+             */
+            expectFailure?: boolean | string | AssertPredicate | undefined;
+            /**
              * If truthy, and the test context is configured to run `only` tests, then this test will be
              * run. Otherwise, the test is skipped.
              * @default false
@@ -1338,8 +1354,6 @@ declare module "node:test" {
              * @since v22.2.0
              */
             plan?: number | undefined;
-            // added in v25.5.0, undocumented
-            expectFailure?: boolean | undefined;
         }
         /**
          * This function creates a hook that runs before executing a suite.

--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -993,6 +993,34 @@ declare module "node:test" {
              */
             readonly attempt: number;
             /**
+             * The unique identifier of the worker running the current test file. This value is
+             * derived from the `NODE_TEST_WORKER_ID` environment variable. When running tests
+             * with `--test-isolation=process` (the default), each test file runs in a separate
+             * child process and is assigned a worker ID from 1 to N, where N is the number of
+             * concurrent workers. When running with `--test-isolation=none`, all tests run in
+             * the same process and the worker ID is always 1. This value is `undefined` when
+             * not running in a test context.
+             *
+             * This property is useful for splitting resources (like database connections or
+             * server ports) across concurrent test files:
+             *
+             * ```js
+             * import { test } from 'node:test';
+             * import { process } from 'node:process';
+             *
+             * test('database operations', async (t) => {
+             *   // Worker ID is available via context
+             *   console.log(`Running in worker ${t.workerId}`);
+             *
+             *   // Or via environment variable (available at import time)
+             *   const workerId = process.env.NODE_TEST_WORKER_ID;
+             *   // Use workerId to allocate separate resources per worker
+             * });
+             * ```
+             * @since v25.8.0
+             */
+            readonly workerId: number | undefined;
+            /**
              * This function is used to set the number of assertions and subtests that are expected to run
              * within the test. If the number of assertions and subtests that run does not match the
              * expected count, the test will fail.

--- a/types/node/url.d.ts
+++ b/types/node/url.d.ts
@@ -235,7 +235,7 @@ declare module "node:url" {
     /**
      * `url.format(urlString)` is shorthand for `url.format(url.parse(urlString))`.
      *
-     * Because it invokes the deprecated `url.parse()`, passing a string argument
+     * Because it invokes the deprecated `url.parse()` internally, passing a string argument
      * to `url.format()` is itself deprecated.
      *
      * Canonicalizing a URL string can be performed using the WHATWG URL API, by
@@ -265,6 +265,8 @@ declare module "node:url" {
      * url.resolve('http://example.com/one', '/two'); // 'http://example.com/two'
      * ```
      *
+     * Because it invokes the deprecated `url.parse()` internally, `url.resolve()` is itself deprecated.
+     *
      * To achieve the same result using the WHATWG URL API:
      *
      * ```js
@@ -283,7 +285,7 @@ declare module "node:url" {
      * resolve('http://example.com/one', '/two'); // 'http://example.com/two'
      * ```
      * @since v0.1.25
-     * @legacy Use the WHATWG URL API instead.
+     * @deprecated Use the WHATWG URL API instead.
      * @param from The base URL to use if `to` is a relative URL.
      * @param to The target URL to resolve.
      */


### PR DESCRIPTION
- deps: update undici to 7.24.4
- sqlite: add limits property to DatabaseSync
- test_runner: expose expectFailure message
- test_runner: expose worker ID for concurrent test execution

Unfortunately, a change slipped into undici-types which monkeypatches @types/node's DOM File interface, which is breaking for a load of polyfills. We are likely going to have to pin this version constraint until it's sorted.