### PR TITLE
feat(bootstrap): define globals as part of each component

### DIFF
--- a/types/bootstrap/index.d.ts
+++ b/types/bootstrap/index.d.ts
@@ -13,41 +13,4 @@ import Tab from "./js/dist/tab";
 import Toast from "./js/dist/toast";
 import Tooltip from "./js/dist/tooltip";
 
-declare global {
-    interface JQuery {
-        alert: Alert.jQueryInterface;
-        button: Button.jQueryInterface;
-        carousel: Carousel.jQueryInterface;
-        collapse: Collapse.jQueryInterface;
-        dropdown: Dropdown.jQueryInterface;
-        tab: Tab.jQueryInterface;
-        modal: Modal.jQueryInterface;
-        offcanvas: Offcanvas.jQueryInterface;
-        [Popover.NAME]: Popover.jQueryInterface;
-        scrollspy: ScrollSpy.jQueryInterface;
-        toast: Toast.jQueryInterface;
-        [Tooltip.NAME]: Tooltip.jQueryInterface;
-    }
-
-    interface Element {
-        addEventListener(
-            type: Carousel.Events | "slide.bs.carousel" | "slid.bs.carousel",
-            listener: (this: Element, ev: Carousel.Event) => any,
-            options?: boolean | AddEventListenerOptions,
-        ): void;
-
-        addEventListener(
-            type:
-                | Modal.Events
-                | "show.bs.modal"
-                | "shown.bs.modal"
-                | "hide.bs.modal"
-                | "hidden.bs.modal"
-                | "hidePrevented.bs.modal",
-            listener: (this: Element, ev: Modal.Event) => any,
-            options?: boolean | AddEventListenerOptions,
-        ): void;
-    }
-}
-
 export { Alert, Button, Carousel, Collapse, Dropdown, Modal, Offcanvas, Popover, ScrollSpy, Tab, Toast, Tooltip };

--- a/types/bootstrap/js/dist/alert.d.ts
+++ b/types/bootstrap/js/dist/alert.d.ts
@@ -1,5 +1,11 @@
 import BaseComponent, { GetInstanceFactory, GetOrCreateInstanceFactory } from "./base-component";
 
+declare global {
+    interface JQuery {
+        alert: Alert.jQueryInterface;
+    }
+}
+
 declare class Alert extends BaseComponent {
     static NAME: "alert";
     static jQueryInterface: Alert.jQueryInterface;

--- a/types/bootstrap/js/dist/button.d.ts
+++ b/types/bootstrap/js/dist/button.d.ts
@@ -1,5 +1,11 @@
 import BaseComponent, { GetInstanceFactory, GetOrCreateInstanceFactory } from "./base-component";
 
+declare global {
+    interface JQuery {
+        button: Button.jQueryInterface;
+    }
+}
+
 declare class Button extends BaseComponent {
     /**
      * Toggles push state. Gives the button the appearance that it has been activated.

--- a/types/bootstrap/js/dist/carousel.d.ts
+++ b/types/bootstrap/js/dist/carousel.d.ts
@@ -1,5 +1,19 @@
 import BaseComponent, { GetInstanceFactory, GetOrCreateInstanceFactory } from "./base-component";
 
+declare global {
+    interface JQuery {
+        carousel: Carousel.jQueryInterface;
+    }
+
+    interface Element {
+        addEventListener(
+            type: Carousel.Events | "slide.bs.carousel" | "slid.bs.carousel",
+            listener: (this: Element, ev: Carousel.Event) => any,
+            options?: boolean | AddEventListenerOptions,
+        ): void;
+    }
+}
+
 declare class Carousel extends BaseComponent {
     /**
      * Default settings of this plugin

--- a/types/bootstrap/js/dist/collapse.d.ts
+++ b/types/bootstrap/js/dist/collapse.d.ts
@@ -1,5 +1,11 @@
 import BaseComponent, { GetInstanceFactory, GetOrCreateInstanceFactory } from "./base-component";
 
+declare global {
+    interface JQuery {
+        collapse: Collapse.jQueryInterface;
+    }
+}
+
 declare class Collapse extends BaseComponent {
     /**
      * Static method which allows you to get the collapse instance associated

--- a/types/bootstrap/js/dist/dropdown.d.ts
+++ b/types/bootstrap/js/dist/dropdown.d.ts
@@ -2,6 +2,12 @@ import * as Popper from "@popperjs/core";
 import BaseComponent, { GetInstanceFactory, GetOrCreateInstanceFactory } from "./base-component";
 import Tooltip from "./tooltip";
 
+declare global {
+    interface JQuery {
+        dropdown: Dropdown.jQueryInterface;
+    }
+}
+
 declare class Dropdown extends BaseComponent {
     /**
      * Static method which allows you to get the dropdown instance associated

--- a/types/bootstrap/js/dist/modal.d.ts
+++ b/types/bootstrap/js/dist/modal.d.ts
@@ -1,5 +1,25 @@
 import BaseComponent, { GetInstanceFactory, GetOrCreateInstanceFactory } from "./base-component";
 
+declare global {
+    interface JQuery {
+        modal: Modal.jQueryInterface;
+    }
+
+    interface Element {
+        addEventListener(
+            type:
+                | Modal.Events
+                | "show.bs.modal"
+                | "shown.bs.modal"
+                | "hide.bs.modal"
+                | "hidden.bs.modal"
+                | "hidePrevented.bs.modal",
+            listener: (this: Element, ev: Modal.Event) => any,
+            options?: boolean | AddEventListenerOptions,
+        ): void;
+    }
+}
+
 declare class Modal extends BaseComponent {
     /**
      * Static method which allows you to get the modal instance associated with

--- a/types/bootstrap/js/dist/offcanvas.d.ts
+++ b/types/bootstrap/js/dist/offcanvas.d.ts
@@ -1,5 +1,11 @@
 import BaseComponent, { GetInstanceFactory, GetOrCreateInstanceFactory } from "./base-component";
 
+declare global {
+    interface JQuery {
+        offcanvas: Offcanvas.jQueryInterface;
+    }
+}
+
 declare class Offcanvas extends BaseComponent {
     /**
      * Static method which allows you to get the offcanvas instance associated with a DOM element

--- a/types/bootstrap/js/dist/popover.d.ts
+++ b/types/bootstrap/js/dist/popover.d.ts
@@ -1,6 +1,12 @@
 import BaseComponent, { GetInstanceFactory, GetOrCreateInstanceFactory } from "./base-component";
 import Tooltip from "./tooltip";
 
+declare global {
+    interface JQuery {
+        [Popover.NAME]: Popover.jQueryInterface;
+    }
+}
+
 declare class Popover extends BaseComponent {
     static getInstance: GetInstanceFactory<Popover>;
 

--- a/types/bootstrap/js/dist/scrollspy.d.ts
+++ b/types/bootstrap/js/dist/scrollspy.d.ts
@@ -1,5 +1,11 @@
 import BaseComponent, { GetInstanceFactory, GetOrCreateInstanceFactory } from "./base-component";
 
+declare global {
+    interface JQuery {
+        scrollspy: ScrollSpy.jQueryInterface;
+    }
+}
+
 declare class ScrollSpy extends BaseComponent {
     /**
      * Static method which allows you to get the scrollspy instance associated

--- a/types/bootstrap/js/dist/tab.d.ts
+++ b/types/bootstrap/js/dist/tab.d.ts
@@ -1,6 +1,12 @@
 import BaseComponent, { GetOrCreateInstanceFactory } from "./base-component";
 import { GetInstanceFactory } from "./base-component.d";
 
+declare global {
+    interface JQuery {
+        tab: Tab.jQueryInterface;
+    }
+}
+
 declare class Tab extends BaseComponent {
     /**
      * Static method which allows you to get the tab instance associated with a

--- a/types/bootstrap/js/dist/toast.d.ts
+++ b/types/bootstrap/js/dist/toast.d.ts
@@ -1,5 +1,11 @@
 import BaseComponent, { GetInstanceFactory, GetOrCreateInstanceFactory } from "./base-component";
 
+declare global {
+    interface JQuery {
+        toast: Toast.jQueryInterface;
+    }
+}
+
 declare class Toast extends BaseComponent {
     /**
      * Static method which allows you to get the toast instance associated

--- a/types/bootstrap/js/dist/tooltip.d.ts
+++ b/types/bootstrap/js/dist/tooltip.d.ts
@@ -1,6 +1,12 @@
 import * as Popper from "@popperjs/core";
 import BaseComponent, { GetInstanceFactory, GetOrCreateInstanceFactory } from "./base-component";
 
+declare global {
+    interface JQuery {
+        [Tooltip.NAME]: Tooltip.jQueryInterface;
+    }
+}
+
 declare class Tooltip extends BaseComponent {
     static getInstance: GetInstanceFactory<Tooltip>;
 

--- a/types/bootstrap/test/global-script.ts
+++ b/types/bootstrap/test/global-script.ts
@@ -8,3 +8,17 @@ new bootstrap.Alert("#alert");
 new bootstrap.Alert(document.querySelector("#alert")!);
 new bootstrap.Modal("#myModal", {});
 new bootstrap.Modal(document.querySelector("#myModal")!, {});
+
+const element = new Element();
+
+element.addEventListener("show.bs.modal", event => {
+    event.target; // $ExpectType HTMLElement
+    event.relatedTarget; // $ExpectType HTMLElement | undefined
+});
+
+element.addEventListener("slid.bs.carousel", event => {
+    event.direction; // $ExpectType Direction
+    event.relatedTarget; // $ExpectType Element
+    event.from; // $ExpectType number
+    event.to; // $ExpectType number
+});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] ~Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>~
- [x] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.~

---

It's very common to import only the components you're actually using but since `JQuery` is only defined in the `index.d.ts` you'll get errors from TypeScript unless you add `bootstrap` to your global `types` or switch to import everything.

Having each component define their globals should avoid this and make things a bit more accurate to boot since you'll only get types for things you are actually using.