### PR TITLE
🤖 [react] Add commandFor and command attributes to ButtonHTMLAttributes

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3050,6 +3050,8 @@ declare namespace React {
     }
 
     interface ButtonHTMLAttributes<T> extends HTMLAttributes<T> {
+        command?: string | undefined;
+        commandFor?: string | undefined;
         disabled?: boolean | undefined;
         form?: string | undefined;
         formAction?:

--- a/types/react/test/elementAttributes.tsx
+++ b/types/react/test/elementAttributes.tsx
@@ -167,8 +167,12 @@ const testCases = [
             // @ts-expect-error
             popoverTargetAction="bad"
         >
-            Hide
+            Bad action
         </button>
+        {/* Tests for Invoker Commands API — commandFor and command */}
+        <button commandFor="my-popover" command="toggle-popover">Toggle</button>
+        <button commandFor="my-dialog" command="show-modal">Open</button>
+        <button commandFor="custom" command="--custom-action">Custom</button>
     </>,
     <>
         <template>

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -3049,6 +3049,8 @@ declare namespace React {
     }
 
     interface ButtonHTMLAttributes<T> extends HTMLAttributes<T> {
+        command?: string | undefined;
+        commandFor?: string | undefined;
         disabled?: boolean | undefined;
         form?: string | undefined;
         formAction?:

--- a/types/react/v18/index.d.ts
+++ b/types/react/v18/index.d.ts
@@ -3158,6 +3158,8 @@ declare namespace React {
     }
 
     interface ButtonHTMLAttributes<T> extends HTMLAttributes<T> {
+        command?: string | undefined;
+        commandFor?: string | undefined;
         disabled?: boolean | undefined;
         form?: string | undefined;
         formAction?:

--- a/types/react/v18/ts5.0/index.d.ts
+++ b/types/react/v18/ts5.0/index.d.ts
@@ -3159,6 +3159,8 @@ declare namespace React {
     }
 
     interface ButtonHTMLAttributes<T> extends HTMLAttributes<T> {
+        command?: string | undefined;
+        commandFor?: string | undefined;
         disabled?: boolean | undefined;
         form?: string | undefined;
         formAction?:


### PR DESCRIPTION
Fixes #74664

## Summary

Add `commandFor` and `command` HTML attributes from the [Invoker Commands API](https://open-ui.org/components/invokers.explainer/) to React's `ButtonHTMLAttributes` interface across all supported type versions.

## Documentation

- [whatwg/html PR #9841](https://github.com/whatwg/html/pull/9841)
- [MDN: HTMLButtonElement.commandForElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLButtonElement/commandForElement)
- [Open UI: Invoker Commands Explainer](https://open-ui.org/components/invokers.explainer/)

## Browser Support

- Chrome/Edge 135+
- Safari Technology Preview
- Firefox Nightly (behind flag)

## Changes

- `types/react/index.d.ts`: add `command?: string | undefined` and `commandFor?: string | undefined` (`+2`)
- `types/react/ts5.0/index.d.ts`: same (`+2`)
- `types/react/v18/index.d.ts`: same (`+2`)
- `types/react/v18/ts5.0/index.d.ts`: same (`+2`)
- `types/react/test/elementAttributes.tsx`: add test cases for all 3 command value forms — built-in (`toggle-popover`, `show-modal`) and custom (`--custom-action`) (`+5 -1`)

## Testing

- `<button commandFor="my-popover" command="toggle-popover">`: compiles ✅
- `<button commandFor="my-dialog" command="show-modal">`: compiles ✅
- `<button commandFor="custom" command="--custom-action">`: custom prefixed values compile ✅
- Existing popoverTarget/popoverTargetAction tests still pass ✅