### PR TITLE
Fix puppeteer-har and puppeteer-screenshot-tester module changes

### DIFF
--- a/types/puppeteer-har/index.d.ts
+++ b/types/puppeteer-har/index.d.ts
@@ -1,4 +1,4 @@
-import type { Frame, Page } from "puppeteer";
+import type { Frame, Page } from "puppeteer" with { "resolution-mode": "import" };
 
 declare namespace PuppeteerHar {
     interface PuppeteerHarOptions {

--- a/types/puppeteer-har/puppeteer-har-tests.ts
+++ b/types/puppeteer-har/puppeteer-har-tests.ts
@@ -1,7 +1,7 @@
 /// <reference lib="dom" />
 
 // Import only for type-checking purposes
-import { Frame, Page } from "puppeteer";
+import type { Frame, Page } from "puppeteer" with { "resolution-mode": "import" };
 import PuppeteerHar from "puppeteer-har";
 
 // Define a mock Page interface just for type-checking

--- a/types/puppeteer-screenshot-tester/index.d.ts
+++ b/types/puppeteer-screenshot-tester/index.d.ts
@@ -1,5 +1,7 @@
-import { Page, ScreenshotOptions as PuppeteerScreenshotOptions } from "puppeteer";
-import { JpegOptions, PngOptions, WebpOptions } from "sharp";
+import type { Page, ScreenshotOptions as PuppeteerScreenshotOptions } from "puppeteer" with {
+    "resolution-mode": "import",
+};
+import type { JpegOptions, PngOptions, WebpOptions } from "sharp" with { "resolution-mode": "import" };
 
 interface PngOutputSettings {
     /**


### PR DESCRIPTION
These packages now need require(ESM). Work around this by setting a resolution mode, in lieu of DT supporting newer resolution modesl