### PR TITLE
[pdfmake] add missing types from version 0.3.4 till 0.3.8

### DIFF
--- a/types/pdfmake/index.d.ts
+++ b/types/pdfmake/index.d.ts
@@ -9,8 +9,8 @@ import {
     TVirtualFileSystem,
 } from "./interfaces";
 
-export type { TCreatedPdf };
 export type { Alignment, Content, CustomTableLayout, Size, Style, Table, TableCell, TableLayout } from "./interfaces";
+export type { TCreatedPdf };
 
 export function createPdf(
     documentDefinitions: TDocumentDefinitions,
@@ -37,5 +37,14 @@ export function addVirtualFileSystem(vfs: TVirtualFileSystem): void;
  * **Note:** Only supported in the browser.
  */
 export function addFontContainer(fontContainer: TFontContainer): void;
+
+/**
+ * **Note:** Only supported in Node.js.
+ */
+export function setUrlAccessPolicy(callback: (url: string) => boolean): void;
+/**
+ * **Note:** Only supported in Node.js.
+ */
+export function setLocalAccessPolicy(callback: (path: string) => boolean): void;
 
 export as namespace pdfMake;

--- a/types/pdfmake/interfaces.d.ts
+++ b/types/pdfmake/interfaces.d.ts
@@ -1056,7 +1056,7 @@ export interface ContentColumns extends ContentBase, ForbidOtherElementPropertie
      *
      * Note: Recursive snaking columns are not supported.
      */
-    snakingColumns?: boolean
+    snakingColumns?: boolean;
 }
 
 /**

--- a/types/pdfmake/interfaces.d.ts
+++ b/types/pdfmake/interfaces.d.ts
@@ -1049,6 +1049,14 @@ export interface ContentText extends ContentLink, ContentBase, ForbidOtherElemen
 export interface ContentColumns extends ContentBase, ForbidOtherElementProperties<"columns"> {
     /** Divides the given elements into multiple columns. */
     columns: Column[];
+    /**
+     * Enables snaking columns (newspaper-style columns), where content flows vertically through the first column
+     * and continues at the top of the next columns as needed. Only the first column should contain content;
+     * the remaining columns act as empty overflow targets.
+     *
+     * Note: Recursive snaking columns are not supported.
+     */
+    snakingColumns?: boolean
 }
 
 /**

--- a/types/pdfmake/interfaces.d.ts
+++ b/types/pdfmake/interfaces.d.ts
@@ -1702,6 +1702,11 @@ export interface TableOfContent {
      * Defaults to the system locale.
      */
     sortLocale?: string | undefined;
+
+    /**
+     * If set to `true`, adds all items to outlines / bookmarks (any existing outline settings on texts are respected)
+     */
+    outlines?: boolean | undefined;
 }
 
 /**

--- a/types/pdfmake/interfaces.d.ts
+++ b/types/pdfmake/interfaces.d.ts
@@ -1023,6 +1023,24 @@ export interface ContentText extends ContentLink, ContentBase, ForbidOtherElemen
      * below one another, but as inline text in a single paragraph.
      */
     text: Content;
+    /**
+     * Adds this node to the PDF outline/bookmark tree.
+     *
+     * Outlines are hierarchical navigation entries shown in the PDF viewer.
+     */
+    outline?: boolean;
+    /**
+     * Overrides the displayed bookmark label.
+     */
+    outlineText?: string;
+    /**
+     * Marks the bookmark as expanded/opened by default.
+     */
+    outlineExpanded?: boolean;
+    /**
+     * Assigns this bookmark to the parent entry with the given `id`.
+     */
+    outlineParentId?: string;
 }
 
 /**

--- a/types/pdfmake/interfaces.d.ts
+++ b/types/pdfmake/interfaces.d.ts
@@ -528,6 +528,13 @@ export interface TableCellProperties {
      * Defaults to `1`.
      */
     overlayOpacity?: number | null | undefined;
+
+    /**
+     * Vertical alignment of the cell's content.
+     *
+     * Defaults to `top`.
+     */
+    verticalAlignment?: "top" | "middle" | "bottom" | undefined;
 }
 
 /**

--- a/types/pdfmake/interfaces.d.ts
+++ b/types/pdfmake/interfaces.d.ts
@@ -1028,19 +1028,19 @@ export interface ContentText extends ContentLink, ContentBase, ForbidOtherElemen
      *
      * Outlines are hierarchical navigation entries shown in the PDF viewer.
      */
-    outline?: boolean;
+    outline?: boolean | undefined;
     /**
      * Overrides the displayed bookmark label.
      */
-    outlineText?: string;
+    outlineText?: string | undefined;
     /**
      * Marks the bookmark as expanded/opened by default.
      */
-    outlineExpanded?: boolean;
+    outlineExpanded?: boolean | undefined;
     /**
      * Assigns this bookmark to the parent entry with the given `id`.
      */
-    outlineParentId?: string;
+    outlineParentId?: string | undefined;
 }
 
 /**
@@ -1056,7 +1056,7 @@ export interface ContentColumns extends ContentBase, ForbidOtherElementPropertie
      *
      * Note: Recursive snaking columns are not supported.
      */
-    snakingColumns?: boolean;
+    snakingColumns?: boolean | undefined;
 }
 
 /**

--- a/types/pdfmake/test/pdfmake-examples-tests.ts
+++ b/types/pdfmake/test/pdfmake-examples-tests.ts
@@ -2423,6 +2423,18 @@ const tables: TDocumentDefinitions = {
                 ],
             },
         },
+        {
+            table: {
+                headerRows: 1,
+                widths: [ '*', 'auto', 100, '*' ],
+
+                body: [
+                    [ 'First', 'Second', 'Third', 'The last one' ],
+                    [ 'Value 1', 'Value 2', 'Value 3', 'Value 4' ],
+                    [ { text: 'Bold value', verticalAlignment: "middle" }, 'Val 2', 'Val 3', 'Val 4' ]
+                ]
+            }
+        }
     ],
     styles: {
         header: {

--- a/types/pdfmake/test/pdfmake-examples-tests.ts
+++ b/types/pdfmake/test/pdfmake-examples-tests.ts
@@ -2466,6 +2466,42 @@ const tables: TDocumentDefinitions = {
     },
 };
 
+const outlinesAndBookmarks: TDocumentDefinitions = {
+  content: [
+    {
+      text: 'First header in bookmarks',
+      outline: true,
+    },
+    {
+      text: 'Second header with custom bookmark',
+      outline: true,
+      outlineText: 'Custom bookmark text',
+    },
+    {
+      text: 'Structured bookmarks',
+      id: 'structured-bookmarks',
+      outline: true,
+      outlineExpanded: true
+    },
+    {
+      text: 'First subheader',
+      outline: true,
+      outlineParentId: 'structured-bookmarks'
+    },
+    {
+      text: 'Second subheader',
+      outline: true,
+      outlineParentId: 'structured-bookmarks'
+    },
+    {
+      text: 'Third subheader',
+      outline: true,
+      outlineParentId: 'structured-bookmarks',
+      id: 'third-subheader'
+    }
+  ]
+};
+
 const textDecorations: TDocumentDefinitions = {
     content: [
         { text: "Higlighted text", fontSize: 18, background: "yellow" },

--- a/types/pdfmake/test/pdfmake-examples-tests.ts
+++ b/types/pdfmake/test/pdfmake-examples-tests.ts
@@ -404,6 +404,19 @@ const columnsSimple: TDocumentDefinitions = {
     },
 };
 
+const columnsSnake: TDocumentDefinitions = {
+    content: [
+        {
+            columns: [
+                {text: "Long content", width: '*'},
+                {text: '', width: '*'},
+                {text: '', width: '*'}
+            ],
+            snakingColumns: true
+        }
+    ]
+};
+
 const images: TDocumentDefinitions = {
     content: [
         "pdfmake (since it's based on pdfkit) supports JPEG and PNG format",

--- a/types/pdfmake/test/pdfmake-examples-tests.ts
+++ b/types/pdfmake/test/pdfmake-examples-tests.ts
@@ -408,13 +408,13 @@ const columnsSnake: TDocumentDefinitions = {
     content: [
         {
             columns: [
-                {text: "Long content", width: '*'},
-                {text: '', width: '*'},
-                {text: '', width: '*'}
+                { text: "Long content", width: "*" },
+                { text: "", width: "*" },
+                { text: "", width: "*" },
             ],
-            snakingColumns: true
-        }
-    ]
+            snakingColumns: true,
+        },
+    ],
 };
 
 const images: TDocumentDefinitions = {
@@ -2439,15 +2439,15 @@ const tables: TDocumentDefinitions = {
         {
             table: {
                 headerRows: 1,
-                widths: [ '*', 'auto', 100, '*' ],
+                widths: ["*", "auto", 100, "*"],
 
                 body: [
-                    [ 'First', 'Second', 'Third', 'The last one' ],
-                    [ 'Value 1', 'Value 2', 'Value 3', 'Value 4' ],
-                    [ { text: 'Bold value', verticalAlignment: "middle" }, 'Val 2', 'Val 3', 'Val 4' ]
-                ]
-            }
-        }
+                    ["First", "Second", "Third", "The last one"],
+                    ["Value 1", "Value 2", "Value 3", "Value 4"],
+                    [{ text: "Bold value", verticalAlignment: "middle" }, "Val 2", "Val 3", "Val 4"],
+                ],
+            },
+        },
     ],
     styles: {
         header: {
@@ -2480,39 +2480,39 @@ const tables: TDocumentDefinitions = {
 };
 
 const outlinesAndBookmarks: TDocumentDefinitions = {
-  content: [
-    {
-      text: 'First header in bookmarks',
-      outline: true,
-    },
-    {
-      text: 'Second header with custom bookmark',
-      outline: true,
-      outlineText: 'Custom bookmark text',
-    },
-    {
-      text: 'Structured bookmarks',
-      id: 'structured-bookmarks',
-      outline: true,
-      outlineExpanded: true
-    },
-    {
-      text: 'First subheader',
-      outline: true,
-      outlineParentId: 'structured-bookmarks'
-    },
-    {
-      text: 'Second subheader',
-      outline: true,
-      outlineParentId: 'structured-bookmarks'
-    },
-    {
-      text: 'Third subheader',
-      outline: true,
-      outlineParentId: 'structured-bookmarks',
-      id: 'third-subheader'
-    }
-  ]
+    content: [
+        {
+            text: "First header in bookmarks",
+            outline: true,
+        },
+        {
+            text: "Second header with custom bookmark",
+            outline: true,
+            outlineText: "Custom bookmark text",
+        },
+        {
+            text: "Structured bookmarks",
+            id: "structured-bookmarks",
+            outline: true,
+            outlineExpanded: true,
+        },
+        {
+            text: "First subheader",
+            outline: true,
+            outlineParentId: "structured-bookmarks",
+        },
+        {
+            text: "Second subheader",
+            outline: true,
+            outlineParentId: "structured-bookmarks",
+        },
+        {
+            text: "Third subheader",
+            outline: true,
+            outlineParentId: "structured-bookmarks",
+            id: "third-subheader",
+        },
+    ],
 };
 
 const textDecorations: TDocumentDefinitions = {

--- a/types/pdfmake/test/pdfmake-examples-tests.ts
+++ b/types/pdfmake/test/pdfmake-examples-tests.ts
@@ -2599,6 +2599,7 @@ const toc: TDocumentDefinitions = {
                 numberStyle: { bold: true },
                 sortBy: "page",
                 sortLocale: "cs",
+                outlines: true,
             },
         },
         {

--- a/types/pdfmake/test/pdfmake-module-server-tests.ts
+++ b/types/pdfmake/test/pdfmake-module-server-tests.ts
@@ -36,3 +36,6 @@ pdfMake.setProgressCallback(progress => console.log("Creating pdf: ", progress *
 pdfMake.createPdf(dd, options).write("fileName.pdf").then(() => {
     console.log("PDF file written");
 });
+
+pdfMake.setUrlAccessPolicy(url => url.startsWith(""));
+pdfMake.setLocalAccessPolicy(path => path.startsWith(""));


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [URL access policy](https://pdfmake.github.io/docs/0.3/getting-started/server-side/methods/#url-access-policy)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

I did not update the version in the `package.json` because currently it is set to **0.3.9999**.  Should I downgrade the version?

- `verticalAlignment` property for table cells was added with version [0.3.4](https://github.com/bpampuch/pdfmake/blob/master/CHANGELOG.md#034---2026-02-13)
- `snakingColumns` property for columns to enable newspaper-like column flow was added with version [0.3.5](https://github.com/bpampuch/pdfmake/blob/master/CHANGELOG.md#035---2026-02-22)
- `outlines` and `bookmarks` for text nodes was added with version [0.3.5](https://github.com/bpampuch/pdfmake/blob/master/CHANGELOG.md#035---2026-02-22)
- `setUrlAccessPolicy` was added with version [0.3.6](https://github.com/bpampuch/pdfmake/blob/master/CHANGELOG.md#036---2026-03-10)
- `setLocalAccessPolicy` was added with version[0.3.8](https://github.com/bpampuch/pdfmake/blob/master/CHANGELOG.md#038---2026-05-06)