### PR TITLE
[navermaps] Mark GL-only methods as optional on StreetLayer

### DIFF
--- a/types/navermaps/index.d.ts
+++ b/types/navermaps/index.d.ts
@@ -1532,6 +1532,10 @@ declare namespace naver.maps {
      */
     class StreetLayer extends LabelLayer {
         constructor(option?: StreetLayerOptions);
+        // Only available in the Maps GL submodule.
+        setAirWaterView?(visible: boolean): void;
+        // Only available in the Maps GL submodule.
+        isVisibleAirWaterView?(): boolean;
     }
 
     /**

--- a/types/navermaps/navermaps-tests.ts
+++ b/types/navermaps/navermaps-tests.ts
@@ -68,6 +68,10 @@ const cadastral = new naver.maps.CadastralLayer();
 naver.maps.Event.once(map, "init", function() {
     street.setMap(map);
     cadastral.setMap(map);
+
+    // Optional methods
+    street.setAirWaterView?.(false);
+    street.isVisibleAirWaterView?.();
 });
 
 /**


### PR DESCRIPTION
## Summary

`StreetLayer.setAirWaterView` and `StreetLayer.isVisibleAirWaterView` are only available in the NAVER Maps GL submodule, not in the standard Maps JS API. 
Marking them as optional so consumers using the non-GL build are not forced to call (or assume the existence of) methods that do not exist at runtime.


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
   - https://navermaps.github.io/maps.js.ncp/docs/naver.maps.StreetLayer.html#setAirWaterView__anchor
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
