### PR TITLE
[pg] Add PoolConfig verify option

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -55,6 +55,7 @@ export interface PoolConfig extends ClientConfig {
     maxLifetimeSeconds?: number | undefined;
     Client?: (new() => ClientBase) | undefined;
     onConnect?: ((client: ClientBase) => void) | undefined;
+    verify?: ((client: PoolClient, done: (err?: Error) => void) => void) | undefined;
 }
 
 export interface QueryConfig<I = any[]> {

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -445,3 +445,13 @@ const poolWithOnConnect = new Pool({
 poolWithOnConnect.connect().then(client => {
     console.log("client connected");
 });
+
+const poolWithVerify = new Pool({
+    verify: (client, done) => {
+        client.query("SELECT 1").then(() => {
+            done();
+        }).catch(err => {
+            done(err);
+        });
+    },
+});


### PR DESCRIPTION
Fixes #74971.

pg-pool calls a `verify(client, done)` callback for every new client when the option is set on the pool (see `pg-pool/index.js`), but `PoolConfig` in the types didn't expose it, so it was a compile error to pass one in. Added as:

```ts
verify?: ((client: PoolClient, done: (err?: Error) => void) => void) | undefined;
```

Test added in `pg-tests.ts` — just makes sure the signature compiles and matches what pg-pool documents.
