### PR TITLE
[discord-rpc] Add myself back

### DIFF
--- a/types/discord-rpc/package.json
+++ b/types/discord-rpc/package.json
@@ -13,6 +13,10 @@
     },
     "owners": [
         {
+            "name": "Brandon Bothell",
+            "githubUsername": "brandonbothell"
+        },
+        {
             "name": "Dylan Hackworth",
             "githubUsername": "dylhack"
         },


### PR DESCRIPTION
I initially wrote the typings for discord-rpc under the username jasonhaxstuff and am open to reviewing PRs for `discord-rpc` typings (please see #30578). My account was initially removed from the owners due to a username change (`jasonhaxstuff -> brandonbothell`, see #64815)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/30578
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
