### PR TITLE
[hotwired__turbo] Add TurboHistory interface

### DIFF
--- a/types/hotwired__turbo/hotwired__turbo-tests.ts
+++ b/types/hotwired__turbo/hotwired__turbo-tests.ts
@@ -15,6 +15,7 @@ import {
     StreamActions,
     StreamMessage,
     StreamSource,
+    TurboHistory,
     Visit,
     visit,
     VisitOptions,
@@ -289,3 +290,29 @@ StreamMessage.contentType;
 
 // $ExpectType StreamMessage
 StreamMessage.wrap("<turbo-stream></turbo-stream>");
+
+// Test TurboHistory via session.history
+// $ExpectType TurboHistory
+session.history;
+// $ExpectType TurboHistory
+Turbo.session.history;
+
+session.history.push(new URL("https://example.com"));
+session.history.push(new URL("https://example.com"), "abc-123");
+session.history.replace(new URL("https://example.com"));
+session.history.replace(new URL("https://example.com"), "abc-123");
+
+// $ExpectType URL
+session.history.location;
+// $ExpectType string
+session.history.restorationIdentifier;
+
+// Test session getters
+// $ExpectType URL
+session.location;
+// $ExpectType string
+session.restorationIdentifier;
+// $ExpectType boolean
+session.started;
+// $ExpectType boolean
+session.enabled;

--- a/types/hotwired__turbo/index.d.ts
+++ b/types/hotwired__turbo/index.d.ts
@@ -277,12 +277,26 @@ export function disconnectStreamSource(source: StreamSource): void;
  */
 export function renderStreamMessage(message: StreamMessage | string): void;
 
+export interface TurboHistory {
+    readonly location: URL;
+    readonly restorationIdentifier: string;
+    push(location: URL, restorationIdentifier?: string): void;
+    replace(location: URL, restorationIdentifier?: string): void;
+}
+
 export interface TurboSession {
+    readonly history: TurboHistory;
+    adapter: Adapter;
+    readonly enabled: boolean;
+    readonly started: boolean;
+
     connectStreamSource(source: StreamSource): void;
     disconnectStreamSource(source: StreamSource): void;
     renderStreamMessage(message: StreamMessage | string): void;
+
     drive: boolean;
-    adapter: Adapter;
+    readonly location: URL;
+    readonly restorationIdentifier: string;
 }
 
 export const StreamActions: {


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
  - Adds a `TurboHistory` interface exposing `push()`, `replace()`, `location`, and `restorationIdentifier` — the navigation-facing subset of Turbo's [History class](https://github.com/hotwired/turbo/blob/main/src/core/drive/history.js).
  - Expands `TurboSession` with `history`, `enabled`, `started`, `location`, and `restorationIdentifier`, matching the [Session class](https://github.com/hotwired/turbo/blob/main/src/core/session.js) public surface. Member order follows the source.
  - Downstream usage: [opf/openproject#21816](https://github.com/opf/openproject/pull/21816) — eliminates a `TurboSessionWithHistory` workaround needed to call `session.history.push()`.