### PR TITLE
(mdx): add missing subpath exports map for types lookup

### DIFF
--- a/types/mdx/package.json
+++ b/types/mdx/package.json
@@ -10,7 +10,8 @@
     "tsconfigs": ["tsconfig.preact.json", "tsconfig.react.json"],
     "exports": {
         ".": "./index.d.ts",
-        "./types": "./types.d.ts"
+        "./types": "./types.d.ts",
+        "./types.js": "./types.d.ts"
     },
     "devDependencies": {
         "@types/mdx": "workspace:.",

--- a/types/mdx/package.json
+++ b/types/mdx/package.json
@@ -8,6 +8,10 @@
         "https://github.com/mdx-js/mdx"
     ],
     "tsconfigs": ["tsconfig.preact.json", "tsconfig.react.json"],
+    "exports": {
+        ".": "./index.d.ts",
+        "./types": "./types.d.ts"
+    },
     "devDependencies": {
         "@types/mdx": "workspace:.",
         "@types/react": "^18",


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

## Summary
Added explicit subpath `"exports"` to `types/mdx/package.json`.

## Context
The package internally targets types from `"mdx/types"`. However, without an explicit subpath exports entry in `package.json`, environments compiling code using modern TypeScript configurations like `"moduleResolution": "bundler"` or `"moduleResolution": "nodenext"` fail to resolve the path if `skipLibCheck` is disabled, throwing a `Cannot find module 'mdx/types' or its corresponding type declarations` error. (I faced with it in in next-mdx-remote-client)

Adding the `exports` field matches the package lookup requirements and guarantees uniform type resolution across both modern and legacy TS compilation options.
