### PR TITLE
node: add randomUUIDv7 to crypto module

### DIFF
--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -3157,6 +3157,13 @@ declare module "node:crypto" {
      * @since v15.6.0, v14.17.0
      */
     function randomUUID(options?: RandomUUIDOptions): UUID;
+    /**
+     * Generates a random [RFC 9562](https://www.rfc-editor.org/rfc/rfc9562.txt) version 7 UUID. The UUID contains a
+     * millisecond precision Unix timestamp in the most significant 48 bits, followed by
+     * cryptographically secure random bits for the remaining fields.
+     * @since v26.1.0
+     */
+    function randomUUIDv7(options?: RandomUUIDOptions): UUID;
     interface X509CheckOptions {
         /**
          * @default 'always'

--- a/types/node/node-tests/crypto.ts
+++ b/types/node/node-tests/crypto.ts
@@ -1608,6 +1608,13 @@ import { promisify } from "node:util";
 }
 
 {
+    crypto.randomUUIDv7({});
+    crypto.randomUUIDv7({ disableEntropyCache: true });
+    crypto.randomUUIDv7({ disableEntropyCache: false });
+    crypto.randomUUIDv7();
+}
+
+{
     const cert = new crypto.X509Certificate("dummy");
     cert.ca; // $ExpectType boolean
     cert.fingerprint; // $ExpectType string


### PR DESCRIPTION
**Changing an existing definition:**
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/crypto.html#cryptorandomuuidv7options
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

**Context:** `crypto.randomUUIDv7()` was added in Node.js v26.1.0. This PR adds the type definition reusing the existing `RandomUUIDOptions` and `UUID` types, matching the pattern of `randomUUID`.

**Test:**
```ts
import { randomUUIDv7 } from "node:crypto";

const id = randomUUIDv7();
const idNoCache = randomUUIDv7({ disableEntropyCache: true });
```