### PR TITLE
[youtube] Allow to extend YT definitions again

### DIFF
--- a/types/youtube/index.d.ts
+++ b/types/youtube/index.d.ts
@@ -1035,7 +1035,3 @@ declare namespace YT {
         getVideoData(): VideoData;
     }
 }
-
-// eslint-disable-next-line @definitelytyped/export-just-namespace
-export = YT;
-export as namespace YT;

--- a/types/youtube/package.json
+++ b/types/youtube/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/youtube",
-    "version": "0.2.9999",
+    "version": "0.3.9999",
     "projects": [
         "https://developers.google.com/youtube/"
     ],

--- a/types/youtube/youtube-tests.ts
+++ b/types/youtube/youtube-tests.ts
@@ -1,5 +1,3 @@
-import * as YT from "youtube";
-
 const players: YT.Player[] = [
     new YT.Player(document.body, {}),
     new YT.Player(document.body, {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://stackblitz.com/edit/vitejs-vite-sdcp4w9p?file=src%2Fmain.ts>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Changes introduced in #74811 makes types to get broken when extending the YT namespace with undocumented methods like `YT.ready()`. This used to work with the previous version. This PR undo the changes.