### PR TITLE
[relay-runtime] add extensions field to PayloadError per GraphQL spec

### DIFF
--- a/types/relay-runtime/lib/network/RelayNetworkTypes.d.ts
+++ b/types/relay-runtime/lib/network/RelayNetworkTypes.d.ts
@@ -24,6 +24,7 @@ export interface PayloadError {
         }>
         | undefined;
     path?: Array<string | number>;
+    extensions?: PayloadExtensions | undefined;
     severity?: "CRITICAL" | "ERROR" | "WARNING" | undefined; // Not officially part of the spec, but used at Facebook
 }
 

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -20,6 +20,7 @@ import {
     isValueResult,
     LiveState,
     Network,
+    PayloadError,
     PreloadableConcreteRequest,
     PreloadableQueryRegistry,
     QueryResponseCache,
@@ -96,6 +97,17 @@ const network = Network.create(fetchFunction);
 
 // Create a cache for storing query responses
 const cache = new QueryResponseCache({ size: 250, ttl: 60000 });
+
+// PayloadError extensions
+const payloadErrorWithExtensions: PayloadError = {
+    message: "Name for character with ID 1002 could not be fetched.",
+    locations: [{ line: 6, column: 7 }],
+    path: ["hero", "heroFriends", 1, "name"],
+    extensions: {
+        code: "CAN_NOT_FETCH_BY_ID",
+        timestamp: "Fri Feb 9 14:33:09 UTC 2018",
+    },
+};
 
 // ~~~~~~~~~~~~~~~~~~~~~
 // Handler Provider


### PR DESCRIPTION
The GraphQL spec (https://spec.graphql.org/September2025/#sec-Errors) states that errors may include an `extensions` entry whose value must be a map with no additional restrictions on its contents. `PayloadError` was missing this field.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [GraphQL Spec](https://spec.graphql.org/September2025/#example-8b658)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
