### PR TITLE
[selenium-webdriver] fix getAttribute return type to Promise<string | null>

### DIFF
--- a/types/selenium-webdriver/index.d.ts
+++ b/types/selenium-webdriver/index.d.ts
@@ -1169,7 +1169,7 @@ export interface IWebElement {
      * @return {!Promise} A promise that will be resolved with the
      *     attribute's value.
      */
-    getAttribute(attributeName: string): Promise<string>;
+    getAttribute(attributeName: string): Promise<string | null>;
 
     /**
      * Get the visible (i.e. not hidden by CSS) innerText of this element,
@@ -1564,7 +1564,7 @@ export class WebElement implements Serializable<IWebElementId> {
      *     resolved with the attribute's value. The returned value will always be
      *     either a string or null.
      */
-    getAttribute(attributeName: string): Promise<string>;
+    getAttribute(attributeName: string): Promise<string | null>;
 
     /**
      * Get the visible (i.e. not hidden by CSS) innerText of this element,

--- a/types/selenium-webdriver/test/index.ts
+++ b/types/selenium-webdriver/test/index.ts
@@ -513,7 +513,12 @@ function TestWebElement() {
     element = element.findElement({ id: "ABC" });
     element.findElements({ className: "ABC" }).then((elements: webdriver.WebElement[]) => {});
 
-    stringPromise = element.getAttribute("class");
+    const maybeAttr: Promise<string | null> = element.getAttribute("class");
+    maybeAttr.then(v => {
+        if (v !== null) {
+            v.toUpperCase();
+        }
+    });
     stringPromise = element.getCssValue("display");
     driver = element.getDriver();
     element.getLocation().then((location: webdriver.ILocation) => {});


### PR DESCRIPTION
The `getAttribute` method on both `IWebElement` and `WebElement` was typed as `Promise<string>`, but the Selenium source explicitly document it as returning `null` when the attribute is absent.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

---

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [JSDoc in source](https://github.com/SeleniumHQ/selenium/blob/trunk/javascript/selenium-webdriver/lib/webdriver.js#L2852)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
