### PR TITLE
msgpack5: pin bl dependency

### DIFF
--- a/types/msgpack5/package.json
+++ b/types/msgpack5/package.json
@@ -8,7 +8,7 @@
     "dependencies": {
         "@types/readable-stream": "*",
         "@types/node": "*",
-        "bl": ">=5.1.0"
+        "bl": ">=5.1.0 <6.0.0"
     },
     "devDependencies": {
         "@types/msgpack5": "workspace:."


### PR DESCRIPTION
bl has moved to a new module format in version 7.0.0, breaking the CI.

msgpack5's bl dependency is `^5.0.0`, so we shouldn't be matching new releases.