### PR TITLE
Yauzl: add missing 3.x API exports

### DIFF
--- a/types/yauzl/index.d.ts
+++ b/types/yauzl/index.d.ts
@@ -18,9 +18,12 @@ export class Entry {
     externalFileAttributes: number;
     extraFieldLength: number;
     extraFields: Array<{ id: number; data: Buffer }>;
+    extraFieldRaw: Buffer;
     fileCommentLength: number;
     fileName: string;
     fileNameLength: number;
+    fileNameRaw: Buffer;
+    fileCommentRaw: Buffer;
     generalPurposeBitFlag: number;
     internalFileAttributes: number;
     lastModFileDate: number;
@@ -30,9 +33,25 @@ export class Entry {
     versionMadeBy: number;
     versionNeededToExtract: number;
 
-    getLastModDate(): Date;
+    getLastModDate(options?: { forceDosFormat?: boolean; timezone?: "local" | "UTC" }): Date;
     isEncrypted(): boolean;
     isCompressed(): boolean;
+}
+
+export class LocalFileHeader {
+    fileDataStart: number;
+    versionNeededToExtract: number;
+    generalPurposeBitFlag: number;
+    compressionMethod: number;
+    lastModFileTime: number;
+    lastModFileDate: number;
+    crc32: number;
+    compressedSize: number;
+    uncompressedSize: number;
+    fileNameLength: number;
+    extraFieldLength: number;
+    fileName: Buffer;
+    extraField: Buffer;
 }
 
 export interface ZipFileOptions {
@@ -40,6 +59,10 @@ export interface ZipFileOptions {
     decrypt: boolean | null;
     start: number | null;
     end: number | null;
+}
+
+export interface ReadLocalFileHeaderOptions {
+    minimal?: boolean;
 }
 
 export class ZipFile extends EventEmitter {
@@ -73,6 +96,24 @@ export class ZipFile extends EventEmitter {
         callback: (err: Error | null, stream: Readable) => void,
     ): void;
     openReadStream(entry: Entry, callback: (err: Error | null, stream: Readable) => void): void;
+    openReadStreamLowLevel(
+        fileDataStart: number,
+        compressedSize: number,
+        relativeStart: number,
+        relativeEnd: number,
+        decompress: boolean,
+        uncompressedSize: number,
+        callback: (err: Error | null, stream: Readable) => void,
+    ): void;
+    readLocalFileHeader(
+        entry: Entry,
+        options: ReadLocalFileHeaderOptions,
+        callback: (err: Error | null, localFileHeader: LocalFileHeader) => void,
+    ): void;
+    readLocalFileHeader(
+        entry: Entry,
+        callback: (err: Error | null, localFileHeader: LocalFileHeader) => void,
+    ): void;
     close(): void;
     readEntry(): void;
 }
@@ -108,3 +149,10 @@ export function fromRandomAccessReader(
 ): void;
 export function dosDateTimeToDate(date: number, time: number): Date;
 export function validateFileName(fileName: string): string | null;
+export function getFileNameLowLevel(
+    generalPurposeBitFlag: number,
+    fileNameBuffer: Buffer,
+    extraFields: Array<{ id: number; data: Buffer }>,
+    strictFileNames: boolean,
+): string;
+export function parseExtraFields(extraFieldBuffer: Buffer): Array<{ id: number; data: Buffer }>;

--- a/types/yauzl/yauzl-tests.ts
+++ b/types/yauzl/yauzl-tests.ts
@@ -28,3 +28,68 @@ yauzl.open("path/to/file.zip", { lazyEntries: true }, (err, zipfile) => {
 });
 
 yauzl.open("options.zip", { strictFileNames: true }, () => {});
+
+// decodeStrings: false returns raw Buffers on Entry
+yauzl.open("raw.zip", { lazyEntries: true, decodeStrings: false }, (err, zipfile) => {
+    if (err) throw err;
+    if (zipfile) {
+        zipfile.on("entry", (entry: yauzl.Entry) => {
+            const rawName: Buffer = entry.fileNameRaw;
+            const rawComment: Buffer = entry.fileCommentRaw;
+            const rawExtra: Buffer = entry.extraFieldRaw;
+
+            const decoded: string = yauzl.getFileNameLowLevel(
+                entry.generalPurposeBitFlag,
+                rawName,
+                entry.extraFields,
+                false,
+            );
+
+            const validationError: string | null = yauzl.validateFileName(decoded);
+
+            zipfile.readEntry();
+        });
+    }
+});
+
+// parseExtraFields
+yauzl.open("extra.zip", { lazyEntries: true }, (err, zipfile) => {
+    if (err) throw err;
+    if (zipfile) {
+        zipfile.on("entry", (entry: yauzl.Entry) => {
+            const extraFields: Array<{ id: number; data: Buffer }> = yauzl.parseExtraFields(entry.extraFieldRaw);
+        });
+    }
+});
+
+// readLocalFileHeader
+yauzl.open("local.zip", { lazyEntries: true }, (err, zipfile) => {
+    if (err) throw err;
+    if (zipfile) {
+        zipfile.on("entry", (entry: yauzl.Entry) => {
+            zipfile.readLocalFileHeader(entry, (err, localFileHeader) => {
+                if (err) throw err;
+                const start: number = localFileHeader.fileDataStart;
+                const name: Buffer = localFileHeader.fileName;
+                const extra: Buffer = localFileHeader.extraField;
+            });
+
+            zipfile.readLocalFileHeader(entry, { minimal: true }, (err, localFileHeader) => {
+                if (err) throw err;
+                const start: number = localFileHeader.fileDataStart;
+            });
+        });
+    }
+});
+
+// getLastModDate options
+yauzl.open("dates.zip", { lazyEntries: true }, (err, zipfile) => {
+    if (err) throw err;
+    if (zipfile) {
+        zipfile.on("entry", (entry: yauzl.Entry) => {
+            const date1: Date = entry.getLastModDate();
+            const date2: Date = entry.getLastModDate({ timezone: "UTC" });
+            const date3: Date = entry.getLastModDate({ forceDosFormat: true });
+        });
+    }
+});


### PR DESCRIPTION
- Add type definitions for getFileNameLowLevel, parseExtraFields, LocalFileHeader, readLocalFileHeader, and openReadStreamLowLevel
- Add raw Buffer properties (fileNameRaw, fileCommentRaw, extraFieldRaw) to Entry
- Update getLastModDate to accept options parameter
- Update tests

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Source](https://github.com/thejoshwolfe/yauzl#getfilenamelowlevelgeneralpurposebitflag-filenamebuffer-extrafields-strictfilenames)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
