### PR TITLE
Re-export the React JSX namespace

### DIFF
--- a/types/react-blessed/index.d.ts
+++ b/types/react-blessed/index.d.ts
@@ -288,15 +288,3 @@ declare module "react" {
         interface IntrinsicElements extends BlessedIntrinsicElementsPrefixed, BlessedIntrinsicElements {}
     }
 }
-
-// augment react/jsx-runtime JSX when new JSX transform is used
-declare module "react/jsx-runtime" {
-    namespace JSX {
-        interface IntrinsicElements extends BlessedIntrinsicElementsPrefixed, BlessedIntrinsicElements {}
-    }
-}
-declare module "react/jsx-dev-runtime" {
-    namespace JSX {
-        interface IntrinsicElements extends BlessedIntrinsicElementsPrefixed, BlessedIntrinsicElements {}
-    }
-}

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -4129,7 +4129,6 @@ declare namespace React {
         componentStack?: string | null;
     }
 
-    // Keep in sync with JSX namespace in ./jsx-runtime.d.ts and ./jsx-dev-runtime.d.ts
     namespace JSX {
         // We don't just alias React.ElementType because React.ElementType
         // historically does more than we need it to.

--- a/types/react/jsx-dev-runtime.d.ts
+++ b/types/react/jsx-dev-runtime.d.ts
@@ -1,17 +1,5 @@
 import * as React from "./";
-export { Fragment } from "./";
-
-export namespace JSX {
-    type ElementType = React.JSX.ElementType;
-    interface Element extends React.JSX.Element {}
-    interface ElementClass extends React.JSX.ElementClass {}
-    interface ElementAttributesProperty extends React.JSX.ElementAttributesProperty {}
-    interface ElementChildrenAttribute extends React.JSX.ElementChildrenAttribute {}
-    type LibraryManagedAttributes<C, P> = React.JSX.LibraryManagedAttributes<C, P>;
-    interface IntrinsicAttributes extends React.JSX.IntrinsicAttributes {}
-    interface IntrinsicClassAttributes<T> extends React.JSX.IntrinsicClassAttributes<T> {}
-    interface IntrinsicElements extends React.JSX.IntrinsicElements {}
-}
+export { Fragment, JSX } from "./";
 
 export interface JSXSource {
     /**

--- a/types/react/jsx-runtime.d.ts
+++ b/types/react/jsx-runtime.d.ts
@@ -1,17 +1,5 @@
 import * as React from "./";
-export { Fragment } from "./";
-
-export namespace JSX {
-    type ElementType = React.JSX.ElementType;
-    interface Element extends React.JSX.Element {}
-    interface ElementClass extends React.JSX.ElementClass {}
-    interface ElementAttributesProperty extends React.JSX.ElementAttributesProperty {}
-    interface ElementChildrenAttribute extends React.JSX.ElementChildrenAttribute {}
-    type LibraryManagedAttributes<C, P> = React.JSX.LibraryManagedAttributes<C, P>;
-    interface IntrinsicAttributes extends React.JSX.IntrinsicAttributes {}
-    interface IntrinsicClassAttributes<T> extends React.JSX.IntrinsicClassAttributes<T> {}
-    interface IntrinsicElements extends React.JSX.IntrinsicElements {}
-}
+export { Fragment, JSX } from "./";
 
 /**
  * Create a React element.

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -4128,7 +4128,6 @@ declare namespace React {
         componentStack?: string | null;
     }
 
-    // Keep in sync with JSX namespace in ./jsx-runtime.d.ts and ./jsx-dev-runtime.d.ts
     namespace JSX {
         interface Element extends React.ReactElement<any, any> {}
         interface ElementClass extends React.Component<any> {

--- a/types/react/ts5.0/jsx-dev-runtime.d.ts
+++ b/types/react/ts5.0/jsx-dev-runtime.d.ts
@@ -1,16 +1,5 @@
 import * as React from "./";
-export { Fragment } from "./";
-
-export namespace JSX {
-    interface Element extends React.JSX.Element {}
-    interface ElementClass extends React.JSX.ElementClass {}
-    interface ElementAttributesProperty extends React.JSX.ElementAttributesProperty {}
-    interface ElementChildrenAttribute extends React.JSX.ElementChildrenAttribute {}
-    type LibraryManagedAttributes<C, P> = React.JSX.LibraryManagedAttributes<C, P>;
-    interface IntrinsicAttributes extends React.JSX.IntrinsicAttributes {}
-    interface IntrinsicClassAttributes<T> extends React.JSX.IntrinsicClassAttributes<T> {}
-    interface IntrinsicElements extends React.JSX.IntrinsicElements {}
-}
+export { Fragment, JSX } from "./";
 
 export interface JSXSource {
     /**

--- a/types/react/ts5.0/jsx-runtime.d.ts
+++ b/types/react/ts5.0/jsx-runtime.d.ts
@@ -1,16 +1,5 @@
 import * as React from "./";
-export { Fragment } from "./";
-
-export namespace JSX {
-    interface Element extends React.JSX.Element {}
-    interface ElementClass extends React.JSX.ElementClass {}
-    interface ElementAttributesProperty extends React.JSX.ElementAttributesProperty {}
-    interface ElementChildrenAttribute extends React.JSX.ElementChildrenAttribute {}
-    type LibraryManagedAttributes<C, P> = React.JSX.LibraryManagedAttributes<C, P>;
-    interface IntrinsicAttributes extends React.JSX.IntrinsicAttributes {}
-    interface IntrinsicClassAttributes<T> extends React.JSX.IntrinsicClassAttributes<T> {}
-    interface IntrinsicElements extends React.JSX.IntrinsicElements {}
-}
+export { Fragment, JSX } from "./";
 
 /**
  * Create a React element.

--- a/types/react/v17/jsx-dev-runtime.d.ts
+++ b/types/react/v17/jsx-dev-runtime.d.ts
@@ -1,17 +1,6 @@
 // Expose `JSX` namespace in `global` namespace
 import * as React from "./";
-export { Fragment } from "./";
-
-export namespace JSX {
-    interface Element extends React.JSX.Element {}
-    interface ElementClass extends React.JSX.ElementClass {}
-    interface ElementAttributesProperty extends React.JSX.ElementAttributesProperty {}
-    interface ElementChildrenAttribute extends React.JSX.ElementChildrenAttribute {}
-    type LibraryManagedAttributes<C, P> = React.JSX.LibraryManagedAttributes<C, P>;
-    interface IntrinsicAttributes extends React.JSX.IntrinsicAttributes {}
-    interface IntrinsicClassAttributes<T> extends React.JSX.IntrinsicClassAttributes<T> {}
-    interface IntrinsicElements extends React.JSX.IntrinsicElements {}
-}
+export { Fragment, JSX } from "./";
 
 export interface JSXSource {
     /**

--- a/types/react/v17/jsx-runtime.d.ts
+++ b/types/react/v17/jsx-runtime.d.ts
@@ -1,17 +1,6 @@
 // Expose `JSX` namespace in `global` namespace
 import * as React from "./";
-export { Fragment } from "./";
-
-export namespace JSX {
-    interface Element extends React.JSX.Element {}
-    interface ElementClass extends React.JSX.ElementClass {}
-    interface ElementAttributesProperty extends React.JSX.ElementAttributesProperty {}
-    interface ElementChildrenAttribute extends React.JSX.ElementChildrenAttribute {}
-    type LibraryManagedAttributes<C, P> = React.JSX.LibraryManagedAttributes<C, P>;
-    interface IntrinsicAttributes extends React.JSX.IntrinsicAttributes {}
-    interface IntrinsicClassAttributes<T> extends React.JSX.IntrinsicClassAttributes<T> {}
-    interface IntrinsicElements extends React.JSX.IntrinsicElements {}
-}
+export { Fragment, JSX } from "./";
 
 /**
  * Create a React element.

--- a/types/react/v18/index.d.ts
+++ b/types/react/v18/index.d.ts
@@ -4284,7 +4284,6 @@ declare namespace React {
         digest?: string | null;
     }
 
-    // Keep in sync with JSX namespace in ./jsx-runtime.d.ts and ./jsx-dev-runtime.d.ts
     namespace JSX {
         type ElementType = GlobalJSXElementType;
         interface Element extends GlobalJSXElement {}

--- a/types/react/v18/jsx-dev-runtime.d.ts
+++ b/types/react/v18/jsx-dev-runtime.d.ts
@@ -1,17 +1,5 @@
 import * as React from "./";
-export { Fragment } from "./";
-
-export namespace JSX {
-    type ElementType = React.JSX.ElementType;
-    interface Element extends React.JSX.Element {}
-    interface ElementClass extends React.JSX.ElementClass {}
-    interface ElementAttributesProperty extends React.JSX.ElementAttributesProperty {}
-    interface ElementChildrenAttribute extends React.JSX.ElementChildrenAttribute {}
-    type LibraryManagedAttributes<C, P> = React.JSX.LibraryManagedAttributes<C, P>;
-    interface IntrinsicAttributes extends React.JSX.IntrinsicAttributes {}
-    interface IntrinsicClassAttributes<T> extends React.JSX.IntrinsicClassAttributes<T> {}
-    interface IntrinsicElements extends React.JSX.IntrinsicElements {}
-}
+export { Fragment, JSX } from "./";
 
 export interface JSXSource {
     /**

--- a/types/react/v18/jsx-runtime.d.ts
+++ b/types/react/v18/jsx-runtime.d.ts
@@ -1,17 +1,5 @@
 import * as React from "./";
-export { Fragment } from "./";
-
-export namespace JSX {
-    type ElementType = React.JSX.ElementType;
-    interface Element extends React.JSX.Element {}
-    interface ElementClass extends React.JSX.ElementClass {}
-    interface ElementAttributesProperty extends React.JSX.ElementAttributesProperty {}
-    interface ElementChildrenAttribute extends React.JSX.ElementChildrenAttribute {}
-    type LibraryManagedAttributes<C, P> = React.JSX.LibraryManagedAttributes<C, P>;
-    interface IntrinsicAttributes extends React.JSX.IntrinsicAttributes {}
-    interface IntrinsicClassAttributes<T> extends React.JSX.IntrinsicClassAttributes<T> {}
-    interface IntrinsicElements extends React.JSX.IntrinsicElements {}
-}
+export { Fragment, JSX } from "./";
 
 /**
  * Create a React element.

--- a/types/react/v18/ts5.0/index.d.ts
+++ b/types/react/v18/ts5.0/index.d.ts
@@ -4284,7 +4284,6 @@ declare namespace React {
         digest?: string | null;
     }
 
-    // Keep in sync with JSX namespace in ./jsx-runtime.d.ts and ./jsx-dev-runtime.d.ts
     namespace JSX {
         interface Element extends GlobalJSXElement {}
         interface ElementClass extends GlobalJSXElementClass {}

--- a/types/react/v18/ts5.0/jsx-dev-runtime.d.ts
+++ b/types/react/v18/ts5.0/jsx-dev-runtime.d.ts
@@ -1,16 +1,5 @@
 import * as React from "./";
-export { Fragment } from "./";
-
-export namespace JSX {
-    interface Element extends React.JSX.Element {}
-    interface ElementClass extends React.JSX.ElementClass {}
-    interface ElementAttributesProperty extends React.JSX.ElementAttributesProperty {}
-    interface ElementChildrenAttribute extends React.JSX.ElementChildrenAttribute {}
-    type LibraryManagedAttributes<C, P> = React.JSX.LibraryManagedAttributes<C, P>;
-    interface IntrinsicAttributes extends React.JSX.IntrinsicAttributes {}
-    interface IntrinsicClassAttributes<T> extends React.JSX.IntrinsicClassAttributes<T> {}
-    interface IntrinsicElements extends React.JSX.IntrinsicElements {}
-}
+export { Fragment, JSX } from "./";
 
 export interface JSXSource {
     /**

--- a/types/react/v18/ts5.0/jsx-runtime.d.ts
+++ b/types/react/v18/ts5.0/jsx-runtime.d.ts
@@ -1,16 +1,5 @@
 import * as React from "./";
-export { Fragment } from "./";
-
-export namespace JSX {
-    interface Element extends React.JSX.Element {}
-    interface ElementClass extends React.JSX.ElementClass {}
-    interface ElementAttributesProperty extends React.JSX.ElementAttributesProperty {}
-    interface ElementChildrenAttribute extends React.JSX.ElementChildrenAttribute {}
-    type LibraryManagedAttributes<C, P> = React.JSX.LibraryManagedAttributes<C, P>;
-    interface IntrinsicAttributes extends React.JSX.IntrinsicAttributes {}
-    interface IntrinsicClassAttributes<T> extends React.JSX.IntrinsicClassAttributes<T> {}
-    interface IntrinsicElements extends React.JSX.IntrinsicElements {}
-}
+export { Fragment, JSX } from "./";
 
 /**
  * Create a React element.


### PR DESCRIPTION
Currently, the React JSX namespace is duplicated between the `react`, `react/jsx-runtime`, and `react/jsx-dev-runtime` modules. Besides the duplication, this also means the JSX namespaces are equivalent, but not the same. This means that the type of the following variable:

```tsx
const element = <div />
```

gets inferred to either `import("react").JSX.Element`, `import("react/jsx-runtime").JSX.Element`, or `import("react/jsx-dev-runtime").JSX.Element`, depending on the compiler options used.

By re-exporting the JSX namespace from `index` in `jsx-runtime` and `jsx-dev-runtime`, their JSX namespaces become aliases. These aliases get resolved in editor navigation and type emitting. So TypeScript will always resolve the type to `import("react").JSX.Element`.

This change also means the namespaces no longer need to be duplicated.

Also, because the members of the JSX namespace now point towards the same types instead of an equal duplicate, this may improve type checking performance.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

