### PR TITLE
[dom-chromium-ai] Add samplingMode; make it mutually exclusive with topK/temperature

### DIFF
--- a/types/dom-chromium-ai/dom-chromium-ai-tests.ts
+++ b/types/dom-chromium-ai/dom-chromium-ai-tests.ts
@@ -16,14 +16,14 @@ async function topLevel() {
     await LanguageModel.create({ samplingMode: "balanced" });
 
     await LanguageModel.create({
-        // @ts-expect-error - samplingMode and topK/temperature are mutually exclusive.
         samplingMode: "balanced",
+        // @ts-expect-error - samplingMode and topK/temperature are mutually exclusive.
         topK: 1,
     });
 
     await LanguageModel.create({
-        // @ts-expect-error - samplingMode and topK/temperature are mutually exclusive.
         samplingMode: "balanced",
+        // @ts-expect-error - samplingMode and topK/temperature are mutually exclusive.
         temperature: 0.5,
     });
 

--- a/types/dom-chromium-ai/dom-chromium-ai-tests.ts
+++ b/types/dom-chromium-ai/dom-chromium-ai-tests.ts
@@ -11,6 +11,22 @@ async function topLevel() {
         initialPrompts: [{ role: "assistant", content: "foo", prefix: true }],
     });
 
+    // samplingMode is valid on its own
+    await LanguageModel.create({ samplingMode: "most-creative" });
+    await LanguageModel.create({ samplingMode: "balanced" });
+
+    await LanguageModel.create({
+        // @ts-expect-error - samplingMode and topK/temperature are mutually exclusive.
+        samplingMode: "balanced",
+        topK: 1,
+    });
+
+    await LanguageModel.create({
+        // @ts-expect-error - samplingMode and topK/temperature are mutually exclusive.
+        samplingMode: "balanced",
+        temperature: 0.5,
+    });
+
     const languageModel = await LanguageModel.create({
         topK: 1,
         temperature: 0,

--- a/types/dom-chromium-ai/index.d.ts
+++ b/types/dom-chromium-ai/index.d.ts
@@ -116,25 +116,42 @@ interface LanguageModelParams {
     readonly maxTemperature: number;
 }
 
-interface LanguageModelCreateCoreOptions {
-    /** @deprecated Restricted to web extension contexts only. Use the topK option within LanguageModel.create() is now restricted to web extensions. */
-    topK?: number;
-    /** @deprecated Restricted to web extension contexts only. Use the temperature option within LanguageModel.create() is now restricted to web extensions. */
-    temperature?: number;
+type LanguageModelSamplingMode =
+    | "most-predictable"
+    | "predictable"
+    | "balanced"
+    | "creative"
+    | "most-creative";
 
+/**
+ * samplingMode and the raw sampling params (topK, temperature) are mutually exclusive.
+ * Providing both results in a TypeError at runtime.
+ * Note: topK and temperature are only available in Chrome extension contexts (Chrome 151+).
+ */
+type LanguageModelSamplingOptions =
+    | { samplingMode?: LanguageModelSamplingMode; topK?: never; temperature?: never }
+    | {
+          samplingMode?: never;
+          /** @deprecated Restricted to web extension contexts only. */
+          topK?: number;
+          /** @deprecated Restricted to web extension contexts only. */
+          temperature?: number;
+      };
+
+type LanguageModelCreateCoreOptions = {
     expectedInputs?: LanguageModelExpected[];
     expectedOutputs?: LanguageModelExpected[];
     tools?: LanguageModelTool[];
-}
+} & LanguageModelSamplingOptions;
 
-interface LanguageModelCreateOptions extends LanguageModelCreateCoreOptions {
+type LanguageModelCreateOptions = LanguageModelCreateCoreOptions & {
     signal?: AbortSignal;
     monitor?: CreateMonitorCallback;
 
     initialPrompts?:
         | [LanguageModelSystemMessage, ...LanguageModelMessage[]]
         | LanguageModelMessage[];
-}
+};
 
 interface LanguageModelPromptOptions {
     responseConstraint?: Record<string, unknown>;

--- a/types/dom-chromium-ai/index.d.ts
+++ b/types/dom-chromium-ai/index.d.ts
@@ -131,12 +131,12 @@ type LanguageModelSamplingMode =
 type LanguageModelSamplingOptions =
     | { samplingMode?: LanguageModelSamplingMode; topK?: never; temperature?: never }
     | {
-          samplingMode?: never;
-          /** @deprecated Restricted to web extension contexts only. */
-          topK?: number;
-          /** @deprecated Restricted to web extension contexts only. */
-          temperature?: number;
-      };
+        samplingMode?: never;
+        /** @deprecated Restricted to web extension contexts only. */
+        topK?: number;
+        /** @deprecated Restricted to web extension contexts only. */
+        temperature?: number;
+    };
 
 type LanguageModelCreateCoreOptions = {
     expectedInputs?: LanguageModelExpected[];


### PR DESCRIPTION
## Description

Chrome 151 introduces a new `samplingMode` semantic enum for `LanguageModel.create()` that replaces the raw `topK`/`temperature` params in web page contexts. The raw params are still available in Chrome extension contexts, but providing both `samplingMode` and a raw param throws a `TypeError` at runtime.

This PR:
- Adds `LanguageModelSamplingMode` union type with the 5 valid values
- Adds `LanguageModelSamplingOptions` discriminated union to enforce the mutual exclusivity between `samplingMode` and `topK`/`temperature` at the type level
- Converts `LanguageModelCreateCoreOptions` and `LanguageModelCreateOptions` from `interface` to `type` (required to intersect with the union)
- Adds test cases for valid `samplingMode` usage and `@ts-expect-error` cases for the mutual-exclusivity constraint

## References

- Chrome 151 release notes: `samplingMode` introduced, raw params removed from web page contexts
- Spec: https://github.com/webmachinelearning/prompt-api