### PR TITLE
Disable arethetypeswrong named exports rule

### DIFF
--- a/attw.json
+++ b/attw.json
@@ -3,7 +3,8 @@
         "no-resolution",
         "cjs-only-exports-default",
         "unexpected-module-syntax",
-        "cjs-resolves-to-esm"
+        "cjs-resolves-to-esm",
+        "named-exports"
     ],
     "failingPackages": [
         "af-utils__react-table",


### PR DESCRIPTION
https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/NamedExports.md was added in a previous arethetypeswrong version bump, which needs to be disabled for DefinitelyTyped.