### PR TITLE
frida-gum: Add size to export details

### DIFF
--- a/types/frida-gum/frida-gum-tests.ts
+++ b/types/frida-gum/frida-gum-tests.ts
@@ -487,3 +487,8 @@ const sampler = new BusyCycleSampler();
 for (const e of Process.getModuleByName("libc.so").enumerateExports().filter(e => e.type === "function")) {
     profiler.instrument(e.address, sampler);
 }
+
+for (const e of Process.getModuleByName("libc.so").enumerateExports()) {
+    // $ExpectType number | undefined
+    e.size;
+}

--- a/types/frida-gum/index.d.ts
+++ b/types/frida-gum/index.d.ts
@@ -1177,6 +1177,11 @@ interface ModuleExportDetails {
      * Absolute address.
      */
     address: NativePointer;
+
+    /**
+     * Size in bytes, if available.
+     */
+    size?: number | undefined;
 }
 
 interface ModuleSymbolDetails {

--- a/types/frida-gum/package.json
+++ b/types/frida-gum/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/frida-gum",
-    "version": "19.4.9999",
+    "version": "19.5.9999",
     "nonNpm": true,
     "nonNpmDescription": "frida-gum",
     "projects": [


### PR DESCRIPTION
Sync with frida-gum bb5d050ebbf9fda301305ac40a030a2027dbcdee, where `GumExportDetails` gained a `size` field, exposed by gumjs as an optional `size` property on `ModuleExportDetails` when known.