### PR TITLE
Add resourceType to Resource, fix SimpleQuantity/MoneyQuantity

### DIFF
--- a/types/fhir/index.d.ts
+++ b/types/fhir/index.d.ts
@@ -1,5 +1,6 @@
 // Type definitions for non-npm package FHIR
 // Project: http://hl7.org/fhir/index.html
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 //
 // Generated with https://github.com/reason-healthcare/fhir-types-workspace/tree/main/packages/fhir-ts-codegen
 /// <reference path="r2.d.ts" />

--- a/types/fhir/r2.d.ts
+++ b/types/fhir/r2.d.ts
@@ -13190,6 +13190,8 @@ export interface ImmunizationRecommendationRecommendation extends BackboneElemen
  * Base StructureDefinition for Resource Resource
  */
 export interface Resource {
+  /** Resource Type Name (for serialization) */
+  readonly resourceType: string;
   /**
    * Logical id of this artifact
    * The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.

--- a/types/fhir/r3.d.ts
+++ b/types/fhir/r3.d.ts
@@ -14778,6 +14778,12 @@ export interface MedicationPackage extends BackboneElement {
 }
 
 /**
+ * A fixed quantity (no comparator)
+ */
+export interface SimpleQuantity extends Quantity {
+}
+
+/**
  * Base StructureDefinition for DiagnosticReport Resource
  */
 export interface DiagnosticReport extends DomainResource {
@@ -20780,6 +20786,8 @@ export interface ImmunizationRecommendationRecommendation extends BackboneElemen
  * Base StructureDefinition for Resource Resource
  */
 export interface Resource {
+  /** Resource Type Name (for serialization) */
+  readonly resourceType: string;
   /**
    * Logical id of this artifact
    * The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.

--- a/types/fhir/r4.d.ts
+++ b/types/fhir/r4.d.ts
@@ -18657,6 +18657,12 @@ export interface MedicationBatch extends BackboneElement {
 }
 
 /**
+ * A fixed quantity (no comparator)
+ */
+export interface SimpleQuantity extends Quantity {
+}
+
+/**
  * The findings and interpretation of diagnostic  tests performed on patients, groups of patients, devices, and locations, and/or specimens derived from these. The report includes clinical context such as requesting and provider information, and some mix of atomic results, images, textual and coded interpretations, and formatted representation of diagnostic reports.
  */
 export interface DiagnosticReport extends DomainResource {
@@ -28032,6 +28038,8 @@ export interface ImmunizationRecommendationRecommendation extends BackboneElemen
  * This is the base resource type for everything.
  */
 export interface Resource {
+  /** Resource Type Name (for serialization) */
+  readonly resourceType: string;
   /**
    * Logical id of this artifact
    * The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.
@@ -33332,6 +33340,12 @@ export interface MedicinalProductContraindicationOtherTherapy extends BackboneEl
   medicationCodeableConcept?: CodeableConcept | undefined;
   /** Reference to a specific medication (active substance, medicinal product or class of products) as part of an indication or contraindication */
   medicationReference?: Reference | undefined;
+}
+
+/**
+ * An amount of money. With regard to precision, see [Decimal Precision](datatypes.html#precision)
+ */
+export interface MoneyQuantity extends Quantity {
 }
 
 /**

--- a/types/fhir/r4b.d.ts
+++ b/types/fhir/r4b.d.ts
@@ -19431,6 +19431,12 @@ export interface MedicationBatch extends BackboneElement {
 }
 
 /**
+ * A fixed quantity (no comparator)
+ */
+export interface SimpleQuantity extends Quantity {
+}
+
+/**
  * The findings and interpretation of diagnostic  tests performed on patients, groups of patients, devices, and locations, and/or specimens derived from these. The report includes clinical context such as requesting and provider information, and some mix of atomic results, images, textual and coded interpretations, and formatted representation of diagnostic reports.
  */
 export interface DiagnosticReport extends DomainResource {
@@ -28408,6 +28414,8 @@ export interface ImmunizationRecommendationRecommendation extends BackboneElemen
  * This is the base resource type for everything.
  */
 export interface Resource {
+  /** Resource Type Name (for serialization) */
+  readonly resourceType: string;
   /**
    * Logical id of this artifact
    * The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.
@@ -34411,6 +34419,12 @@ export interface Quantity extends Element {
    */
   code?: string | undefined;
   _code?: Element | undefined;
+}
+
+/**
+ * An amount of money. With regard to precision, see [Decimal Precision](datatypes.html#precision)
+ */
+export interface MoneyQuantity extends Quantity {
 }
 
 /**

--- a/types/fhir/r5.d.ts
+++ b/types/fhir/r5.d.ts
@@ -23451,6 +23451,12 @@ export interface MedicationBatch extends BackboneElement {
 }
 
 /**
+ * A fixed quantity (no comparator)
+ */
+export interface SimpleQuantity extends Quantity {
+}
+
+/**
  * The findings and interpretation of diagnostic tests performed on patients, groups of patients, products, substances, devices, and locations, and/or specimens derived from these. The report includes clinical context such as requesting provider information, and some mix of atomic results, images, textual and coded interpretations, and formatted representation of diagnostic reports. The report also includes non-clinical context such as batch analysis and stability reporting of products and substances.
  */
 export interface DiagnosticReport extends DomainResource {
@@ -34968,6 +34974,8 @@ export interface ImmunizationRecommendationRecommendation extends BackboneElemen
  * This is the base resource type for everything.
  */
 export interface Resource extends Base {
+  /** Resource Type Name (for serialization) */
+  readonly resourceType: string;
   /**
    * Logical id of this artifact
    * The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.
@@ -42998,6 +43006,12 @@ export interface Quantity extends DataType {
    */
   code?: string | undefined;
   _code?: Element | undefined;
+}
+
+/**
+ * An amount of money. With regard to precision, see [Decimal Precision](datatypes.html#precision)
+ */
+export interface MoneyQuantity extends Quantity {
 }
 
 /**

--- a/types/fhir/test/r2-tests.ts
+++ b/types/fhir/test/r2-tests.ts
@@ -265,3 +265,54 @@ const r2Test5710: fhir2.ValueSet = {"resourceType":"ValueSet","id":"account-stat
 // VisionPrescription-33123.json
 const r2Test6726: fhir2.VisionPrescription = {"dateWritten":"2014-06-15","dispense":[{"add":2,"base":"down","eye":"right","prism":0.5,"product":{"code":"lens","system":"http://hl7.org/fhir/ex-visionprescriptionproduct"},"sphere":-2},{"add":2,"axis":180,"base":"up","cylinder":-0.5,"eye":"left","prism":0.5,"product":{"code":"lens","system":"http://hl7.org/fhir/ex-visionprescriptionproduct"},"sphere":-1}],"id":"33123","identifier":[{"system":"http://www.happysight.com/prescription","value":"15013"}],"patient":{"reference":"Patient/example"},"prescriber":{"reference":"Practitioner/example"},"resourceType":"VisionPrescription","text":{"div":"<div>\n\t  <p>OD -2.00 SPH         +2.00 add    0.5 p.d. BD</p>\n      <p>OS -1.00 -0.50 x 180 +2.00 add    0.5 p.d. BU</p>\n    </div>","status":"generated"}};
 
+
+// Regression tests for https://github.com/DefinitelyTyped/DefinitelyTyped/issues/71984
+// FhirResource must not circularly reference itself (TS2456).
+// The root cause was that DomainResource.contained (and similar fields) were typed as
+// FhirResource[] instead of Resource[], creating a cycle through every resource type.
+
+// 1. FhirResource is assignable from any concrete resource type
+const r2FhirResourcePatient: fhir2.FhirResource = { resourceType: "Patient", id: "pt-1" };
+const r2FhirResourceObservation: fhir2.FhirResource = { resourceType: "Observation", id: "obs-1", status: "final", code: { text: "test" } };
+
+// 2. FhirResource discriminated union narrows correctly via resourceType
+function processR2FhirResource(resource: fhir2.FhirResource): string {
+  if (resource.resourceType === "Patient") {
+    const patient: fhir2.Patient = resource;
+    return patient.resourceType;
+  }
+  if (resource.resourceType === "Observation") {
+    const obs: fhir2.Observation = resource;
+    return obs.resourceType;
+  }
+  return resource.resourceType;
+}
+processR2FhirResource(r2FhirResourcePatient);
+processR2FhirResource(r2FhirResourceObservation);
+
+// 3. DomainResource.contained uses Resource[] (not FhirResource[]) — no circularity
+const r2InlineObs: fhir2.Observation = { resourceType: "Observation", id: "inline-obs", status: "final", code: { text: "test" } };
+const r2PatientWithContained: fhir2.Patient = {
+  resourceType: "Patient",
+  id: "pt-contained",
+  contained: [r2InlineObs],
+};
+
+// 4. ParametersParameter.resource uses Resource (not FhirResource) — no circularity
+const r2InlinePatient: fhir2.Patient = { resourceType: "Patient", id: "pt-1" };
+const r2Params: fhir2.Parameters = {
+  resourceType: "Parameters",
+  parameter: [{ name: "subject", resource: r2InlinePatient }],
+};
+
+// 5. Resource.resourceType is accessible on base-typed fields
+//    Regression for https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/75015
+//    BundleEntry.resource is typed as Resource — resourceType must be reachable.
+const r2Bundle: fhir2.Bundle = {
+  resourceType: "Bundle",
+  type: "collection",
+  entry: [{ resource: r2InlinePatient }],
+};
+const r2HasPatient = r2Bundle.entry?.some(
+  (e) => e.resource?.resourceType === "Patient",
+);

--- a/types/fhir/test/r3-tests.ts
+++ b/types/fhir/test/r3-tests.ts
@@ -337,3 +337,54 @@ const r3Test7131: fhir3.ValueSet = {"resourceType":"ValueSet","id":"abstract-typ
 // VisionPrescription-33123.json
 const r3Test8285: fhir3.VisionPrescription = {"resourceType":"VisionPrescription","id":"33123","text":{"status":"generated","div":"<div xmlns=\"http://www.w3.org/1999/xhtml\">\n\t  <p>OD -2.00 SPH         +2.00 add    0.5 p.d. BD</p>\n      <p>OS -1.00 -0.50 x 180 +2.00 add    0.5 p.d. BU</p>\n    </div>"},"identifier":[{"system":"http://www.happysight.com/prescription","value":"15013"}],"status":"active","patient":{"reference":"Patient/example"},"dateWritten":"2014-06-15","prescriber":{"reference":"Practitioner/example"},"dispense":[{"product":{"coding":[{"system":"http://hl7.org/fhir/ex-visionprescriptionproduct","code":"lens"}]},"eye":"right","sphere":-2,"prism":0.5,"base":"down","add":2},{"product":{"coding":[{"system":"http://hl7.org/fhir/ex-visionprescriptionproduct","code":"lens"}]},"eye":"left","sphere":-1,"cylinder":-0.5,"axis":180,"prism":0.5,"base":"up","add":2}]};
 
+
+// Regression tests for https://github.com/DefinitelyTyped/DefinitelyTyped/issues/71984
+// FhirResource must not circularly reference itself (TS2456).
+// The root cause was that DomainResource.contained (and similar fields) were typed as
+// FhirResource[] instead of Resource[], creating a cycle through every resource type.
+
+// 1. FhirResource is assignable from any concrete resource type
+const r3FhirResourcePatient: fhir3.FhirResource = { resourceType: "Patient", id: "pt-1" };
+const r3FhirResourceObservation: fhir3.FhirResource = { resourceType: "Observation", id: "obs-1", status: "final", code: { text: "test" } };
+
+// 2. FhirResource discriminated union narrows correctly via resourceType
+function processR3FhirResource(resource: fhir3.FhirResource): string {
+  if (resource.resourceType === "Patient") {
+    const patient: fhir3.Patient = resource;
+    return patient.resourceType;
+  }
+  if (resource.resourceType === "Observation") {
+    const obs: fhir3.Observation = resource;
+    return obs.resourceType;
+  }
+  return resource.resourceType;
+}
+processR3FhirResource(r3FhirResourcePatient);
+processR3FhirResource(r3FhirResourceObservation);
+
+// 3. DomainResource.contained uses Resource[] (not FhirResource[]) — no circularity
+const r3InlineObs: fhir3.Observation = { resourceType: "Observation", id: "inline-obs", status: "final", code: { text: "test" } };
+const r3PatientWithContained: fhir3.Patient = {
+  resourceType: "Patient",
+  id: "pt-contained",
+  contained: [r3InlineObs],
+};
+
+// 4. ParametersParameter.resource uses Resource (not FhirResource) — no circularity
+const r3InlinePatient: fhir3.Patient = { resourceType: "Patient", id: "pt-1" };
+const r3Params: fhir3.Parameters = {
+  resourceType: "Parameters",
+  parameter: [{ name: "subject", resource: r3InlinePatient }],
+};
+
+// 5. Resource.resourceType is accessible on base-typed fields
+//    Regression for https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/75015
+//    BundleEntry.resource is typed as Resource — resourceType must be reachable.
+const r3Bundle: fhir3.Bundle = {
+  resourceType: "Bundle",
+  type: "collection",
+  entry: [{ resource: r3InlinePatient }],
+};
+const r3HasPatient = r3Bundle.entry?.some(
+  (e) => e.resource?.resourceType === "Patient",
+);

--- a/types/fhir/test/r4-tests.ts
+++ b/types/fhir/test/r4-tests.ts
@@ -409,3 +409,54 @@ const r4Test5306: fhir4.VerificationResult = {"resourceType":"VerificationResult
 // VisionPrescription-33123.json
 const r4Test5307: fhir4.VisionPrescription = {"resourceType":"VisionPrescription","id":"33123","text":{"status":"generated","div":"<div xmlns=\"http://www.w3.org/1999/xhtml\">\n\t\t\t<p>OD -2.00 SPH         +2.00 add    0.5 p.d. BD</p>\n\t\t\t<p>OS -1.00 -0.50 x 180 +2.00 add    0.5 p.d. BU</p>\n\t\t</div>"},"identifier":[{"system":"http://www.happysight.com/prescription","value":"15013"}],"status":"active","created":"2014-06-15","patient":{"reference":"Patient/example"},"dateWritten":"2014-06-15","prescriber":{"reference":"Practitioner/example"},"lensSpecification":[{"product":{"coding":[{"system":"http://terminology.hl7.org/CodeSystem/ex-visionprescriptionproduct","code":"lens"}]},"eye":"right","sphere":-2,"prism":[{"amount":0.5,"base":"down"}],"add":2},{"product":{"coding":[{"system":"http://terminology.hl7.org/CodeSystem/ex-visionprescriptionproduct","code":"lens"}]},"eye":"left","sphere":-1,"cylinder":-0.5,"axis":180,"prism":[{"amount":0.5,"base":"up"}],"add":2}]};
 
+
+// Regression tests for https://github.com/DefinitelyTyped/DefinitelyTyped/issues/71984
+// FhirResource must not circularly reference itself (TS2456).
+// The root cause was that DomainResource.contained (and similar fields) were typed as
+// FhirResource[] instead of Resource[], creating a cycle through every resource type.
+
+// 1. FhirResource is assignable from any concrete resource type
+const r4FhirResourcePatient: fhir4.FhirResource = { resourceType: "Patient", id: "pt-1" };
+const r4FhirResourceObservation: fhir4.FhirResource = { resourceType: "Observation", id: "obs-1", status: "final", code: { text: "test" } };
+
+// 2. FhirResource discriminated union narrows correctly via resourceType
+function processR4FhirResource(resource: fhir4.FhirResource): string {
+  if (resource.resourceType === "Patient") {
+    const patient: fhir4.Patient = resource;
+    return patient.resourceType;
+  }
+  if (resource.resourceType === "Observation") {
+    const obs: fhir4.Observation = resource;
+    return obs.resourceType;
+  }
+  return resource.resourceType;
+}
+processR4FhirResource(r4FhirResourcePatient);
+processR4FhirResource(r4FhirResourceObservation);
+
+// 3. DomainResource.contained uses Resource[] (not FhirResource[]) — no circularity
+const r4InlineObs: fhir4.Observation = { resourceType: "Observation", id: "inline-obs", status: "final", code: { text: "test" } };
+const r4PatientWithContained: fhir4.Patient = {
+  resourceType: "Patient",
+  id: "pt-contained",
+  contained: [r4InlineObs],
+};
+
+// 4. ParametersParameter.resource uses Resource (not FhirResource) — no circularity
+const r4InlinePatient: fhir4.Patient = { resourceType: "Patient", id: "pt-1" };
+const r4Params: fhir4.Parameters = {
+  resourceType: "Parameters",
+  parameter: [{ name: "subject", resource: r4InlinePatient }],
+};
+
+// 5. Resource.resourceType is accessible on base-typed fields
+//    Regression for https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/75015
+//    BundleEntry.resource is typed as Resource — resourceType must be reachable.
+const r4Bundle: fhir4.Bundle = {
+  resourceType: "Bundle",
+  type: "collection",
+  entry: [{ resource: r4InlinePatient }],
+};
+const r4HasPatient = r4Bundle.entry?.some(
+  (e) => e.resource?.resourceType === "Patient",
+);

--- a/types/fhir/test/r5-tests.ts
+++ b/types/fhir/test/r5-tests.ts
@@ -448,3 +448,54 @@ const r5Test2820: fhir5.VerificationResult = {"resourceType":"VerificationResult
 // VisionPrescription-33123.json
 const r5Test2821: fhir5.VisionPrescription = {"resourceType":"VisionPrescription","id":"33123","text":{"status":"generated","div":"<div xmlns=\"http://www.w3.org/1999/xhtml\">\n\t\t\t<p>OD -2.00 SPH         +2.00 add    0.5 p.d. BD</p>\n\t\t\t<p>OS -1.00 -0.50 x 180 +2.00 add    0.5 p.d. BU</p>\n\t\t</div>"},"identifier":[{"system":"http://www.happysight.com/prescription","value":"15013"}],"status":"active","created":"2014-06-15","patient":{"reference":"Patient/example"},"dateWritten":"2014-06-15","prescriber":{"reference":"Practitioner/example"},"lensSpecification":[{"product":{"coding":[{"system":"http://terminology.hl7.org/CodeSystem/ex-visionprescriptionproduct","code":"lens"}]},"eye":"right","sphere":-2,"prism":[{"amount":0.5,"base":"down"}],"add":2},{"product":{"coding":[{"system":"http://terminology.hl7.org/CodeSystem/ex-visionprescriptionproduct","code":"lens"}]},"eye":"left","sphere":-1,"cylinder":-0.5,"axis":180,"prism":[{"amount":0.5,"base":"up"}],"add":2}],"meta":{"tag":[{"system":"http://terminology.hl7.org/CodeSystem/v3-ActReason","code":"HTEST","display":"test health data"}]}};
 
+
+// Regression tests for https://github.com/DefinitelyTyped/DefinitelyTyped/issues/71984
+// FhirResource must not circularly reference itself (TS2456).
+// The root cause was that DomainResource.contained (and similar fields) were typed as
+// FhirResource[] instead of Resource[], creating a cycle through every resource type.
+
+// 1. FhirResource is assignable from any concrete resource type
+const r5FhirResourcePatient: fhir5.FhirResource = { resourceType: "Patient", id: "pt-1" };
+const r5FhirResourceObservation: fhir5.FhirResource = { resourceType: "Observation", id: "obs-1", status: "final", code: { text: "test" } };
+
+// 2. FhirResource discriminated union narrows correctly via resourceType
+function processR5FhirResource(resource: fhir5.FhirResource): string {
+  if (resource.resourceType === "Patient") {
+    const patient: fhir5.Patient = resource;
+    return patient.resourceType;
+  }
+  if (resource.resourceType === "Observation") {
+    const obs: fhir5.Observation = resource;
+    return obs.resourceType;
+  }
+  return resource.resourceType;
+}
+processR5FhirResource(r5FhirResourcePatient);
+processR5FhirResource(r5FhirResourceObservation);
+
+// 3. DomainResource.contained uses Resource[] (not FhirResource[]) — no circularity
+const r5InlineObs: fhir5.Observation = { resourceType: "Observation", id: "inline-obs", status: "final", code: { text: "test" } };
+const r5PatientWithContained: fhir5.Patient = {
+  resourceType: "Patient",
+  id: "pt-contained",
+  contained: [r5InlineObs],
+};
+
+// 4. ParametersParameter.resource uses Resource (not FhirResource) — no circularity
+const r5InlinePatient: fhir5.Patient = { resourceType: "Patient", id: "pt-1" };
+const r5Params: fhir5.Parameters = {
+  resourceType: "Parameters",
+  parameter: [{ name: "subject", resource: r5InlinePatient }],
+};
+
+// 5. Resource.resourceType is accessible on base-typed fields
+//    Regression for https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/75015
+//    BundleEntry.resource is typed as Resource — resourceType must be reachable.
+const r5Bundle: fhir5.Bundle = {
+  resourceType: "Bundle",
+  type: "collection",
+  entry: [{ resource: r5InlinePatient }],
+};
+const r5HasPatient = r5Bundle.entry?.some(
+  (e) => e.resource?.resourceType === "Patient",
+);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

- Add `readonly resourceType: string` to the base `Resource` interface across all FHIR versions (R2–R5), fixing TS errors when accessing `resourceType` on fields typed as `Resource` (e.g. `BundleEntry.resource`). Closes https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/75015

- Add `SimpleQuantity extends Quantity` (R3–R5) and `MoneyQuantity extends Quantity` (R4, R4B, R5) — FHIR-defined constrained quantity profiles that were missing from the generated type definitions. Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/74830

- Add `// Definitions:` header to `index.d.ts` (cosmetic, aligns with DT convention).

- Add regression test cases to every version's test file covering:
  1. `FhirResource` assignability from concrete resource types
  2. Discriminated-union narrowing via `resourceType`
  3. `DomainResource.contained` typed as `Resource[]` (not `FhirResource[]`) — no TS2456 circularity (https://github.com/DefinitelyTyped/DefinitelyTyped/issues/71984)
  4. `ParametersParameter.resource` typed as `Resource` — no circularity
  5. `BundleEntry.resource?.resourceType` accessible on base `Resource` types

Generated from https://github.com/reason-healthcare/fhir-types-workspace/commit/3a80dddb and /commit/b6b61b66