### PR TITLE
Nodemailer: `Address["name"]` is optional

### DIFF
--- a/types/nodemailer/lib/mailer/index.d.ts
+++ b/types/nodemailer/lib/mailer/index.d.ts
@@ -27,8 +27,11 @@ declare namespace Mail {
 
     type TextEncoding = "quoted-printable" | "base64";
 
+    /** Most reliable way to represent an email address with optional name. Nodemailer handles all the escaping and formatting automatically, forming `Name <email>` strings. */
     interface Address {
-        name: string;
+        /** Name part of `Name <email>` address; if falsey, only the email address will be used */
+        name?: string | undefined;
+        /** Email part of `Name <email>` address; technically optional, but Nodemailer ignores address-less objects, so we require it to help prevent bugs. */
         address: string;
     }
 

--- a/types/nodemailer/nodemailer-tests.ts
+++ b/types/nodemailer/nodemailer-tests.ts
@@ -131,6 +131,20 @@ function message_common_fields_array_test() {
     };
 }
 
+function message_common_fields_optional_address_object_test() {
+    const message: Mail.Options = {
+        from: { address: "sender@server.com" },
+        to: [{ name: "Receiver", address: "receiver@sender.com" }, { address: "receiver2@sender.com" }],
+        cc: { name: "Carbon Copy", address: "cc@sender.com" },
+        bcc: { address: "bcc@sender.com" },
+    };
+
+    const missingAddress: Mail.Options = {
+        // @ts-expect-error - Nodemailer ignores address-less objects, so the type requires address.
+        to: { name: "Receiver" },
+    };
+}
+
 // More advanced fields
 
 function message_more_advanced_fields_test() {

--- a/types/nodemailer/v6/lib/mailer/index.d.ts
+++ b/types/nodemailer/v6/lib/mailer/index.d.ts
@@ -27,8 +27,11 @@ declare namespace Mail {
 
     type TextEncoding = "quoted-printable" | "base64";
 
+    /** Most reliable way to represent an email address with optional name. Nodemailer handles all the escaping and formatting automatically, forming `Name <email>` strings. */
     interface Address {
-        name: string;
+        /** Name part of `Name <email>` address; if falsey, only the email address will be used */
+        name?: string | undefined;
+        /** Email part of `Name <email>` address; technically optional, but Nodemailer ignores address-less objects, so we require it to help prevent bugs. */
         address: string;
     }
 

--- a/types/nodemailer/v6/nodemailer-tests.ts
+++ b/types/nodemailer/v6/nodemailer-tests.ts
@@ -109,6 +109,20 @@ function message_common_fields_test() {
     };
 }
 
+function message_common_fields_optional_address_object_test() {
+    const message: Mail.Options = {
+        from: { address: "sender@server.com" },
+        to: [{ name: "Receiver", address: "receiver@sender.com" }, { address: "receiver2@sender.com" }],
+        cc: { name: "Carbon Copy", address: "cc@sender.com" },
+        bcc: { address: "bcc@sender.com" },
+    };
+
+    const missingAddress: Mail.Options = {
+        // @ts-expect-error - Nodemailer ignores address-less objects, so the type requires address.
+        to: { name: "Receiver" },
+    };
+}
+
 // More advanced fields
 
 function message_more_advanced_fields_test() {

--- a/types/nodemailer/v7/lib/mailer/index.d.ts
+++ b/types/nodemailer/v7/lib/mailer/index.d.ts
@@ -27,8 +27,11 @@ declare namespace Mail {
 
     type TextEncoding = "quoted-printable" | "base64";
 
+    /** Most reliable way to represent an email address with optional name. Nodemailer handles all the escaping and formatting automatically, forming `Name <email>` strings. */
     interface Address {
-        name: string;
+        /** Name part of `Name <email>` address; if falsey, only the email address will be used */
+        name?: string | undefined;
+        /** Email part of `Name <email>` address; technically optional, but Nodemailer ignores address-less objects, so we require it to help prevent bugs. */
         address: string;
     }
 

--- a/types/nodemailer/v7/nodemailer-tests.ts
+++ b/types/nodemailer/v7/nodemailer-tests.ts
@@ -131,6 +131,20 @@ function message_common_fields_array_test() {
     };
 }
 
+function message_common_fields_optional_address_object_test() {
+    const message: Mail.Options = {
+        from: { address: "sender@server.com" },
+        to: [{ name: "Receiver", address: "receiver@sender.com" }, { address: "receiver2@sender.com" }],
+        cc: { name: "Carbon Copy", address: "cc@sender.com" },
+        bcc: { address: "bcc@sender.com" },
+    };
+
+    const missingAddress: Mail.Options = {
+        // @ts-expect-error - Nodemailer ignores address-less objects, so the type requires address.
+        to: { name: "Receiver" },
+    };
+}
+
 // More advanced fields
 
 function message_more_advanced_fields_test() {


### PR DESCRIPTION
Update Nodemailer `Mail.Address` types so `name` is optional while `address` remains required.

Motivation:

* Nodemailer [documents](https://nodemailer.com/message/addresses#3-address-object) address objects as supporting omitted `name`, in which case only the email address is used. The previous types required both `name` and `address`, rejecting valid address objects like `{ address: "user@example.com" }`.
* `{address}` has a function difference from just specifying an `address` string: [the code](https://github.com/nodemailer/nodemailer/blob/a6bcbf6865c601baf74323567ee51c67fb76b1a6/lib/mime-node/index.js#L1190) escapes `address`es with spaces in them by wrapping in the necessary `<...>`. As [mentioned in the documentation](https://nodemailer.com/message/addresses#3-address-object), "[address objects let] Nodemailer handle all the escaping and formatting automatically".
* Although Nodemailer technically allows omitting `address`, it ignores address-less objects at runtime, so the types keep `address` required to catch likely bugs where `Address` objects are silently ignored. Happy to change if you think making optional is more accurate.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://nodemailer.com/message/addresses#3-address-object says
    > Both properties are optional. If you omit `name`, only the email address is used. If you omit `address`, the entry is ignored.
  - https://github.com/nodemailer/nodemailer/blob/a6bcbf6865c601baf74323567ee51c67fb76b1a6/lib/mime-node/index.js#L1189 confirms that it checks falseyness of `name` property, so `undefined` and `""` are treated the same.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`: NA
