### PR TITLE
[node] webstreams: restore TransformStream transformer cancel callback

### DIFF
--- a/types/node/node-tests/stream-web.ts
+++ b/types/node/node-tests/stream-web.ts
@@ -101,3 +101,12 @@ async function queuingStrategySizeReceivesTheChunk() {
     assert.deepStrictEqual(result, { done: false, value: "size" });
     assert.deepStrictEqual(sizeChunks, ["size"]);
 }
+
+// Transformer's `cancel` callback, absent from @types/web
+{
+    new TransformStream({
+        cancel(reason) {
+            reason; // $ExpectType any
+        },
+    });
+}

--- a/types/node/stream/web.d.ts
+++ b/types/node/stream/web.d.ts
@@ -52,11 +52,15 @@ declare module "node:stream/web" {
         signal?: AbortSignal;
     }
     interface Transformer<I = any, O = any> {
+        cancel?: TransformerCancelCallback;
         flush?: TransformerFlushCallback<O>;
         readableType?: undefined;
         start?: TransformerStartCallback<O>;
         transform?: TransformerTransformCallback<I, O>;
         writableType?: undefined;
+    }
+    interface TransformerCancelCallback {
+        (reason: any): void | PromiseLike<void>;
     }
     interface TransformerFlushCallback<O> {
         (controller: TransformStreamDefaultController<O>): void | PromiseLike<void>;


### PR DESCRIPTION
Someone (🙄) managed to accidentally squish this during the v25.x major branch while synchronising the webstream types with lib.dom, as this feature is manually removed from @types/web due to poor browser adoption.

These definitions match the generator types if that override is removed.

Refs: #74846