### PR TITLE
Chrome, ManifestV3, content script: added  match_origin_as_fallback and updated definition of run_at

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -9458,7 +9458,7 @@ declare namespace chrome {
                     exclude_matches?: string[] | undefined;
                     css?: string[] | undefined;
                     js?: string[] | undefined;
-                    run_at?: string | undefined;
+                    run_at?: extensionTypes.RunAt | undefined;
                     all_frames?: boolean | undefined;
                     match_about_blank?: boolean | undefined;
                     include_globs?: string[] | undefined;
@@ -9501,7 +9501,7 @@ declare namespace chrome {
                     exclude_matches?: string[] | undefined;
                     css?: string[] | undefined;
                     js?: string[] | undefined;
-                    run_at?: 'document_start' | 'document_end' | 'document_idle' | undefined;
+                    run_at?: extensionTypes.RunAt | undefined;
                     all_frames?: boolean | undefined;
                     match_about_blank?: boolean | undefined;
                     match_origin_as_fallback?: boolean | undefined;

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -9501,9 +9501,10 @@ declare namespace chrome {
                     exclude_matches?: string[] | undefined;
                     css?: string[] | undefined;
                     js?: string[] | undefined;
-                    run_at?: string | undefined;
+                    run_at?: 'document_start' | 'document_end' | 'document_idle' | undefined;
                     all_frames?: boolean | undefined;
                     match_about_blank?: boolean | undefined;
+                    match_origin_as_fallback?: boolean | undefined;
                     include_globs?: string[] | undefined;
                     exclude_globs?: string[] | undefined;
                     world?: "ISOLATED" | "MAIN" | undefined;

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1194,6 +1194,12 @@ function testGetManifest() {
                 matches: ["https://github.com/*"],
                 js: ["cs.js"],
             },
+            {
+                matches: ["https://example.com/*"],
+                js: ["cs-example.js"],
+                all_frames: true,
+                run_at: "document_start",
+            },
         ],
         content_security_policy: "default-src 'self'",
         optional_permissions: ["https://*/*"],
@@ -1218,7 +1224,7 @@ function testGetManifest() {
                 world: "MAIN",
                 all_frames: true,
                 match_origin_as_fallback: true,
-                run_at: "document_start"
+                run_at: "document_start",
             },
         ],
         content_security_policy: {

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1212,6 +1212,14 @@ function testGetManifest() {
                 js: ["cs.js"],
                 world: "MAIN",
             },
+            {
+                matches: ["https://example.com/*"],
+                js: ["cs-example.js"],
+                world: "MAIN",
+                all_frames: true,
+                match_origin_as_fallback: true,
+                run_at: "document_start"
+            },
         ],
         content_security_policy: {
             extension_pages: "default-src 'self'",


### PR DESCRIPTION
Added missing fields for content scripts:
 - match_origin_as_fallback
 - run_at - stricter rules from documentation

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
  Added tests, represents real life situation.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
 Tests are passing

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  *run-at*: https://developer.chrome.com/docs/extensions/develop/concepts/content-scripts#run_time
  *match_origin_as_fallback*  - https://developer.chrome.com/docs/extensions/develop/concepts/content-scripts#injecting-in-related-frames
  *MV2* *run-at*: https://developer.chrome.com/docs/extensions/mv2/content-scripts#run_time
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
 It exists since Chrome 96
