### PR TITLE
Add default export support for concaveman@1

### DIFF
--- a/types/concaveman/index.d.ts
+++ b/types/concaveman/index.d.ts
@@ -14,6 +14,9 @@ declare module "concaveman" {
      * //=hull
      */
     function concaveman(points: number[][], concavity?: number, lengthThreshold?: number): number[][];
-    namespace concaveman {}
+    namespace concaveman {
+        const _default: typeof concaveman;
+        export { _default as default };
+    }
     export = concaveman;
 }


### PR DESCRIPTION
I'm trying to set `esModuleInterop: false` in TurfJS. One of our packages imports concaveman like so:

```
import concaveman from "concaveman";
```

This causes a typings error, but the [underlying JavaScript actually supports this](https://github.com/mapbox/concaveman/blob/f01d6e4b2c94e644a46e8113c6065aa0b4b79bc6/index.js#L13-L14).

This fixes the @types/concaveman@1 to better represent the actual code, but leaves concaveman@2 support for another day, as that version [fails arethetypeswrong](https://arethetypeswrong.github.io/?p=concaveman%402.0.0) in a way which probably should be fixed in the underlying package first.

I wanted to make types/concaveman/tsconfig.json more strict with `esModuleInterop: false`, but that was an error as that property will be dropped in typesceript@7. That means that the existing tests (that already passed) will have to do.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.~
