### PR TITLE
[pg] Add PoolConfig verify option

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -55,6 +55,7 @@ export interface PoolConfig extends ClientConfig {
     maxLifetimeSeconds?: number | undefined;
     Client?: (new() => ClientBase) | undefined;
     onConnect?: ((client: ClientBase) => void) | undefined;
+    verify?: ((client: PoolClient, done: (err?: Error) => void) => void) | undefined;
 }
 
 export interface QueryConfig<I = any[]> {

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -445,3 +445,19 @@ const poolWithOnConnect = new Pool({
 poolWithOnConnect.connect().then(client => {
     console.log("client connected");
 });
+
+const poolWithVerify = new Pool({
+    verify: (client, done) => {
+        const poolClient: pg.PoolClient = client;
+        poolClient.query("SELECT 1");
+        if (Math.random() > 0.5) {
+            done(new Error("verification failed"));
+        } else {
+            done();
+        }
+    },
+});
+
+poolWithVerify.connect().then(client => {
+    console.log("client connected");
+});


### PR DESCRIPTION
Fixes #74971

Adds the missing `PoolConfig.verify` option from pg-pool and covers the callback type in tests.

Validation:
- `corepack pnpm test pg`
- `corepack pnpm exec dprint check types/pg/index.d.ts types/pg/pg-tests.ts`
- `git diff --check`