### PR TITLE
stream: allow async functions as async stateless transforms

### DIFF
--- a/types/node/node-tests/stream-iter.ts
+++ b/types/node/node-tests/stream-iter.ts
@@ -1,5 +1,6 @@
 import { FileHandle, open } from "node:fs/promises";
 import { bytes, from, fromSync, pipeTo, pull, pullSync, text, textSync } from "node:stream/iter";
+import { setTimeout } from "node:timers/promises";
 import { compressGzip, compressGzipSync, decompressGzip, decompressGzipSync } from "node:zlib/iter";
 
 // Async round-trip
@@ -30,4 +31,11 @@ void async function() {
     const fh: FileHandle = await open("file");
     using syncDispose = fh.writer();
     await using asyncDispose = fh.writer();
+};
+
+void async function() {
+    pull("hello", async (chunk: Uint8Array[] | null) => {
+        await setTimeout(1000);
+        return chunk;
+    });
 };

--- a/types/node/stream/iter.d.ts
+++ b/types/node/stream/iter.d.ts
@@ -111,7 +111,10 @@ declare module "node:stream/iter" {
         signal: AbortSignal;
     }
     interface StatelessTransformFn {
-        (chunks: Uint8Array[] | null, options: TransformCallbackOptions): TransformResult | null;
+        (
+            chunks: Uint8Array[] | null,
+            options: TransformCallbackOptions,
+        ): Promise<TransformResult | null> | TransformResult | null;
     }
     interface SyncStatelessTransformFn {
         (chunks: Uint8Array[] | null): SyncTransformResult | null;


### PR DESCRIPTION
Undocumented, but intentional: https://github.com/nodejs/node/blob/2ebf53330ddeddc7e49557de8cddc5e7d8180a30/lib/internal/streams/iter/pull.js#L281-L286
