### PR TITLE
Use GHA token instead of deploy key for format job

### DIFF
--- a/.github/workflows/format-and-commit.yml
+++ b/.github/workflows/format-and-commit.yml
@@ -12,12 +12,11 @@ on:
 jobs:
   dprint-fmt:
     runs-on: ubuntu-slim
+    permissions:
+      contents: write
     if: github.repository == 'DefinitelyTyped/DefinitelyTyped'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          # Use a deploy key so that CI triggers on pushes; we want to know if formatting broke something.
-          ssh-key: ${{ secrets.DEPLOY_KEY }}
       - uses: ./.github/actions/setup-for-scripts
 
       - name: Get date


### PR DESCRIPTION
I did a deploy key originally in order to make CI run on push. But, I don't think this ever had much value, and I would like to delete this secret.