### PR TITLE
feat(libnpmpublish): add support for stageId

### DIFF
--- a/types/libnpmpublish/index.d.ts
+++ b/types/libnpmpublish/index.d.ts
@@ -61,7 +61,7 @@ export interface PublishOptions extends fetch.Options {
 export function publish(
     manifest: PackageJson,
     tarballData: Buffer,
-    options: Omit<PublishOptions, "stage"> & { stage: true },
+    options: PublishOptions & { stage: true },
 ): Promise<Response & { stageId: string }>;
 export function publish(
     manifest: PackageJson,

--- a/types/libnpmpublish/index.d.ts
+++ b/types/libnpmpublish/index.d.ts
@@ -35,6 +35,11 @@ export interface PublishOptions extends fetch.Options {
      * @default ["sha512"]
      */
     algorithms?: string[];
+    /**
+     * If true, the package will be published to the registry in a staged state, meaning it will not be publicly visible
+     * until someone manually approves it.
+     */
+    stage?: boolean;
 }
 
 /**
@@ -53,7 +58,10 @@ export interface PublishOptions extends fetch.Options {
  * await libpub.publish(manifest, tarData, { npmVersion: 'my-pub-script@1.0.2', token: 'my-auth-token-here' }, opts)
  * // Package has been published to the npm registry.
  */
-export function publish(manifest: PackageJson, tarballData: Buffer, options?: PublishOptions): Promise<Response>;
+declare function publish(manifest: PackageJson, tarballData: Buffer, options: Omit<PublishOptions, "stage"> & {stage: true}): Promise<Response & { stageId: string }>;
+declare function publish(manifest: PackageJson, tarballData: Buffer, options?: PublishOptions): Promise<Response & { stageId?: string }>;
+
+export { publish };
 
 /**
  * Unpublishes spec from the appropriate registry. The registry in question may have its own limitations on unpublishing.

--- a/types/libnpmpublish/index.d.ts
+++ b/types/libnpmpublish/index.d.ts
@@ -58,8 +58,16 @@ export interface PublishOptions extends fetch.Options {
  * await libpub.publish(manifest, tarData, { npmVersion: 'my-pub-script@1.0.2', token: 'my-auth-token-here' }, opts)
  * // Package has been published to the npm registry.
  */
-declare function publish(manifest: PackageJson, tarballData: Buffer, options: Omit<PublishOptions, "stage"> & {stage: true}): Promise<Response & { stageId: string }>;
-declare function publish(manifest: PackageJson, tarballData: Buffer, options?: PublishOptions): Promise<Response & { stageId?: string }>;
+declare function publish(
+    manifest: PackageJson,
+    tarballData: Buffer,
+    options: Omit<PublishOptions, "stage"> & { stage: true },
+): Promise<Response & { stageId: string }>;
+declare function publish(
+    manifest: PackageJson,
+    tarballData: Buffer,
+    options?: PublishOptions,
+): Promise<Response & { stageId?: string }>;
 
 export { publish };
 

--- a/types/libnpmpublish/index.d.ts
+++ b/types/libnpmpublish/index.d.ts
@@ -58,18 +58,16 @@ export interface PublishOptions extends fetch.Options {
  * await libpub.publish(manifest, tarData, { npmVersion: 'my-pub-script@1.0.2', token: 'my-auth-token-here' }, opts)
  * // Package has been published to the npm registry.
  */
-declare function publish(
+export function publish(
     manifest: PackageJson,
     tarballData: Buffer,
     options: Omit<PublishOptions, "stage"> & { stage: true },
 ): Promise<Response & { stageId: string }>;
-declare function publish(
+export function publish(
     manifest: PackageJson,
     tarballData: Buffer,
     options?: PublishOptions,
 ): Promise<Response & { stageId?: string }>;
-
-export { publish };
 
 /**
  * Unpublishes spec from the appropriate registry. The registry in question may have its own limitations on unpublishing.

--- a/types/libnpmpublish/libnpmpublish-tests.ts
+++ b/types/libnpmpublish/libnpmpublish-tests.ts
@@ -31,8 +31,8 @@ async function test() {
     await libnpmpublish.publish();
     // @ts-expect-error
     await libnpmpublish.publish(manifest);
-    await libnpmpublish.publish(manifest, tarballData); // $ExpectType Response
-    await libnpmpublish.publish(manifest, tarballData, options); // $ExpectType Response
+    await libnpmpublish.publish(manifest, tarballData); // $ExpectType Response & { stageId?: string | undefined }
+    await libnpmpublish.publish(manifest, tarballData, options); // $ExpectType Response & { stageId?: string | undefined }
 
     const publishOptions = {
         ...options,
@@ -43,10 +43,23 @@ async function test() {
         npmVersion: "1.0.0",
         algorithms: ["sha512"],
     };
-    await libnpmpublish.publish(manifest, tarballData, publishOptions); // $ExpectType Response
+    await libnpmpublish.publish(manifest, tarballData, publishOptions); // $ExpectType Response & { stageId?: string | undefined }
 
     // @ts-expect-error
     await libnpmpublish.unpublish();
     await libnpmpublish.unpublish("npmpackage"); // $ExpectType boolean
     await libnpmpublish.unpublish("npmpackage", options); // $ExpectType boolean
+}
+
+async function stagingTest() {
+    const options = {
+        stage: true,
+    } as const;
+    const manifest: PackageJson = {
+        name: "",
+        version: "",
+    };
+    const tarballData: Buffer = Buffer.from("thisisafillerforthebuffertowork");
+
+    await libnpmpublish.publish(manifest, tarballData, options); // $ExpectType Response & { stageId: string }
 }

--- a/types/libnpmpublish/package.json
+++ b/types/libnpmpublish/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/libnpmpublish",
-    "version": "9.0.9999",
+    "version": "11.2.9999",
     "projects": [
         "https://npmjs.com/package/libnpmpublish"
     ],


### PR DESCRIPTION
Adds support for the new stageId and associated `stage` option.

When `stage: true`, we _always_ get a `stageId` back. Otherwise, we type it as
`stageId?: string` so it can at least still be accessed if we pass a
`stage: boolean` in for example.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/npm/cli/pull/9201
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
