### PR TITLE
node/http: Fix Agent.keepSocketAlive() return type to boolean

### DIFF
--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -1688,7 +1688,7 @@ declare module "node:http" {
          * The `socket` argument can be an instance of `net.Socket`, a subclass of `stream.Duplex`.
          * @since v8.1.0
          */
-        keepSocketAlive(socket: stream.Duplex): void;
+        keepSocketAlive(socket: stream.Duplex): boolean;
         /**
          * Called when `socket` is attached to `request` after being persisted because of
          * the keep-alive options. Default behavior is to:

--- a/types/node/node-tests/http.ts
+++ b/types/node/node-tests/http.ts
@@ -383,7 +383,7 @@ import * as url from "node:url";
     agent satisfies EventEmitter;
 
     agent.createConnection({ port: 1234 });
-    agent.keepSocketAlive(new stream.Duplex());
+    agent.keepSocketAlive(new stream.Duplex()) satisfies boolean;
     agent.reuseSocket(new stream.Duplex(), new http.ClientRequest(""));
 
     // test custom overrides

--- a/types/node/v20/http.d.ts
+++ b/types/node/v20/http.d.ts
@@ -1624,7 +1624,7 @@ declare module "http" {
          * The `socket` argument can be an instance of `net.Socket`, a subclass of `stream.Duplex`.
          * @since v8.1.0
          */
-        keepSocketAlive(socket: stream.Duplex): void;
+        keepSocketAlive(socket: stream.Duplex): boolean;
         /**
          * Called when `socket` is attached to `request` after being persisted because of
          * the keep-alive options. Default behavior is to:

--- a/types/node/v20/test/http.ts
+++ b/types/node/v20/test/http.ts
@@ -368,7 +368,7 @@ import * as url from "node:url";
     agent.emit("free");
 
     agent.createConnection({ port: 1234 });
-    agent.keepSocketAlive(new stream.Duplex());
+    agent.keepSocketAlive(new stream.Duplex()) satisfies boolean;
     agent.reuseSocket(new stream.Duplex(), new http.ClientRequest(""));
 
     // test custom overrides

--- a/types/node/v22/http.d.ts
+++ b/types/node/v22/http.d.ts
@@ -1651,7 +1651,7 @@ declare module "http" {
          * The `socket` argument can be an instance of `net.Socket`, a subclass of `stream.Duplex`.
          * @since v8.1.0
          */
-        keepSocketAlive(socket: stream.Duplex): void;
+        keepSocketAlive(socket: stream.Duplex): boolean;
         /**
          * Called when `socket` is attached to `request` after being persisted because of
          * the keep-alive options. Default behavior is to:

--- a/types/node/v22/test/http.ts
+++ b/types/node/v22/test/http.ts
@@ -375,7 +375,7 @@ import * as url from "node:url";
     agent.emit("free");
 
     agent.createConnection({ port: 1234 });
-    agent.keepSocketAlive(new stream.Duplex());
+    agent.keepSocketAlive(new stream.Duplex()) satisfies boolean;
     agent.reuseSocket(new stream.Duplex(), new http.ClientRequest(""));
 
     // test custom overrides

--- a/types/node/v24/http.d.ts
+++ b/types/node/v24/http.d.ts
@@ -1716,7 +1716,7 @@ declare module "http" {
          * The `socket` argument can be an instance of `net.Socket`, a subclass of `stream.Duplex`.
          * @since v8.1.0
          */
-        keepSocketAlive(socket: stream.Duplex): void;
+        keepSocketAlive(socket: stream.Duplex): boolean;
         /**
          * Called when `socket` is attached to `request` after being persisted because of
          * the keep-alive options. Default behavior is to:

--- a/types/node/v24/test/http.ts
+++ b/types/node/v24/test/http.ts
@@ -384,7 +384,7 @@ import * as url from "node:url";
     agent.emit("free");
 
     agent.createConnection({ port: 1234 });
-    agent.keepSocketAlive(new stream.Duplex());
+    agent.keepSocketAlive(new stream.Duplex()) satisfies boolean;
     agent.reuseSocket(new stream.Duplex(), new http.ClientRequest(""));
 
     // test custom overrides


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/docs/latest-v26.x/api/http.html#agentkeepsocketalivesocket
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
