### PR TITLE
[koa] Allow augmenting ContextDelegatedRequest/Response

### DIFF
--- a/types/koa/index.d.ts
+++ b/types/koa/index.d.ts
@@ -543,6 +543,9 @@ declare class Application<
 }
 
 declare namespace Application {
+    interface DefaultContextDelegatedRequest extends ContextDelegatedRequest {}
+    interface DefaultContextDelegatedResponse extends ContextDelegatedResponse {}
+
     type DefaultStateExtends = any;
     /**
      * This interface can be augmented by users to add types to Koa's default state
@@ -564,7 +567,7 @@ declare namespace Application {
         ParameterizedContext<StateT, ContextT, ResponseBodyT>
     >;
 
-    interface BaseRequest extends ContextDelegatedRequest {
+    interface BaseRequest extends DefaultContextDelegatedRequest {
         /**
          * Get the charset when present or undefined.
          */
@@ -592,7 +595,7 @@ declare namespace Application {
         toJSON(): any;
     }
 
-    interface BaseResponse extends ContextDelegatedResponse {
+    interface BaseResponse extends DefaultContextDelegatedResponse {
         /**
          * Return the request socket.
          *
@@ -654,7 +657,7 @@ declare namespace Application {
         toJSON(): any;
     }
 
-    interface BaseContext extends ContextDelegatedRequest, ContextDelegatedResponse {
+    interface BaseContext extends DefaultContextDelegatedRequest, DefaultContextDelegatedResponse {
         /**
          * util.inspect() implementation, which
          * just returns the JSON output.

--- a/types/koa/test/augment-delegated.ts
+++ b/types/koa/test/augment-delegated.ts
@@ -1,0 +1,31 @@
+import Koa = require("koa");
+
+declare module "koa" {
+    interface DefaultContextDelegatedRequest {
+        requestId: string;
+    }
+
+    interface DefaultContextDelegatedResponse {
+        sendCustom(payload: unknown): void;
+    }
+}
+
+const app = new Koa();
+
+app.use((ctx, next) => {
+    // Augmented members are visible on ctx (delegated through BaseContext).
+    ctx.requestId; // $ExpectType string
+    ctx.sendCustom({ ok: true });
+
+    // Augmented members are visible on request/response as well.
+    ctx.request.requestId; // $ExpectType string
+    ctx.response.sendCustom("hello");
+
+    // Original delegated members still exist — augmentation must not erase them.
+    ctx.redirect("/login");
+    ctx.attachment("file.txt");
+    ctx.header; // $ExpectType IncomingHttpHeaders
+    ctx.method; // $ExpectType string
+
+    return next();
+});

--- a/types/koa/tsconfig.json
+++ b/types/koa/tsconfig.json
@@ -5,7 +5,8 @@
         "test/constructor.ts",
         "test/default.ts",
         "test/settings.ts",
-        "test/typed-response-body.ts"
+        "test/typed-response-body.ts",
+        "test/augment-delegated.ts"
     ],
     "compilerOptions": {
         "module": "node16",

--- a/types/koa/v2/index.d.ts
+++ b/types/koa/v2/index.d.ts
@@ -532,6 +532,9 @@ declare class Application<
 }
 
 declare namespace Application {
+    interface DefaultContextDelegatedRequest extends ContextDelegatedRequest {}
+    interface DefaultContextDelegatedResponse extends ContextDelegatedResponse {}
+
     type DefaultStateExtends = any;
     /**
      * This interface can be augmented by users to add types to Koa's default state
@@ -553,7 +556,7 @@ declare namespace Application {
         ParameterizedContext<StateT, ContextT, ResponseBodyT>
     >;
 
-    interface BaseRequest extends ContextDelegatedRequest {
+    interface BaseRequest extends DefaultContextDelegatedRequest {
         /**
          * Get the charset when present or undefined.
          */
@@ -581,7 +584,7 @@ declare namespace Application {
         toJSON(): any;
     }
 
-    interface BaseResponse extends ContextDelegatedResponse {
+    interface BaseResponse extends DefaultContextDelegatedResponse {
         /**
          * Return the request socket.
          *
@@ -643,7 +646,7 @@ declare namespace Application {
         toJSON(): any;
     }
 
-    interface BaseContext extends ContextDelegatedRequest, ContextDelegatedResponse {
+    interface BaseContext extends DefaultContextDelegatedRequest, DefaultContextDelegatedResponse {
         /**
          * util.inspect() implementation, which
          * just returns the JSON output.

--- a/types/koa/v2/test/augment-delegated.ts
+++ b/types/koa/v2/test/augment-delegated.ts
@@ -1,0 +1,31 @@
+import Koa = require("koa");
+
+declare module "koa" {
+    interface DefaultContextDelegatedRequest {
+        requestId: string;
+    }
+
+    interface DefaultContextDelegatedResponse {
+        sendCustom(payload: unknown): void;
+    }
+}
+
+const app = new Koa();
+
+app.use((ctx, next) => {
+    // Augmented members are visible on ctx (delegated through BaseContext).
+    ctx.requestId; // $ExpectType string
+    ctx.sendCustom({ ok: true });
+
+    // Augmented members are visible on request/response as well.
+    ctx.request.requestId; // $ExpectType string
+    ctx.response.sendCustom("hello");
+
+    // Original delegated members still exist — augmentation must not erase them.
+    ctx.redirect("/login");
+    ctx.attachment("file.txt");
+    ctx.header; // $ExpectType IncomingHttpHeaders
+    ctx.method; // $ExpectType string
+
+    return next();
+});

--- a/types/koa/v2/tsconfig.json
+++ b/types/koa/v2/tsconfig.json
@@ -5,7 +5,8 @@
         "test/constructor.ts",
         "test/default.ts",
         "test/settings.ts",
-        "test/typed-response-body.ts"
+        "test/typed-response-body.ts",
+        "test/augment-delegated.ts"
     ],
     "compilerOptions": {
         "module": "node16",


### PR DESCRIPTION
Stacked on top of #74990 ([koa] Add v2 types). Should be reviewed/merged after that PR; until then the diff here will include the v2 add commit.

## Why

Koa v2's `BaseContext` extends `ContextDelegatedRequest` and `ContextDelegatedResponse` directly, and `BaseRequest`/`BaseResponse` extend those same interfaces. Because the original interface names aren't re-declared anywhere that's open for augmentation, consumers can't extend the delegated members through declaration merging — attempting to do so silently overrides the original interface instead.

Real-world example: strapi/strapi#25424 tried to extend `ContextDelegatedResponse` with custom delegated methods. The augmentation accidentally wiped out the original delegated members instead of adding to them.

## What

- Add two empty marker interfaces inside `declare namespace Application`:
  - `DefaultContextDelegatedRequest extends ContextDelegatedRequest`
  - `DefaultContextDelegatedResponse extends ContextDelegatedResponse`
- Point `BaseRequest`, `BaseResponse`, and `BaseContext` at the new `Default*` interfaces.

Naming mirrors the existing `DefaultState` / `DefaultContext` pattern already in this file, giving consumers a stable, augmentation-friendly seam for the delegated request and response shapes without changing the public API for existing users.

## Follow-up

~If reviewers want, happy to apply the same augmentation seam to koa v3 (`./types/koa`) in a separate PR — same problem exists there.~ Applied in the same PR

## Test plan

- [x] Existing koa tests still pass (no behavioral change to default types).
- [x] Declaration-merging `Koa.DefaultContextDelegatedResponse` adds members to `BaseContext` without erasing the originals.