### PR TITLE
[jsdom] Omit numeric index signature from Window to fix DOMWindow Infinity/NaN conflict

### DIFF
--- a/types/jsdom/index.d.ts
+++ b/types/jsdom/index.d.ts
@@ -198,8 +198,6 @@ export interface DOMWindow extends Omit<Window, "top" | "self" | "window"> {
 
     /* ECMAScript Globals */
     globalThis: DOMWindow;
-    readonly ["Infinity"]: number;
-    readonly ["NaN"]: number;
     readonly undefined: undefined;
 
     eval(script: string): unknown;

--- a/types/jsdom/index.d.ts
+++ b/types/jsdom/index.d.ts
@@ -186,7 +186,7 @@ export interface ResourcesOptions {
     interceptors?: Dispatcher.DispatcherComposeInterceptor[] | undefined;
 }
 
-export interface DOMWindow extends Omit<Window, "top" | "self" | "window"> {
+export interface DOMWindow extends Omit<Window, "top" | "self" | "window" | number> {
     [key: string]: any;
     [index: number]: any;
 
@@ -198,6 +198,8 @@ export interface DOMWindow extends Omit<Window, "top" | "self" | "window"> {
 
     /* ECMAScript Globals */
     globalThis: DOMWindow;
+    readonly ["Infinity"]: number;
+    readonly ["NaN"]: number;
     readonly undefined: undefined;
 
     eval(script: string): unknown;

--- a/types/jsdom/jsdom-tests.ts
+++ b/types/jsdom/jsdom-tests.ts
@@ -24,8 +24,8 @@ domWindow.WebAssembly; // $ExpectType typeof WebAssembly
 domWindow.InputEvent.prototype; // $ExpectType InputEvent
 domWindow.external; // $ExpectType External
 
-domWindow["Infinity"]; // $ExpectType any
-domWindow["NaN"]; // $ExpectType any
+domWindow["Infinity"]; // $ExpectType number
+domWindow["NaN"]; // $ExpectType number
 
 domWindow.FinalizationRegistry; // $ExpectType FinalizationRegistryConstructor
 domWindow.WeakRef; // $ExpectType WeakRefConstructor

--- a/types/jsdom/jsdom-tests.ts
+++ b/types/jsdom/jsdom-tests.ts
@@ -24,6 +24,9 @@ domWindow.WebAssembly; // $ExpectType typeof WebAssembly
 domWindow.InputEvent.prototype; // $ExpectType InputEvent
 domWindow.external; // $ExpectType External
 
+domWindow["Infinity"]; // $ExpectType any
+domWindow["NaN"]; // $ExpectType any
+
 domWindow.FinalizationRegistry; // $ExpectType FinalizationRegistryConstructor
 domWindow.WeakRef; // $ExpectType WeakRefConstructor
 


### PR DESCRIPTION
Omit the `[index: number]: Window` numeric index signature from `Window` in the `DOMWindow` extends clause, so that `readonly ["Infinity"]: number` and `readonly ["NaN"]: number` no longer conflict with it.

These numeric-string literal property names conflict with the numeric index signature inherited from `Window` (via `lib.dom.d.ts`), producing TS2411:

```
Property '["Infinity"]' of type 'number' is not assignable to 'number' index type 'Window'.
Property '["NaN"]' of type 'number' is not assignable to 'number' index type 'Window'.
```

This has been reported since TypeScript 4.4 (#57467, #57466) and affects anyone using `skipLibCheck: false`. TypeScript 7 (tsgo / Corsa) now reports this error consistently — the previous tsc behavior of silently suppressing it was [confirmed as a bug by @ahejlsberg](https://github.com/microsoft/typescript-go/issues/3490#issuecomment-2824431498), and the tsgo team closed [microsoft/typescript-go#3490](https://github.com/microsoft/typescript-go/issues/3490) as wontfix.

The fix adds `| number` to the `Omit` type parameter, stripping the numeric index signature from the inherited `Window` type. This preserves the explicit `Infinity` and `NaN` property types (`number`) rather than falling back to `any` through the string index signature.

Fixes #57467.