### PR TITLE
[xrm] Use generic type T in OptionSetAttribute and MultiSelectOptionSetAttribute getOption/setValue

### DIFF
--- a/types/xrm/index.d.ts
+++ b/types/xrm/index.d.ts
@@ -2919,7 +2919,7 @@ declare namespace Xrm {
              * @param value The enumeration value of the option desired.
              * @returns The option.
              */
-            getOption(value: number): OptionSetValue;
+            getOption(value: T): OptionSetValue;
 
             /**
              * Gets the option matching a label.
@@ -2954,7 +2954,7 @@ declare namespace Xrm {
              *              OptionSet attribute. Attributes on Quick Create Forms will not save values set
              *              with this method.
              */
-            setValue(value: number | null): void;
+            setValue(value: T | null): void;
 
             /**
              * A collection of all the controls on the form that interface with this attribute.
@@ -2985,7 +2985,7 @@ declare namespace Xrm {
              * @param value The enumeration value of the option desired.
              * @returns The option.
              */
-            getOption(value: number): OptionSetValue;
+            getOption(value: T): OptionSetValue;
 
             /**
              * Gets the option matching a label.
@@ -3020,7 +3020,7 @@ declare namespace Xrm {
              *              OptionSet attribute. Attributes on Quick Create Forms will not save values set
              *              with this method.
              */
-            setValue(value: number[] | null): void;
+            setValue(value: T[] | null): void;
 
             /**
              * A collection of all the controls on the form that interface with this attribute.

--- a/types/xrm/xrm-tests.ts
+++ b/types/xrm/xrm-tests.ts
@@ -180,6 +180,11 @@ enum TestOptionSet {
 const optionSetAttributeEnum = formContext.getAttribute<Xrm.Attributes.OptionSetAttribute<TestOptionSet>>("statuscode");
 if (optionSetAttributeEnum !== null) {
     const optionEnumValue: TestOptionSet | null = optionSetAttributeEnum.getValue();
+    optionSetAttributeEnum.getOption(TestOptionSet.Option1);
+    optionSetAttributeEnum.setValue(TestOptionSet.Option1);
+    optionSetAttributeEnum.setValue(null);
+    // @ts-expect-error — plain number is not assignable to TestOptionSet
+    optionSetAttributeEnum.setValue(123);
 }
 
 /// Demonstrate MultiSelectOptionSet Value as int
@@ -203,6 +208,11 @@ const multiSelectOptionSetAttributeEnum = formContext.getAttribute<
 >("statuscode");
 if (multiSelectOptionSetAttributeEnum !== null) {
     const multiSelectOptionEnumValue: TestMultiSelectOptionSet[] | null = multiSelectOptionSetAttributeEnum.getValue();
+    multiSelectOptionSetAttributeEnum.getOption(TestMultiSelectOptionSet.Option1);
+    multiSelectOptionSetAttributeEnum.setValue([TestMultiSelectOptionSet.Option1]);
+    multiSelectOptionSetAttributeEnum.setValue(null);
+    // @ts-expect-error — plain number is not assignable to TestMultiSelectOptionSet
+    multiSelectOptionSetAttributeEnum.setValue([123]);
 }
 
 // Demonstrate that controls on a MultiSelectOptionSetAttribute are typed as MultiSelectOptionSetControl


### PR DESCRIPTION
## Summary

`OptionSetAttribute<T>` and `MultiSelectOptionSetAttribute<T>` both have a generic type parameter `T extends number`, but `getOption(value)` and `setValue(value)` were typed as plain `number`/`number[]` instead of `T`/`T[]`. This meant callers typed to a specific enum got no type safety on those methods.

- `getOption(value: number)` → `getOption(value: T)`
- `setValue(value: number | null)` → `setValue(value: T | null)` (OptionSet)
- `setValue(value: number[] | null)` → `setValue(value: T[] | null)` (MultiSelectOptionSet)

Tests added with `@ts-expect-error` to confirm plain `number` is rejected when `T` is a specific enum.