### PR TITLE
@types/qunit - make callback required in todo and skip test signatures

### DIFF
--- a/types/qunit/index.d.ts
+++ b/types/qunit/index.d.ts
@@ -593,12 +593,12 @@ declare global {
         }
 
         interface TodoFunction {
-            (name: string, callback?: TestFunctionCallback): void;
+            (name: string, callback: TestFunctionCallback): void;
             each: EachFunction;
         }
 
         interface SkipFunction {
-            (name: string, callback?: TestFunctionCallback): void;
+            (name: string, callback: TestFunctionCallback): void;
             each: EachFunction;
         }
 

--- a/types/qunit/index.d.ts
+++ b/types/qunit/index.d.ts
@@ -598,7 +598,7 @@ declare global {
         }
 
         interface SkipFunction {
-            (name: string, callback: TestFunctionCallback): void;
+            (name: string, callback?: TestFunctionCallback): void;
             each: EachFunction;
         }
 

--- a/types/qunit/test/global-test.ts
+++ b/types/qunit/test/global-test.ts
@@ -21,8 +21,6 @@ QUnit.test.todo("todo test example", function(assert) {
     assert.ok(true, "this is a todo");
 });
 
-QUnit.test.todo("todo test example w/o callback");
-
 QUnit.test.only("only test example", function(assert) {
     assert.ok(true, "only this is called");
 });
@@ -30,8 +28,6 @@ QUnit.test.only("only test example", function(assert) {
 QUnit.test.skip("skip test example", function(assert) {
     assert.ok(true, "this is skiped");
 });
-
-QUnit.test.skip("skip test example w/o callback");
 
 QUnit.test.if("if test example", true, function(assert) {
     assert.ok(true, "this is called if true");

--- a/types/qunit/test/global-test.ts
+++ b/types/qunit/test/global-test.ts
@@ -29,6 +29,8 @@ QUnit.test.skip("skip test example", function(assert) {
     assert.ok(true, "this is skiped");
 });
 
+QUnit.test.skip("skip test example w/o callback");
+
 QUnit.test.if("if test example", true, function(assert) {
     assert.ok(true, "this is called if true");
 });

--- a/types/qunit/test/module-test.ts
+++ b/types/qunit/test/module-test.ts
@@ -17,8 +17,6 @@ QUnit.module("basic tests for importing QUnit", function(hooks) {
         assert.ok(true, "this is a todo");
     });
 
-    QUnit.test.todo("todo test example w/o callback");
-
     QUnit.test.only("only test example", function(assert) {
         assert.ok(true, "only this is called");
     });
@@ -26,8 +24,6 @@ QUnit.module("basic tests for importing QUnit", function(hooks) {
     QUnit.test.skip("skip test example", function(assert) {
         assert.ok(true, "this is skiped");
     });
-
-    QUnit.test.skip("skip test example w/o callback");
 
     QUnit.test.if("if test example", true, function(assert) {
         assert.ok(true, "this is called if true");

--- a/types/qunit/test/module-test.ts
+++ b/types/qunit/test/module-test.ts
@@ -25,6 +25,8 @@ QUnit.module("basic tests for importing QUnit", function(hooks) {
         assert.ok(true, "this is skiped");
     });
 
+    QUnit.test.skip("skip test example w/o callback");
+
     QUnit.test.if("if test example", true, function(assert) {
         assert.ok(true, "this is called if true");
     });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://qunitjs.com/api/QUnit/test.todo/
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

---

This reverts the core change of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/71036, which made the `callback` argument to `todo` and `skip` tests optional. As far as I can tell, these were never optional in Qunit, but they at least aren't right now.

References
* [The PR to types](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/23972) that made callback optional.
* [The docs](https://qunitjs.com/api/QUnit/test.todo/) show it as required, with no changelog entry showing that has ever changed.
* [The library code](https://github.com/qunitjs/qunit/blame/main/src/core/test.js#L73) that throws this exception has been this way for a lot longer than the PR that changed the types.
