### PR TITLE
[jquery] Fix module import error in jquery 4.0.0

### DIFF
--- a/types/jquery/index.d.mts
+++ b/types/jquery/index.d.mts
@@ -1,4 +1,5 @@
 /// <reference path="index.d.ts" />
 
+export const jQuery: JQueryStatic;
+export const $: JQueryStatic;
 export default jQuery;
-export { jQuery, jQuery as $ };

--- a/types/jquery/slim.d.mts
+++ b/types/jquery/slim.d.mts
@@ -1,4 +1,5 @@
 /// <reference path="index.d.ts" />
 
+export const jQuery: JQueryStatic;
+export const $: JQueryStatic;
 export default jQuery;
-export { jQuery, jQuery as $ };


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/74639
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---

This is my attempt to fix the issue described in #74639 and https://github.com/DefinitelyTyped/DefinitelyTyped/pull/74367#discussion_r2849909514, which is that simply importing jquery gives an error if you use modern TypeScript options.

Please check my work. I don't really know what I'm doing. I thought somebody would fix it by now, but here we are.

This PR does not contain any regression tests, because [dtslint](https://github.com/microsoft/DefinitelyTyped-tools/blob/main/packages/dtslint/src/checks.ts) only allows `"module": "commonjs"` or `"node16"`, in which the issue doesn't happen. It also doesn't allow `"moduleResolution"`.

Best I have is this manual test:

-   ```console
    $ pnpm add typescript jquery @types/jquery
    Packages: +3
    +++
    Progress: resolved 3, reused 2, downloaded 1, added 3, done

    dependencies:
    + @types/jquery 4.0.0
    + jquery 4.0.0
    + typescript 6.0.3

    Done in 1.2s using pnpm v11.1.0
    ```

-   ```console
    $ echo 'import $ from "jquery";' > main.ts
    ```

-   ```console
    $ pnpm tsc main.ts
    node_modules/.pnpm/@types+jquery@4.0.0/node_modules/@types/jquery/index.d.mts:4:10 - error TS2661: Cannot export 'jQuery'. Only local declarations can be exported from a module.

    4 export { jQuery, jQuery as $ };
               ~~~~~~

    node_modules/.pnpm/@types+jquery@4.0.0/node_modules/@types/jquery/index.d.mts:4:18 - error TS2661: Cannot export 'jQuery'. Only local declarations can be exported from a module.

    4 export { jQuery, jQuery as $ };
                       ~~~~~~


    Found 2 errors in the same file, starting at: node_modules/.pnpm/@types+jquery@4.0.0/node_modules/@types/jquery/index.d.mts:4
    ```

    (You may notice that with new defaults in TypeScript 6.0, the error is trivially reproducible with default tsc options.)

-   ```console
    $ pnpm add link:../DefinitelyTyped/types/jquery
    Packages: -1
    -
    Progress: resolved 3, reused 3, downloaded 0, added 0, done

    dependencies:
    - @types/jquery 4.0.0
    + @types/jquery 4.0.9999 <- ../DefinitelyTyped/types/jquery

    Done in 685ms using pnpm v11.1.0
    ```

-   ```console
    $ pnpm tsc main.ts
    ```

    (tsc prints nothing.)

This should prove that the PR fixes the issue. I hope it doesn't break anything else.

FYI CC @DreierF, @valipanahi, @gabritto, @andersk, @marekdedic
