### PR TITLE
africastalking: rewrite against SDK 0.8.0

### DIFF
--- a/types/africastalking/africastalking-tests.ts
+++ b/types/africastalking/africastalking-tests.ts
@@ -1,29 +1,354 @@
 import AfricasTalking = require("africastalking");
 
-const africastalking = AfricasTalking({
+// =========================================================================
+// Client construction
+// =========================================================================
+
+const client = AfricasTalking({
     apiKey: "apiKey",
     username: "username",
 });
 
-const SMS = async () => {
-    const token = africastalking.TOKEN;
-    const sms = africastalking.SMS;
+const clientXml = AfricasTalking({
+    apiKey: "apiKey",
+    username: "username",
+    format: "xml",
+});
 
-    const sendSmsResult = await africastalking.SMS.send({
-        to: "to",
-        message: "message",
-        from: "from",
+const clientHandle: AfricasTalking.AfricasTalking = client;
+
+// =========================================================================
+// SMS  (sms.d.ts)
+// =========================================================================
+
+async function smsSurface() {
+    const sms: AfricasTalking.SMS = client.SMS;
+
+    const single: AfricasTalking.SMSResponse = await sms.send({
+        to: "+254700000000",
+        message: "hello",
+    });
+    const message: string = single.SMSMessageData.Message;
+    const recipients: AfricasTalking.SMSRecipient[] = single.SMSMessageData.Recipients;
+    const status: AfricasTalking.SMSRecipientStatus = recipients[0].status;
+    const messageId: string = recipients[0].messageId;
+    void message;
+    void status;
+    void messageId;
+
+    await sms.send({
+        to: ["+254700000000", "+254700000001"],
+        message: "hi",
+        from: "AFRICASTKNG",
+        senderId: "AFRICASTKNG",
+        enqueue: true,
     });
 
-    const checkoutTokenResponse = await token.createCheckoutToken("phoneNumber");
+    const batch: AfricasTalking.SMSResponse[] = await sms.send([
+        { to: "+254700000000", message: "hi" },
+        { to: "+254700000001", message: "hi" },
+    ]);
+    void batch;
 
-    const options = {
-        // Set your premium product shortCode and keyword
-        shortCode: "shortCode",
-        keyword: "keyword",
-        phoneNumber: "+phoneNumber",
-        checkoutToken: checkoutTokenResponse.token,
+    const bulk: AfricasTalking.SMSResponse = await sms.sendBulk({
+        to: "+254700000000",
+        message: "bulk",
+    });
+    const bulkArray: AfricasTalking.SMSResponse[] = await sms.sendBulk([
+        { to: "+254700000000", message: "bulk" },
+    ]);
+    void bulk;
+    void bulkArray;
+
+    const premium: AfricasTalking.SMSResponse = await sms.sendPremium({
+        to: "+254700000000",
+        message: "premium",
+        keyword: "premium",
+        linkId: "linkId",
+        retryDurationInHours: 1,
+    });
+    void premium;
+
+    const inbox: AfricasTalking.SMSFetchMessagesResponse = await sms.fetchMessages({
+        lastReceivedId: 0,
+    });
+    const inboxMessages: AfricasTalking.SMSInboundMessage[] = inbox.SMSMessageData.Messages;
+    void inboxMessages;
+
+    const createSub: AfricasTalking.SMSSubscriptionResponse = await sms.createSubscription({
+        shortCode: "12345",
+        keyword: "PREMIUM",
+        phoneNumber: "+254700000000",
+    });
+    void createSub;
+
+    const fetchSub: AfricasTalking.SMSFetchSubscriptionResponse = await sms.fetchSubscription({
+        shortCode: "12345",
+        keyword: "PREMIUM",
+        lastReceivedId: 0,
+    });
+    const subscribers: AfricasTalking.SMSSubscriber[] = fetchSub.responses;
+    void subscribers;
+
+    const deleteSub: AfricasTalking.SMSDeleteSubscriptionResponse = await sms.deleteSubscription({
+        shortCode: "12345",
+        keyword: "PREMIUM",
+        phoneNumber: "+254700000000",
+    });
+    void deleteSub;
+}
+
+// =========================================================================
+// Token  (token.d.ts)
+// =========================================================================
+
+async function tokenSurface() {
+    const token: AfricasTalking.TOKEN = client.TOKEN;
+    const auth: AfricasTalking.AuthTokenResponse = await token.generateAuthToken();
+    const t: string = auth.token;
+    const lifetime: number = auth.lifetimeInSeconds;
+    void t;
+    void lifetime;
+}
+
+// =========================================================================
+// Voice  (voice.d.ts + actionbuilder.d.ts)
+// =========================================================================
+
+async function voiceSurface() {
+    const voice: AfricasTalking.VOICE = client.VOICE;
+
+    const call: AfricasTalking.VoiceCallResponse = await voice.call({
+        callFrom: "+254700000000",
+        callTo: ["+254700000001"],
+        clientRequestId: "req_1",
+    });
+    const callEntries: AfricasTalking.VoiceCallEntry[] = call.entries;
+    void callEntries;
+
+    const queued: AfricasTalking.VoiceQueuedCallsResponse = await voice.getNumQueuedCalls({
+        phoneNumbers: ["+254700000000"],
+    });
+    void queued;
+
+    const upload: AfricasTalking.VoiceUploadMediaResponse = await voice.uploadMediaFile({
+        url: "https://example.com/audio.wav",
+        phoneNumber: "+254700000000",
+    });
+    void upload;
+
+    const builder: AfricasTalking.ActionBuilder = new voice.ActionBuilder();
+    const xml: string = builder
+        .say("Welcome", { voice: "woman", playBeep: true })
+        .play("https://example.com/jingle.mp3")
+        .getDigits(
+            { say: { text: "Enter your pin", attributes: { voice: "woman" } } },
+            { finishOnKey: "#", numDigits: 4, callbackUrl: "https://example.com/cb" },
+        )
+        .dial("+254700000001", { record: true, sequential: true })
+        .record(
+            { play: { url: "https://example.com/beep.mp3" } },
+            { finishOnKey: "#", maxLength: 30 },
+        )
+        .enqueue({ name: "support" })
+        .dequeue("+254700000001", { name: "support" })
+        .redirect("https://example.com/next")
+        .conference()
+        .reject()
+        .build();
+    void xml;
+}
+
+// =========================================================================
+// Airtime  (airtime.d.ts)
+// =========================================================================
+
+async function airtimeSurface() {
+    const airtime: AfricasTalking.AIRTIME = client.AIRTIME;
+
+    const sendResult: AfricasTalking.AirtimeSendResponse = await airtime.send({
+        idempotencyKey: "abc",
+        maxNumRetry: 3,
+        recipients: [
+            { phoneNumber: "+254700000000", currencyCode: "KES", amount: 50 },
+        ],
+    });
+    const responses: AfricasTalking.AirtimeResponseEntry[] = sendResult.responses;
+    void responses;
+
+    const status: AfricasTalking.AirtimeTransactionStatusResponse = await airtime.findTransactionStatus(
+        "tx_id",
+    );
+    const data: AfricasTalking.AirtimeTransactionData | undefined = status.data;
+    void data;
+}
+
+// =========================================================================
+// Application  (application.d.ts)
+// =========================================================================
+
+async function applicationSurface() {
+    const app: AfricasTalking.APPLICATION = client.APPLICATION;
+    const data: AfricasTalking.ApplicationDataResponse = await app.fetchApplicationData();
+    const balance: string = data.UserData.balance;
+    void balance;
+
+    const accountSurface: AfricasTalking.APPLICATION = client.ACCOUNT;
+    const accountData: AfricasTalking.ApplicationDataResponse = await accountSurface.fetchAccount();
+    void accountData;
+}
+
+// =========================================================================
+// Insights  (insights.d.ts)
+// =========================================================================
+
+async function insightsSurface() {
+    const insights: AfricasTalking.INSIGHTS = client.INSIGHTS;
+    const oneNumber: AfricasTalking.InsightsSimSwapResponse = await insights.checkSimSwapState(
+        "+254700000000",
+    );
+    const manyNumbers: AfricasTalking.InsightsSimSwapResponse = await insights.checkSimSwapState([
+        "+254700000000",
+        "+254700000001",
+    ]);
+    const entries: AfricasTalking.InsightsSimSwapEntry[] = oneNumber.responses;
+    void manyNumbers;
+    void entries;
+}
+
+// =========================================================================
+// Mobile data  (mobileData.d.ts)
+// =========================================================================
+
+async function mobileDataSurface() {
+    const md: AfricasTalking.MOBILE_DATA = client.MOBILE_DATA;
+    await md.send({
+        productName: "DataBundle",
+        idempotencyKey: "abc",
+        recipients: [
+            {
+                phoneNumber: "+254700000000",
+                quantity: 1,
+                unit: "GB",
+                validity: "Month",
+                metadata: { userId: "user_1" },
+            },
+        ],
+    });
+    await md.findTransaction({ transactionId: "tx_id" });
+    await md.fetchWalletBalance();
+}
+
+// =========================================================================
+// WhatsApp  (whatsapp.d.ts)
+// =========================================================================
+
+async function whatsappSurface() {
+    const wa: AfricasTalking.WHATSAPP = client.WHATSAPP;
+
+    await wa.sendMessage({
+        waNumber: "wa_number",
+        phoneNumber: "+254700000000",
+        body: { message: "hello" },
+    });
+
+    await wa.sendMessage({
+        waNumber: "wa_number",
+        phoneNumber: "+254700000000",
+        body: {
+            templateId: "welcome_v1",
+            headerValue: "Welcome",
+            bodyValues: ["Alice"],
+        },
+    });
+
+    await wa.sendMessage({
+        waNumber: "wa_number",
+        phoneNumber: "+254700000000",
+        body: {
+            mediaType: "Image",
+            url: "https://example.com/img.png",
+            caption: "see attached",
+        },
+    });
+
+    await wa.sendMessage({
+        waNumber: "wa_number",
+        phoneNumber: "+254700000000",
+        body: {
+            action: {
+                button: "Pick one",
+                sections: [
+                    {
+                        title: "Options",
+                        rows: [{ id: "1", title: "First", description: "..." }],
+                    },
+                ],
+            },
+            body: { text: "Select an option" },
+        },
+    });
+
+    await wa.sendMessage({
+        waNumber: "wa_number",
+        phoneNumber: "+254700000000",
+        body: {
+            action: {
+                buttons: [
+                    { id: "yes", title: "Yes" },
+                    { id: "no", title: "No" },
+                ],
+            },
+            body: { text: "Confirm?" },
+        },
+    });
+
+    await wa.createTemplate({
+        waNumber: "wa_number",
+        name: "promo_template",
+        language: "en",
+        category: "MARKETING",
+        components: {
+            body: { type: "BODY", text: "Hi {{1}}" },
+        },
+    });
+}
+
+// =========================================================================
+// USSD  (ussd.d.ts)
+// =========================================================================
+
+function ussdSurface() {
+    const ussd: AfricasTalking.USSDMiddlewareFactory = client.USSD;
+
+    const handler: AfricasTalking.USSDHandlerFn = (payload, respond) => {
+        const session: string = payload.sessionId;
+        const phone: string = payload.phoneNumber;
+        const text: string = payload.text;
+        const code: string = payload.serviceCode;
+        void session;
+        void phone;
+        void code;
+
+        if (text === "") {
+            respond({ response: "Welcome", endSession: false });
+        } else {
+            respond({ response: "Goodbye", endSession: true });
+        }
     };
 
-    const res = await sms.createSubscription(options);
-};
+    const middleware: AfricasTalking.USSDMiddleware[] = ussd(handler);
+    void middleware;
+}
+
+void clientHandle;
+void clientXml;
+void smsSurface;
+void tokenSurface;
+void voiceSurface;
+void airtimeSurface;
+void applicationSurface;
+void insightsSurface;
+void mobileDataSurface;
+void whatsappSurface;
+void ussdSurface;

--- a/types/africastalking/index.d.ts
+++ b/types/africastalking/index.d.ts
@@ -1,66 +1,625 @@
-interface SMSMessageData {
-    Message: string;
-    Recipients: {
-        "statusCode": number;
-        "number": string;
-        "status": "fulfilled" | "failed";
-        "cost": string;
-        "messageId": string;
-    };
-}
-
-interface SMSOptions {
-    to: string | string[];
-    from: string;
-    message: string;
-}
-
-interface SMS {
-    /**
-     * This is used to send SMSs to your clients/recipients.
-     *
-     * @param to The recipients' phone number.  e.g +2547********. Note it can either be a string or an array
-     * @param from Your registered short code or alphanumeric, e.g. AFRICASTKNG.
-     * @param message The message to be sent.
-     */
-    send: (options: SMSOptions) => Promise<SMSMessageData>;
-    /**
-     * This is used to send SMSs to your clients/recipients.
-     *
-     * @param to The recipients' phone number.  e.g +2547********. Note it can either be a string or an array
-     * @param from Your registered short code or alphanumeric, e.g. AFRICASTKNG.
-     * @param message The message to be sent.
-     */
-    sendBulk: (options: SMSOptions) => Promise<SMSMessageData>;
-    createSubscription: (options: {
-        shortCode: string;
-        keyword: string;
-        phoneNumber: string;
-        checkoutToken: string;
-    }) => Promise<{
-        "description": "Success" | "Failed";
-        "token": string;
-    }>;
-}
-
-interface TOKEN {
-    generateAuthToken: () => Promise<{
-        "description": "Success" | "Failed";
-        "token": string;
-    }>;
-    createCheckoutToken: (phoneNumber: string) => Promise<{
-        description: "Success" | "Failed";
-        token: string;
-    }>;
-}
-
-interface AfricasTalking {
-    SMS: SMS;
-    TOKEN: TOKEN;
-}
+// Single-file declaration; section comments below mirror the SDK's `lib/`
+// layout one-to-one. DT's `@definitelytyped/no-declare-current-package` rule
+// blocks cross-file namespace augmentation for `export =` packages, so all
+// types live here.
 
 export = africastalking;
 
 declare function africastalking(
-    options: { username: string; apiKey: string },
-): AfricasTalking;
+    options: africastalking.ClientOptions,
+): africastalking.AfricasTalking;
+
+declare namespace africastalking {
+    // =========================================================================
+    // Client  (mirrors `lib/index.js`)
+    // =========================================================================
+
+    interface ClientOptions {
+        username: string;
+        apiKey: string;
+        /** Response wire format. SDK default is `"json"`. */
+        format?: "json" | "xml";
+    }
+
+    /**
+     * Top-level client surface returned by `africastalking(options)`. Each
+     * property is a service handle the SDK constructs at instantiation.
+     */
+    interface AfricasTalking {
+        SMS: SMS;
+        TOKEN: TOKEN;
+        VOICE: VOICE;
+        AIRTIME: AIRTIME;
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        INSIGHTS: INSIGHTS;
+        WHATSAPP: WHATSAPP;
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        MOBILE_DATA: MOBILE_DATA;
+        APPLICATION: APPLICATION;
+        /** Backward-compat alias for {@link APPLICATION}; same instance. */
+        ACCOUNT: APPLICATION;
+        /** Express/connect middleware factory for USSD callbacks. */
+        USSD: USSDMiddlewareFactory;
+    }
+
+    // =========================================================================
+    // SMS  (mirrors `lib/sms.js`)
+    // =========================================================================
+
+    interface SMSOptions {
+        /** Recipient phone number(s) in E.164 format. */
+        to: string | string[];
+        /** Message body. */
+        message: string;
+        /** Registered short code or alphanumeric sender id, e.g. `AFRICASTKNG`. */
+        from?: string;
+        /** Alternate name for {@link SMSOptions.from}. */
+        senderId?: string;
+        /** Bulk-mode toggle to queue messages rather than dispatch immediately. */
+        enqueue?: boolean;
+    }
+
+    interface SMSPremiumOptions extends SMSOptions {
+        keyword: string;
+        linkId?: string;
+        retryDurationInHours?: number;
+    }
+
+    /**
+     * Status returned per recipient. See AT bulk-SMS status codes:
+     * https://developers.africastalking.com/docs/sms/sending/bulk
+     */
+    type SMSRecipientStatus =
+        | "Success"
+        | "Failed"
+        | "Throttled"
+        | "InsufficientBalance"
+        | "UserInBlackList"
+        | "CouldNotRoute"
+        | "InternalServerError"
+        | "UserIsInactive"
+        | "RequestExpired"
+        | "InvalidLongShortCode"
+        // Forward-compat for AT status values not yet enumerated.
+        | (string & {});
+
+    interface SMSRecipient {
+        statusCode: number;
+        number: string;
+        status: SMSRecipientStatus;
+        cost: string;
+        messageId: string;
+    }
+
+    /** Inner content of the AT SMS-send response envelope. */
+    interface SMSMessageData {
+        Message: string;
+        Recipients: SMSRecipient[];
+    }
+
+    /** Top-level shape resolved by {@link SMS.send} for a single request. */
+    interface SMSResponse {
+        SMSMessageData: SMSMessageData;
+    }
+
+    interface SMSFetchOptions {
+        lastReceivedId?: number;
+        keyword?: string;
+        shortCode?: string;
+    }
+
+    interface SMSInboundMessage {
+        linkId: string;
+        text: string;
+        to: string;
+        id: number;
+        date: string;
+        from: string;
+    }
+
+    interface SMSFetchMessagesResponse {
+        SMSMessageData: {
+            Messages: SMSInboundMessage[];
+        };
+    }
+
+    interface SMSSubscriptionOptions {
+        shortCode: string;
+        keyword: string;
+        phoneNumber: string;
+    }
+
+    interface SMSFetchSubscriptionOptions {
+        shortCode: string;
+        keyword: string;
+        lastReceivedId?: number;
+    }
+
+    interface SMSSubscriber {
+        phoneNumber: string;
+        id: number;
+        updateType?: string;
+    }
+
+    interface SMSSubscriptionResponse {
+        description: string;
+        success: string;
+        token?: string;
+    }
+
+    interface SMSFetchSubscriptionResponse {
+        responses: SMSSubscriber[];
+    }
+
+    interface SMSDeleteSubscriptionResponse {
+        description: string;
+        success: string;
+    }
+
+    interface SMS {
+        /**
+         * Send the same content to one or more recipients in a single request.
+         *
+         * @see https://developers.africastalking.com/docs/sms/sending/bulk
+         */
+        send(options: SMSOptions): Promise<SMSResponse>;
+        /**
+         * Send multiple distinct payloads in parallel (one request per element).
+         * Rejected requests appear as `{ SMSMessageData: { Message: <reason>, Recipients: [], status: "failed" } }`.
+         */
+        send(options: SMSOptions[]): Promise<SMSResponse[]>;
+        /** Alias for {@link SMS.send}. */
+        sendBulk(options: SMSOptions): Promise<SMSResponse>;
+        sendBulk(options: SMSOptions[]): Promise<SMSResponse[]>;
+        /**
+         * Send a premium-content SMS. Bulk-mode off; per-recipient delivery
+         * state surfaces in the response.
+         *
+         * @see https://developers.africastalking.com/docs/sms/sending/premium
+         */
+        sendPremium(options: SMSPremiumOptions): Promise<SMSResponse>;
+        /**
+         * Fetch inbound messages received against the account's short codes.
+         *
+         * @see https://developers.africastalking.com/docs/sms/incoming
+         */
+        fetchMessages(options?: SMSFetchOptions): Promise<SMSFetchMessagesResponse>;
+        /**
+         * Create a premium-SMS subscription for a phone number against a
+         * (`shortCode`, `keyword`) pair.
+         *
+         * @see https://developers.africastalking.com/docs/sms/subscriptions/create
+         */
+        createSubscription(options: SMSSubscriptionOptions): Promise<SMSSubscriptionResponse>;
+        fetchSubscription(options: SMSFetchSubscriptionOptions): Promise<SMSFetchSubscriptionResponse>;
+        deleteSubscription(options: SMSSubscriptionOptions): Promise<SMSDeleteSubscriptionResponse>;
+    }
+
+    // =========================================================================
+    // Token  (mirrors `lib/token.js`)
+    // =========================================================================
+
+    interface AuthTokenResponse {
+        token: string;
+        lifetimeInSeconds: number;
+    }
+
+    interface TOKEN {
+        /**
+         * Generate a short-lived auth token usable by client SDKs (mobile / web).
+         *
+         * @see https://developers.africastalking.com/docs/auth-token
+         */
+        generateAuthToken(): Promise<AuthTokenResponse>;
+    }
+
+    // =========================================================================
+    // Voice  (mirrors `lib/voice.js`)
+    // =========================================================================
+
+    interface VoiceCallOptions {
+        callFrom: string;
+        callTo: string | string[];
+        clientRequestId?: string;
+    }
+
+    type VoiceCallStatus =
+        | "Queued"
+        | "InvalidPhoneNumber"
+        | "DestinationNotSupported"
+        | "InsufficientCredit"
+        | (string & {});
+
+    interface VoiceCallEntry {
+        phoneNumber: string;
+        status: VoiceCallStatus;
+        sessionId?: string;
+        errorMessage?: string;
+    }
+
+    interface VoiceCallResponse {
+        entries: VoiceCallEntry[];
+        errorMessage?: string;
+    }
+
+    interface VoiceQueuedCallsOptions {
+        phoneNumbers: string | string[];
+    }
+
+    interface VoiceQueuedCallEntry {
+        phoneNumber: string;
+        queueName: string;
+        numCalls: number;
+    }
+
+    interface VoiceQueuedCallsResponse {
+        entries: VoiceQueuedCallEntry[];
+        errorMessage?: string;
+    }
+
+    interface VoiceUploadMediaOptions {
+        url: string;
+        phoneNumber: string;
+    }
+
+    /**
+     * Response shape is documented only on the AT side and not in the SDK.
+     * Consumers should treat as opaque or narrow against runtime checks.
+     */
+    type VoiceUploadMediaResponse = unknown;
+
+    interface VOICE {
+        /**
+         * Initiate an outbound voice call to one or more numbers.
+         *
+         * @see https://developers.africastalking.com/docs/voice/makecall
+         */
+        call(options: VoiceCallOptions): Promise<VoiceCallResponse>;
+        /**
+         * Get the number of calls currently queued against the account's
+         * virtual numbers.
+         *
+         * @see https://developers.africastalking.com/docs/voice/queue
+         */
+        getNumQueuedCalls(options: VoiceQueuedCallsOptions): Promise<VoiceQueuedCallsResponse>;
+        /**
+         * Upload a media file to AT for later playback in voice flows.
+         *
+         * @see https://developers.africastalking.com/docs/voice/mediaupload
+         */
+        uploadMediaFile(options: VoiceUploadMediaOptions): Promise<VoiceUploadMediaResponse>;
+        /** Constructor for the voice-XML response builder. Instantiate per response. */
+        readonly ActionBuilder: ActionBuilderConstructor;
+    }
+
+    // =========================================================================
+    // ActionBuilder  (mirrors `lib/actionbuilder.js`)
+    // =========================================================================
+
+    interface VoiceSayAttributes {
+        voice?: "man" | "woman" | (string & {});
+        playBeep?: boolean;
+    }
+
+    interface VoiceGetDigitsAttributes {
+        finishOnKey?: string;
+        numDigits?: number;
+        timeout?: number;
+        callbackUrl?: string;
+    }
+
+    interface VoiceDialAttributes {
+        callerId?: string;
+        record?: boolean;
+        sequential?: boolean;
+        maxDuration?: number;
+        ringBackTone?: string;
+    }
+
+    interface VoiceRecordAttributes {
+        finishOnKey?: string;
+        maxLength?: number;
+        timeout?: number;
+        playBeep?: boolean;
+        trimSilence?: boolean;
+        callbackUrl?: string;
+    }
+
+    interface VoiceEnqueueAttributes {
+        holdMusic?: string;
+        name?: string;
+    }
+
+    interface VoiceDequeueAttributes {
+        name?: string;
+    }
+
+    interface VoiceActionChild {
+        say?: { text: string; attributes?: VoiceSayAttributes };
+        play?: { url: string };
+    }
+
+    interface ActionBuilder {
+        say(text: string, attributes?: VoiceSayAttributes): ActionBuilder;
+        play(url: string): ActionBuilder;
+        getDigits(children: VoiceActionChild, attributes: VoiceGetDigitsAttributes): ActionBuilder;
+        dial(phoneNumbers: string, attributes?: VoiceDialAttributes): ActionBuilder;
+        record(children: VoiceActionChild, attributes?: VoiceRecordAttributes): ActionBuilder;
+        enqueue(attributes?: VoiceEnqueueAttributes): ActionBuilder;
+        dequeue(phoneNumber: string, attributes?: VoiceDequeueAttributes): ActionBuilder;
+        redirect(url: string): ActionBuilder;
+        conference(): ActionBuilder;
+        reject(): ActionBuilder;
+        /** Finalize and return the response XML. Throws if called twice. */
+        build(): string;
+    }
+
+    interface ActionBuilderConstructor {
+        new(): ActionBuilder;
+    }
+
+    // =========================================================================
+    // Airtime  (mirrors `lib/airtime.js`)
+    // =========================================================================
+
+    interface AirtimeRecipient {
+        phoneNumber: string;
+        currencyCode: string;
+        amount: number;
+    }
+
+    interface AirtimeSendOptions {
+        recipients: AirtimeRecipient[];
+        idempotencyKey?: string;
+        maxNumRetry?: number;
+    }
+
+    interface AirtimeResponseEntry {
+        phoneNumber: string;
+        amount: string;
+        discount: string;
+        status: string;
+        requestId: string;
+        errorMessage: string;
+    }
+
+    interface AirtimeSendResponse {
+        numSent: number;
+        totalAmount: string;
+        totalDiscount: string;
+        responses: AirtimeResponseEntry[];
+        errorMessage?: string;
+    }
+
+    interface AirtimeTransactionData {
+        amount: string;
+        deliveredAt?: string;
+        phoneNumber: string;
+        requestId: string;
+        status: string;
+        transactionDate?: string;
+    }
+
+    interface AirtimeTransactionStatusResponse {
+        errorMessage?: string;
+        data?: AirtimeTransactionData;
+    }
+
+    interface AIRTIME {
+        /** @see https://developers.africastalking.com/docs/airtime/sending */
+        send(options: AirtimeSendOptions): Promise<AirtimeSendResponse>;
+        /** @see https://developers.africastalking.com/docs/airtime/status */
+        findTransactionStatus(transactionId: string): Promise<AirtimeTransactionStatusResponse>;
+    }
+
+    // =========================================================================
+    // Application  (mirrors `lib/application.js`; also exposed as `ACCOUNT`)
+    // =========================================================================
+
+    interface ApplicationDataResponse {
+        UserData: {
+            balance: string;
+        };
+    }
+
+    interface APPLICATION {
+        /**
+         * Fetch the application's wallet balance and metadata.
+         *
+         * @see https://developers.africastalking.com/docs/application/balance
+         */
+        fetchApplicationData(): Promise<ApplicationDataResponse>;
+        /** Alias for {@link APPLICATION.fetchApplicationData}; same shape. */
+        fetchAccount(): Promise<ApplicationDataResponse>;
+    }
+
+    // =========================================================================
+    // Insights  (mirrors `lib/insights.js`)
+    // =========================================================================
+
+    interface InsightsSimSwapEntry {
+        phoneNumber: string;
+        simSwapStatus?: string;
+        errorMessage?: string;
+    }
+
+    interface InsightsSimSwapResponse {
+        status: "Processed" | (string & {});
+        responses: InsightsSimSwapEntry[];
+    }
+
+    // Identifier matches the SDK's `this.INSIGHTS` runtime property on the
+    // client; `@typescript-eslint/naming-convention` rejects names matching
+    // `^I[A-Z]/u`, so the override is necessary to preserve the runtime-
+    // property convention used across this declaration.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    interface INSIGHTS {
+        /**
+         * Check whether the given phone number(s) have undergone a SIM swap
+         * recently. Useful for fraud / takeover signals.
+         *
+         * @see https://developers.africastalking.com/docs/insights/sim-swap
+         */
+        checkSimSwapState(phoneNumbers: string | string[]): Promise<InsightsSimSwapResponse>;
+    }
+
+    // =========================================================================
+    // Mobile data  (mirrors `lib/mobileData.js`)
+    // =========================================================================
+
+    type MobileDataUnit = "MB" | "GB";
+    type MobileDataValidity = "Day" | "Week" | "BiWeek" | "Month" | "Quarterly";
+
+    interface MobileDataRecipient {
+        phoneNumber: string;
+        quantity: number;
+        unit: MobileDataUnit;
+        validity: MobileDataValidity;
+        metadata: Record<string, unknown>;
+    }
+
+    interface MobileDataSendOptions {
+        productName: string;
+        recipients: MobileDataRecipient[];
+        idempotencyKey?: string;
+    }
+
+    interface MobileDataFindTransactionOptions {
+        transactionId: string;
+    }
+
+    /**
+     * Response shapes for mobile-data endpoints are documented only on the
+     * AT side; opaque to keep the type honest until they stabilize.
+     */
+    type MobileDataResponse = unknown;
+
+    // Identifier matches the SDK's `this.MOBILE_DATA` runtime property on
+    // the client; `@typescript-eslint/naming-convention` rejects
+    // SCREAMING_SNAKE_CASE for interfaces, so the override is necessary to
+    // preserve the runtime-property convention used across this declaration.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    interface MOBILE_DATA {
+        send(options: MobileDataSendOptions): Promise<MobileDataResponse>;
+        findTransaction(options: MobileDataFindTransactionOptions): Promise<MobileDataResponse>;
+        fetchWalletBalance(): Promise<MobileDataResponse>;
+    }
+
+    // =========================================================================
+    // WhatsApp  (mirrors `lib/whatsapp.js`)
+    // =========================================================================
+
+    type WhatsAppMediaType = "Image" | "Video" | "Audio" | "Voice";
+    type WhatsAppTemplateCategory = "MARKETING" | "UTILITY" | "AUTHENTICATION";
+
+    interface WhatsAppTextBody {
+        message: string;
+    }
+
+    interface WhatsAppTemplateBody {
+        templateId: string;
+        headerValue: string;
+        bodyValues: string[];
+    }
+
+    interface WhatsAppMediaBody {
+        mediaType: WhatsAppMediaType;
+        url: string;
+        caption?: string;
+    }
+
+    interface WhatsAppInteractiveSectionRow {
+        id?: string;
+        title?: string;
+        description?: string;
+    }
+
+    interface WhatsAppInteractiveSection {
+        title?: string;
+        product_items?: Array<Record<string, unknown>>;
+        rows: WhatsAppInteractiveSectionRow[];
+    }
+
+    interface WhatsAppInteractiveListAction {
+        button?: string;
+        sections?: WhatsAppInteractiveSection[];
+    }
+
+    interface WhatsAppInteractiveButton {
+        id?: string;
+        title?: string;
+    }
+
+    interface WhatsAppInteractiveButtonAction {
+        buttons?: WhatsAppInteractiveButton[];
+    }
+
+    interface WhatsAppInteractiveBody {
+        action?: WhatsAppInteractiveListAction | WhatsAppInteractiveButtonAction;
+        body?: { text?: string };
+        header?: { text?: string };
+        footer?: { text?: string };
+    }
+
+    type WhatsAppBody = WhatsAppTextBody | WhatsAppTemplateBody | WhatsAppMediaBody | WhatsAppInteractiveBody;
+
+    interface WhatsAppSendOptions {
+        waNumber: string;
+        phoneNumber: string;
+        body: WhatsAppBody;
+    }
+
+    interface WhatsAppTemplateComponents {
+        header?: Record<string, unknown>;
+        body?: Record<string, unknown>;
+        footer?: Record<string, unknown>;
+        buttons?: Record<string, unknown>;
+    }
+
+    interface WhatsAppCreateTemplateOptions {
+        waNumber: string;
+        name: string;
+        language: string;
+        category: WhatsAppTemplateCategory;
+        components: WhatsAppTemplateComponents;
+    }
+
+    type WhatsAppResponse = unknown;
+
+    interface WHATSAPP {
+        sendMessage(options: WhatsAppSendOptions): Promise<WhatsAppResponse>;
+        createTemplate(options: WhatsAppCreateTemplateOptions): Promise<WhatsAppResponse>;
+    }
+
+    // =========================================================================
+    // USSD  (mirrors `lib/ussd.js`)
+    // =========================================================================
+
+    interface USSDPayload {
+        sessionId: string;
+        serviceCode: string;
+        phoneNumber: string;
+        text: string;
+        networkCode?: string;
+        [key: string]: string | undefined;
+    }
+
+    interface USSDResponseOptions {
+        response: string;
+        endSession: boolean;
+    }
+
+    type USSDRespondCallback = (opts: USSDResponseOptions) => void;
+    type USSDHandlerFn = (payload: USSDPayload, respond: USSDRespondCallback) => void;
+
+    /** Connect/Express-compatible middleware function. */
+    type USSDMiddleware = (req: unknown, res: unknown, next: (err?: unknown) => void) => void;
+
+    /**
+     * Factory that takes a USSD handler and returns the middleware tuple to
+     * mount on the USSD callback route.
+     *
+     * @see https://developers.africastalking.com/docs/ussd/callback
+     */
+    type USSDMiddlewareFactory = (handler: USSDHandlerFn) => USSDMiddleware[];
+}

--- a/types/africastalking/package.json
+++ b/types/africastalking/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/africastalking",
-    "version": "0.6.9999",
+    "version": "0.8.9999",
     "projects": [
         "https://www.npmjs.com/package/africastalking"
     ],


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test africastalking`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/AfricasTalkingLtd/africastalking-node.js (`africastalking@0.8.0`).
- [x] Bumped `package.json` from `0.6.9999` to `0.8.9999` to track the SDK major.minor.

## Summary

The existing typings covered only `SMS` and `TOKEN`, and several of those typings diverged from the SDK runtime. Consumers also could not import any supporting interface (`SMSOptions`, `SMSResponse`, etc.) because nothing was exported beyond the factory function.

## Changes

- Wrap all interfaces in `declare namespace africastalking` so consumers can import them by name (`import type { SMSOptions } from "africastalking"` or `AfricasTalking.SMSOptions`).
- Add typings for the seven services that were missing: `VOICE`, `AIRTIME`, `INSIGHTS`, `WHATSAPP`, `MOBILE_DATA`, `APPLICATION`, `USSD`, plus the `ActionBuilder` constructor exposed on the `VOICE` handle.
- Fix `SMS.send` response shape. The SDK resolves `response.data`, which wraps the payload in an `SMSMessageData` envelope (`{ SMSMessageData: { Message, Recipients } }`). The previous typing had the inner shape at the top level. Also fix `Recipients`: typed as a single object, runtime returns an array of one entry per recipient.
- Fix `Token.generateAuthToken` return shape to `{ token, lifetimeInSeconds }`. The previous typing returned `{ description, token }`, which is the error response shape rather than the success shape.
- Remove `TOKEN.createCheckoutToken`. The current SDK does not implement this method; calling it throws at runtime.
- Fix `SMSOptions`. `from` is optional in the SDK Joi schema but was required in the previous type. Add `senderId`, `enqueue`. Add `SMSPremiumOptions` extending `SMSOptions` with `keyword`, `linkId`, `retryDurationInHours`.
- Fix `SMS.createSubscription` to drop the `checkoutToken` parameter that the SDK validator rejects.
- Add overload `SMS.send(options: SMSOptions[]): Promise<SMSResponse[]>` for parallel batch send (the SDK uses `Promise.allSettled` internally and returns a per-element response).
- Add `SMS.sendPremium`, `SMS.fetchMessages`, `SMS.fetchSubscription`, `SMS.deleteSubscription`, all of which exist in the SDK but were absent from the typings.

## Naming

Interface names follow the SDK runtime property names on the client (`SMS`, `TOKEN`, `VOICE`, `AIRTIME`, `INSIGHTS`, `WHATSAPP`, `MOBILE_DATA`, `APPLICATION`). `INSIGHTS` and `MOBILE_DATA` carry targeted `eslint-disable @typescript-eslint/naming-convention` comments because their shapes match the runtime property names exactly; three overrides total, used only where the SDK identifier conflicts with the convention rule.

## Coverage

`africastalking-tests.ts` exercises every named export and every service's call surface, including:

- Single and array overloads of `SMS.send` and `SMS.sendBulk`.
- Each `WhatsApp.sendMessage` body shape (text, template, media, interactive list, interactive button).
- The full chainable `ActionBuilder` surface ending in `build()`.
- USSD handler payload destructuring and middleware return type.

## Out of scope

A few response shapes are intentionally `unknown` (`VoiceUploadMediaResponse`, `MobileDataResponse`, `WhatsAppResponse`) because their shapes are documented only on the AT side and not surfaced through the SDK. Opaque is more honest than a fabricated shape until the public API stabilizes.

The `Recipients[].status` and `VoiceCallEntry.status` unions list the known AT API values plus `(string & {})` for forward compatibility, since the AT documentation may add status values without notice.
