### PR TITLE
types(oracledb): add NCLOB to fetchAsString type

### DIFF
--- a/types/oracledb/index.d.ts
+++ b/types/oracledb/index.d.ts
@@ -658,7 +658,7 @@ declare namespace OracleDB {
      *
      * For non-CLOB types, the conversion to string is handled by Oracle client libraries and is often referred to as defining the fetch type.
      */
-    let fetchAsString: Array<typeof DATE | typeof NUMBER | typeof BUFFER | typeof CLOB>;
+     let fetchAsString: Array<typeof DATE | typeof NUMBER | typeof BUFFER | typeof CLOB | typeof NCLOB>;
     /**
      * Converter can be used with fetch type handlers to change the returned data.
      * If the value returned by the fetch type handler function is undefined then no conversion takes place.

--- a/types/oracledb/index.d.ts
+++ b/types/oracledb/index.d.ts
@@ -658,7 +658,7 @@ declare namespace OracleDB {
      *
      * For non-CLOB types, the conversion to string is handled by Oracle client libraries and is often referred to as defining the fetch type.
      */
-     let fetchAsString: Array<typeof DATE | typeof NUMBER | typeof BUFFER | typeof CLOB | typeof NCLOB>;
+    let fetchAsString: Array<typeof DATE | typeof NUMBER | typeof BUFFER | typeof CLOB | typeof NCLOB>;
     /**
      * Converter can be used with fetch type handlers to change the returned data.
      * If the value returned by the fetch type handler function is undefined then no conversion takes place.

--- a/types/oracledb/oracledb-tests.ts
+++ b/types/oracledb/oracledb-tests.ts
@@ -720,7 +720,7 @@ export const fetchAsBufferTests = (): void => {
 };
 
 export const fetchAsStringTests = (): void => {
-    defaultOracledb.fetchAsString = [oracledb.DATE, oracledb.NUMBER, oracledb.BUFFER, oracledb.CLOB];
+    defaultOracledb.fetchAsString = [oracledb.DATE, oracledb.NUMBER, oracledb.BUFFER, oracledb.CLOB, oracledb.NCLOB];
     // @ts-expect-error
     defaultOracledb.fetchAsString = [{}];
     // @ts-expect-error


### PR DESCRIPTION
## Summary

Add `NCLOB` to the `fetchAsString` type definition.

## Why

`oracledb` v6+ supports `NCLOB` in `fetchAsString` at runtime (confirmed in `lib/settings.js`), but the `@types/oracledb` type definition was missing it, causing TypeScript errors:

```ts
// Runtime works, but TS error:
oracledb.fetchAsString = [oracledb.CLOB, oracledb.NCLOB];
//                              ~~~~~~~~~~ Type 'DbType' is not assignable...
```

## Evidence

Runtime source (`lib/settings.js`):
```js
case types.DB_TYPE_CLOB:
case types.DB_TYPE_NCLOB:
  map.set(types.DB_TYPE_CLOB, types.DB_TYPE_LONG);
  map.set(types.DB_TYPE_NCLOB, types.DB_TYPE_LONG_NVARCHAR);
  break;
```

`NCLOB` constant is already exported in the type definitions, just missing from `fetchAsString`.

## Changes

- `types/oracledb/index.d.ts`: Added `typeof NCLOB` to `fetchAsString` array type
- `types/oracledb/oracledb-tests.ts`: Added `oracledb.NCLOB` to fetchAsString test