### PR TITLE
[chrome-remote-interface] add once and emoveListener overloads

### DIFF
--- a/types/chrome-remote-interface/chrome-remote-interface-tests.ts
+++ b/types/chrome-remote-interface/chrome-remote-interface-tests.ts
@@ -14,6 +14,16 @@ function assertType<T>(value: T): T {
         client.on("event", (message) => {
             if (message.method === "Network.requestWillBeSent") {}
         });
+        // `once` / `removeListener` overloads mirror `on(...)`.
+        const onceDisconnectHandler = () => {};
+        client.once("disconnect", onceDisconnectHandler);
+        client.removeListener("disconnect", onceDisconnectHandler);
+        client.once("Network.requestWillBeSent", (params) => {
+            params.documentURL;
+        });
+        client.removeListener("event", (message) => {
+            if (message.method === "Network.requestWillBeSent") {}
+        });
 
         // Stable Domains
         {

--- a/types/chrome-remote-interface/index.d.ts
+++ b/types/chrome-remote-interface/index.d.ts
@@ -381,6 +381,22 @@ declare namespace CDP {
             ): void;
             // '<domain>.<method>.<sessionId>' i.e. Network.requestWillBeSent.abc123
             on(event: string, callback: (params: object, sessionId?: string) => void): void;
+            // `once` mirrors `on(...)` — auto-removes the listener after the first invocation.
+            once(event: "event", callback: (message: EventMessage) => void): void;
+            once(event: "ready" | "disconnect", callback: () => void): void;
+            once<T extends keyof ProtocolMappingApi.Events>(
+                event: T,
+                callback: (params: ProtocolMappingApi.Events[T][0], sessionId?: string) => void,
+            ): void;
+            once(event: string, callback: (params: object, sessionId?: string) => void): void;
+            // `removeListener` mirrors `on(...)` — detaches a previously registered listener.
+            removeListener(event: "event", callback: (message: EventMessage) => void): void;
+            removeListener(event: "ready" | "disconnect", callback: () => void): void;
+            removeListener<T extends keyof ProtocolMappingApi.Events>(
+                event: T,
+                callback: (params: ProtocolMappingApi.Events[T][0], sessionId?: string) => void,
+            ): void;
+            removeListener(event: string, callback: (params: object, sessionId?: string) => void): void;
             // client.send(method, [params], [sessionId], [callback])
             send<T extends keyof ProtocolMappingApi.Commands>(event: T, callback: SendCallback<T>): void;
             send<T extends keyof ProtocolMappingApi.Commands>(


### PR DESCRIPTION
<!-- Please fill in this template before submitting. -->

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/.github/CONTRIBUTING.md#common-mistakes).
- [x] Tracking issue (https://github.com/DefinitelyTyped/DefinitelyTyped/issues/__) — N/A, this is a missing-API addition.

## What this PR does

Adds `once` and `removeListener` overloads to `chrome-remote-interface`'s `Client` type, mirroring the existing four `on(...)` overloads.

## Why

The runtime `Client` returned by `await CDP(...)` extends Node's `EventEmitter`, so `once`, `removeListener`, `off`, `addListener`, etc. are all callable at runtime. The current declarations only expose `on(...)`, forcing consumers to cast through `unknown` to use the rest. Concrete real-world impact: a test runner using `client.once("Page.loadEventFired", handler)` + `client.removeListener(..., handler)` on the timeout branch (to avoid `MaxListenersExceededWarning` from accumulating one-shot listeners) cannot compile without a local cast.

## Relationship to #70178

That PR took a broader approach — adding `& EventEmitter` to the `Client` intersection — which clashed with the existing typed `on(...)` overloads (EventEmitter's own `on(eventName, listener)` competes with the four typed overloads). The PR's CI never passed and the bot auto-closed it after a month of inactivity.

This PR is intentionally narrower: it adds **only** `once` and `removeListener`, mirroring the four `on(...)` overloads one-for-one. Same signatures, same hot-path coverage, **no** EventEmitter intersection, so no conflict with the existing typed `on(...)` overloads.

If `off` / `addListener` / `removeAllListeners` are also desired, those would come in a follow-up PR with the same per-method pattern to keep CI green.

## Tests

The test file exercises the new overloads against the same `(disconnect, event, Network.requestWillBeSent)` event names already used for `on(...)`, so the overload resolution is verified end-to-end:

```ts
const onceDisconnectHandler = () => {};
client.once("disconnect", onceDisconnectHandler);
client.removeListener("disconnect", onceDisconnectHandler);
client.once("Network.requestWillBeSent", (params) => {
    params.documentURL;
});
client.removeListener("event", (message) => {
    if (message.method === "Network.requestWillBeSent") {}
});
```
