### PR TITLE
[@types/fhir] Restore generic Bundle<T> and BundleEntry<T>

### DIFF
--- a/types/fhir/r2.d.ts
+++ b/types/fhir/r2.d.ts
@@ -12038,7 +12038,7 @@ export interface HumanName extends Element {
 /**
  * Base StructureDefinition for Bundle Resource
  */
-export interface Bundle extends Resource {
+export interface Bundle<T extends Resource = Resource> extends Resource {
   /** Resource Type Name (for serialization) */
   readonly resourceType: 'Bundle';
   /**
@@ -12062,7 +12062,7 @@ export interface Bundle extends Resource {
    * Entry in the bundle - will have a resource, or information
    * An entry in a bundle resource - will either contain a resource, or information about a resource (transactions and history only).
    */
-  entry?: BundleEntry[] | undefined;
+  entry?: BundleEntry<T>[] | undefined;
   /**
    * Digital Signature
    * Digital Signature - base64 encoded. XML DigSIg or a JWT.
@@ -12186,7 +12186,7 @@ export interface BundleEntryResponse extends BackboneElement {
  * Entry in the bundle - will have a resource, or information
  * An entry in a bundle resource - will either contain a resource, or information about a resource (transactions and history only).
  */
-export interface BundleEntry extends BackboneElement {
+export interface BundleEntry<T extends Resource = Resource> extends BackboneElement {
   /**
    * Absolute URL for resource (server address, or UUID/OID)
    * The Absolute URL for the resource. This must be provided for all resources. The fullUrl SHALL not disagree with the id in the resource. The fullUrl is a version independent reference to the resource.
@@ -12197,7 +12197,7 @@ export interface BundleEntry extends BackboneElement {
    * A resource in the bundle
    * The Resources for the entry.
    */
-  resource?: Resource | undefined;
+  resource?: T | undefined;
   /**
    * Search related information
    * Information about the search process that lead to the creation of this entry.

--- a/types/fhir/r3.d.ts
+++ b/types/fhir/r3.d.ts
@@ -18821,7 +18821,7 @@ export interface HumanName extends Element {
 /**
  * Base StructureDefinition for Bundle Resource
  */
-export interface Bundle extends Resource {
+export interface Bundle<T extends Resource = Resource> extends Resource {
   /** Resource Type Name (for serialization) */
   readonly resourceType: 'Bundle';
   /**
@@ -18853,7 +18853,7 @@ export interface Bundle extends Resource {
    * Entry in the bundle - will have a resource, or information
    * An entry in a bundle resource - will either contain a resource, or information about a resource (transactions and history only).
    */
-  entry?: BundleEntry[] | undefined;
+  entry?: BundleEntry<T>[] | undefined;
   /**
    * Digital Signature
    * Digital Signature - base64 encoded. XML-DSIg or a JWT.
@@ -18989,7 +18989,7 @@ export interface BundleEntryResponse extends BackboneElement {
  * Entry in the bundle - will have a resource, or information
  * An entry in a bundle resource - will either contain a resource, or information about a resource (transactions and history only).
  */
-export interface BundleEntry extends BackboneElement {
+export interface BundleEntry<T extends Resource = Resource> extends BackboneElement {
   /**
    * Links related to this entry
    * A series of links that provide context to this entry.
@@ -19008,7 +19008,7 @@ export interface BundleEntry extends BackboneElement {
    * A resource in the bundle
    * The Resources for the entry.
    */
-  resource?: Resource | undefined;
+  resource?: T | undefined;
   /**
    * Search related information
    * Information about the search process that lead to the creation of this entry.

--- a/types/fhir/r4.d.ts
+++ b/types/fhir/r4.d.ts
@@ -25659,7 +25659,7 @@ export interface EvidenceVariableCharacteristic extends BackboneElement {
 /**
  * A container for a collection of resources.
  */
-export interface Bundle extends Resource {
+export interface Bundle<T extends Resource = Resource> extends Resource {
   /** Resource Type Name (for serialization) */
   readonly resourceType: 'Bundle';
   /**
@@ -25708,7 +25708,7 @@ export interface Bundle extends Resource {
    * Entry in the bundle - will have a resource or information
    * An entry in a bundle resource - will either contain a resource or information about a resource (transactions and history only).
    */
-  entry?: BundleEntry[] | undefined;
+  entry?: BundleEntry<T>[] | undefined;
   /**
    * Digital Signature
    * Digital Signature - base64 encoded. XML-DSig or a JWT.
@@ -25849,7 +25849,7 @@ export interface BundleEntryResponse extends BackboneElement {
  * Entry in the bundle - will have a resource or information
  * An entry in a bundle resource - will either contain a resource or information about a resource (transactions and history only).
  */
-export interface BundleEntry extends BackboneElement {
+export interface BundleEntry<T extends Resource = Resource> extends BackboneElement {
   /**
    * Links related to this entry
    * A series of links that provide context to this entry.
@@ -25869,7 +25869,7 @@ export interface BundleEntry extends BackboneElement {
    * A resource in the bundle
    * The Resource for the entry. The purpose/meaning of the resource is determined by the Bundle.type.
    */
-  resource?: Resource | undefined;
+  resource?: T | undefined;
   /**
    * Search related information
    * Information about the search process that lead to the creation of this entry.

--- a/types/fhir/r4b.d.ts
+++ b/types/fhir/r4b.d.ts
@@ -26035,7 +26035,7 @@ export interface CodeableReference extends Element {
 /**
  * A container for a collection of resources.
  */
-export interface Bundle extends Resource {
+export interface Bundle<T extends Resource = Resource> extends Resource {
   /** Resource Type Name (for serialization) */
   readonly resourceType: 'Bundle';
   /**
@@ -26084,7 +26084,7 @@ export interface Bundle extends Resource {
    * Entry in the bundle - will have a resource or information
    * An entry in a bundle resource - will either contain a resource or information about a resource (transactions and history only).
    */
-  entry?: BundleEntry[] | undefined;
+  entry?: BundleEntry<T>[] | undefined;
   /**
    * Digital Signature
    * Digital Signature - base64 encoded. XML-DSig or a JWT.
@@ -26225,7 +26225,7 @@ export interface BundleEntryResponse extends BackboneElement {
  * Entry in the bundle - will have a resource or information
  * An entry in a bundle resource - will either contain a resource or information about a resource (transactions and history only).
  */
-export interface BundleEntry extends BackboneElement {
+export interface BundleEntry<T extends Resource = Resource> extends BackboneElement {
   /**
    * Links related to this entry
    * A series of links that provide context to this entry.
@@ -26245,7 +26245,7 @@ export interface BundleEntry extends BackboneElement {
    * A resource in the bundle
    * The Resource for the entry. The purpose/meaning of the resource is determined by the Bundle.type.
    */
-  resource?: Resource | undefined;
+  resource?: T | undefined;
   /**
    * Search related information
    * Information about the search process that lead to the creation of this entry.

--- a/types/fhir/r5.d.ts
+++ b/types/fhir/r5.d.ts
@@ -32200,7 +32200,7 @@ export interface CodeableReference extends DataType {
 /**
  * A container for a collection of resources.
  */
-export interface Bundle extends Resource {
+export interface Bundle<T extends Resource = Resource> extends Resource {
   /** Resource Type Name (for serialization) */
   readonly resourceType: 'Bundle';
   /**
@@ -32249,7 +32249,7 @@ export interface Bundle extends Resource {
    * Entry in the bundle - will have a resource or information
    * An entry in a bundle resource - will either contain a resource or information about a resource (transactions and history only).
    */
-  entry?: BundleEntry[] | undefined;
+  entry?: BundleEntry<T>[] | undefined;
   /**
    * Digital Signature
    * Digital Signature - base64 encoded. XML-DSig or a JWS.
@@ -32396,7 +32396,7 @@ export interface BundleEntryResponse extends BackboneElement {
  * Entry in the bundle - will have a resource or information
  * An entry in a bundle resource - will either contain a resource or information about a resource (transactions and history only).
  */
-export interface BundleEntry extends BackboneElement {
+export interface BundleEntry<T extends Resource = Resource> extends BackboneElement {
   /**
    * Links related to this entry
    * A series of links that provide context to this entry.
@@ -32417,7 +32417,7 @@ export interface BundleEntry extends BackboneElement {
    * A resource in the bundle
    * The Resource for the entry. The purpose/meaning of the resource is determined by the Bundle.type. This is allowed to be a Parameters resource if and only if it is referenced by something else within the Bundle that provides context/meaning.
    */
-  resource?: Resource | undefined;
+  resource?: T | undefined;
   /**
    * Search related information
    * Information about the search process that lead to the creation of this entry.

--- a/types/fhir/test/r2-tests.ts
+++ b/types/fhir/test/r2-tests.ts
@@ -316,3 +316,17 @@ const r2Bundle: fhir2.Bundle = {
 const r2HasPatient = r2Bundle.entry?.some(
   (e) => e.resource?.resourceType === "Patient",
 );
+
+// 6. Bundle<T> and BundleEntry<T> generic typing
+//    Regression for https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/75098
+const r2PatientBundle: fhir2.Bundle<fhir2.Patient> = {
+  resourceType: "Bundle",
+  type: "collection",
+  entry: [{ resource: r2InlinePatient }],
+};
+const r2PatientEntry = r2PatientBundle.entry?.[0];
+// patientEntry resource should be typed as Patient | undefined
+if (r2PatientEntry?.resource?.resourceType === "Patient") {
+  // Access a Patient-specific field (e.g. id) to prove narrow typing
+  const r2PtId: string | undefined = r2PatientEntry.resource.id;
+}

--- a/types/fhir/test/r3-tests.ts
+++ b/types/fhir/test/r3-tests.ts
@@ -388,3 +388,17 @@ const r3Bundle: fhir3.Bundle = {
 const r3HasPatient = r3Bundle.entry?.some(
   (e) => e.resource?.resourceType === "Patient",
 );
+
+// 6. Bundle<T> and BundleEntry<T> generic typing
+//    Regression for https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/75098
+const r3PatientBundle: fhir3.Bundle<fhir3.Patient> = {
+  resourceType: "Bundle",
+  type: "collection",
+  entry: [{ resource: r3InlinePatient }],
+};
+const r3PatientEntry = r3PatientBundle.entry?.[0];
+// patientEntry resource should be typed as Patient | undefined
+if (r3PatientEntry?.resource?.resourceType === "Patient") {
+  // Access a Patient-specific field (e.g. id) to prove narrow typing
+  const r3PtId: string | undefined = r3PatientEntry.resource.id;
+}

--- a/types/fhir/test/r4-tests.ts
+++ b/types/fhir/test/r4-tests.ts
@@ -460,3 +460,17 @@ const r4Bundle: fhir4.Bundle = {
 const r4HasPatient = r4Bundle.entry?.some(
   (e) => e.resource?.resourceType === "Patient",
 );
+
+// 6. Bundle<T> and BundleEntry<T> generic typing
+//    Regression for https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/75098
+const r4PatientBundle: fhir4.Bundle<fhir4.Patient> = {
+  resourceType: "Bundle",
+  type: "collection",
+  entry: [{ resource: r4InlinePatient }],
+};
+const r4PatientEntry = r4PatientBundle.entry?.[0];
+// patientEntry resource should be typed as Patient | undefined
+if (r4PatientEntry?.resource?.resourceType === "Patient") {
+  // Access a Patient-specific field (e.g. id) to prove narrow typing
+  const r4PtId: string | undefined = r4PatientEntry.resource.id;
+}

--- a/types/fhir/test/r5-tests.ts
+++ b/types/fhir/test/r5-tests.ts
@@ -499,3 +499,17 @@ const r5Bundle: fhir5.Bundle = {
 const r5HasPatient = r5Bundle.entry?.some(
   (e) => e.resource?.resourceType === "Patient",
 );
+
+// 6. Bundle<T> and BundleEntry<T> generic typing
+//    Regression for https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/75098
+const r5PatientBundle: fhir5.Bundle<fhir5.Patient> = {
+  resourceType: "Bundle",
+  type: "collection",
+  entry: [{ resource: r5InlinePatient }],
+};
+const r5PatientEntry = r5PatientBundle.entry?.[0];
+// patientEntry resource should be typed as Patient | undefined
+if (r5PatientEntry?.resource?.resourceType === "Patient") {
+  // Access a Patient-specific field (e.g. id) to prove narrow typing
+  const r5PtId: string | undefined = r5PatientEntry.resource.id;
+}


### PR DESCRIPTION
Between 0.0.41 and 0.0.42 the generator unintentionally dropped the hand-maintained generics on Bundle and BundleEntry. This change restores the ergonomic typing across all FHIR versions (R2–R5).

- Bundle<T extends Resource = Resource>
- BundleEntry<T extends Resource = Resource>
- Bundle.entry typed as BundleEntry<T>[]
- BundleEntry.resource typed as T
- Adds regression tests for all versions

The default parameter keeps plain  backward-compatible.

Fixes: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/75098

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/75098
