### PR TITLE
Update webkit prefixed SpeechRecognition to match non-prefixed version

### DIFF
--- a/types/dom-speech-recognition/dom-speech-recognition-tests.ts
+++ b/types/dom-speech-recognition/dom-speech-recognition-tests.ts
@@ -94,4 +94,8 @@ const speechRecognitionOptions: SpeechRecognitionOptions = {
 (async () => {
     const availability: AvailabilityStatus = await SpeechRecognition.available(speechRecognitionOptions);
     const installOutcome: boolean = await SpeechRecognition.install(speechRecognitionOptions);
+
+    // "webkit" prefixed vars should have the same static methods
+    const webkitAvailability: AvailabilityStatus = await webkitSpeechRecognition.available(speechRecognitionOptions);
+    const webkitInstallOutcome: boolean = await webkitSpeechRecognition.install(speechRecognitionOptions);
 });

--- a/types/dom-speech-recognition/index.d.ts
+++ b/types/dom-speech-recognition/index.d.ts
@@ -146,7 +146,12 @@ declare var SpeechGrammarList: { prototype: SpeechGrammarList; new(): SpeechGram
 
 // prefixed global variables in Chrome; should match the equivalents above
 // https://developer.mozilla.org/en-US/docs/Web/API/Web_Speech_API/Using_the_Web_Speech_API#chrome_support
-declare var webkitSpeechRecognition: { prototype: SpeechRecognition; new(): SpeechRecognition };
+declare var webkitSpeechRecognition: {
+    prototype: SpeechRecognition;
+    new(): SpeechRecognition;
+    available(options: SpeechRecognitionOptions): Promise<AvailabilityStatus>;
+    install(options: SpeechRecognitionOptions): Promise<boolean>;
+};
 declare var webkitSpeechGrammarList: { prototype: SpeechGrammarList; new(): SpeechGrammarList };
 declare var webkitSpeechRecognitionEvent: {
     prototype: SpeechRecognitionEvent;

--- a/types/dom-speech-recognition/ts5.9/dom-speech-recognition-tests.ts
+++ b/types/dom-speech-recognition/ts5.9/dom-speech-recognition-tests.ts
@@ -94,4 +94,8 @@ const speechRecognitionOptions: SpeechRecognitionOptions = {
 (async () => {
     const availability: AvailabilityStatus = await SpeechRecognition.available(speechRecognitionOptions);
     const installOutcome: boolean = await SpeechRecognition.install(speechRecognitionOptions);
+
+    // "webkit" prefixed vars should have the same static methods
+    const webkitAvailability: AvailabilityStatus = await webkitSpeechRecognition.available(speechRecognitionOptions);
+    const webkitInstallOutcome: boolean = await webkitSpeechRecognition.install(speechRecognitionOptions);
 });

--- a/types/dom-speech-recognition/ts5.9/index.d.ts
+++ b/types/dom-speech-recognition/ts5.9/index.d.ts
@@ -146,7 +146,12 @@ declare var SpeechGrammarList: { prototype: SpeechGrammarList; new(): SpeechGram
 
 // prefixed global variables in Chrome; should match the equivalents above
 // https://developer.mozilla.org/en-US/docs/Web/API/Web_Speech_API/Using_the_Web_Speech_API#chrome_support
-declare var webkitSpeechRecognition: { prototype: SpeechRecognition; new(): SpeechRecognition };
+declare var webkitSpeechRecognition: {
+    prototype: SpeechRecognition;
+    new(): SpeechRecognition;
+    available(options: SpeechRecognitionOptions): Promise<AvailabilityStatus>;
+    install(options: SpeechRecognitionOptions): Promise<boolean>;
+};
 declare var webkitSpeechGrammarList: { prototype: SpeechGrammarList; new(): SpeechGrammarList };
 declare var webkitSpeechRecognitionEvent: {
     prototype: SpeechRecognitionEvent;


### PR DESCRIPTION
Re-upload of #74874 now that I'm an owner of the SpeechRecognition types, to see what the bot will do.

Update webkitSpeechRecognition in both TS5.9 and TS6.0 versions to match the non-prefixed version, per the comment.
Syncs changes from #74783 & #74792 to the prefixed version.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [draft spec](https://webaudio.github.io/web-speech-api/)
