### PR TITLE
html-pdf-node: return promises from PDF generation APIs

### DIFF
--- a/types/html-pdf-node/html-pdf-node-tests.ts
+++ b/types/html-pdf-node/html-pdf-node-tests.ts
@@ -1,6 +1,6 @@
 import { generatePdf, generatePdfs } from "html-pdf-node/index";
 
-// $ExpectType void
+// $ExpectType Promise<Buffer> || Promise<Buffer<ArrayBufferLike>>
 generatePdf(
     {
         content: "<h1>Hello World!</h1>",
@@ -15,22 +15,50 @@ generatePdf(
     },
 );
 
-// $ExpectType void
+// $ExpectType Promise<Buffer> || Promise<Buffer<ArrayBufferLike>>
+generatePdf({
+    content: "<h1>Hello World!</h1>",
+});
+
+generatePdf({
+    content: "<h1>Hello World!</h1>",
+}).then(buffer => {
+    // $ExpectType Buffer || Buffer<ArrayBufferLike>
+    buffer;
+});
+
+// $ExpectType Promise<PdfOutput<{ content: string; name: string; }>[]>
 generatePdfs(
     [
         {
             content: "<h1>Hello World!</h1>",
+            name: "first.pdf",
         },
         {
             content: "<h1>Hello World!</h1>",
+            name: "second.pdf",
         },
     ],
     {
         format: "A4",
         printBackground: true,
     },
-    (err, buffer) => {
+    (err, output) => {
         // $ExpectType Buffer || Buffer<ArrayBufferLike>
-        buffer;
+        output[0].buffer;
+        // $ExpectType string
+        output[0].name;
     },
 );
+
+generatePdfs([
+    {
+        content: "<h1>Hello World!</h1>",
+        name: "first.pdf",
+    },
+]).then(output => {
+    // $ExpectType Buffer || Buffer<ArrayBufferLike>
+    output[0].buffer;
+    // $ExpectType string
+    output[0].name;
+});

--- a/types/html-pdf-node/index.d.ts
+++ b/types/html-pdf-node/index.d.ts
@@ -29,14 +29,16 @@ export interface Options {
     preferCSSPageSize?: boolean | undefined;
 }
 
+export type PdfOutput<T extends File = File> = Omit<T, "content"> & { buffer: Buffer };
+
 export function generatePdf(
     file: File,
     options?: Options,
     callback?: (err: Error, buffer: Buffer) => void,
-): void;
+): Promise<Buffer>;
 
-export function generatePdfs(
-    files: File[],
+export function generatePdfs<T extends File>(
+    files: T[],
     options?: Options,
-    callback?: (err: Error, buffer: Buffer) => void,
-): void;
+    callback?: (err: Error, output: Array<PdfOutput<T>>) => void,
+): Promise<Array<PdfOutput<T>>>;


### PR DESCRIPTION
Updates @types/html-pdf-node so generatePdf returns Promise<Buffer>, matching the async runtime implementation while keeping callback support. Also updates generatePdfs to return Promise<PdfOutput<T>[]> and preserve callback support for the array output shape documented by the package.

Runtime reference: https://github.com/mrafiqk/html-pdf-node/blob/master/index.js
README reference: https://github.com/mrafiqk/html-pdf-node/blob/master/README.md

Tested with pnpm test html-pdf-node.