### PR TITLE
Adds package maps to node:modules

### DIFF
--- a/types/node/module.d.ts
+++ b/types/node/module.d.ts
@@ -138,6 +138,36 @@ declare module "node:module" {
          */
         function getCompileCacheDir(): string | undefined;
         /**
+         * The contents of a package map configuration file used by
+         * `--experimental-package-map`.
+         *
+         * Package maps define package locations and the dependency names that
+         * each package can resolve.
+         * @experimental
+         */
+        interface PackageMap {
+            packages: Record<string, PackageMap.Package>;
+        }
+        namespace PackageMap {
+            /**
+             * A package entry in a package map configuration file.
+             * @experimental
+             */
+            interface Package {
+                /**
+                 * An absolute or relative URL for the package location. Only
+                 * `file:` URLs and relative URLs are currently supported by Node.js.
+                 */
+                url: string;
+                /**
+                 * Maps bare specifiers used by this package to package IDs in
+                 * the package map's `packages` object.
+                 * @default {}
+                 */
+                dependencies?: Record<string, string> | undefined;
+            }
+        }
+        /**
          * ```text
          * /path/to/project
          *   ├ packages/

--- a/types/node/node-tests/module.ts
+++ b/types/node/node-tests/module.ts
@@ -1,4 +1,5 @@
 import Module = require("node:module");
+import type { PackageMap } from "node:module";
 import { URL } from "node:url";
 
 Module.Module === Module;
@@ -57,6 +58,59 @@ Module.Module === Module;
 
     // $ExpectType void
     Module.syncBuiltinESMExports();
+}
+
+// Package maps
+{
+    const packageMap: Module.PackageMap = {
+        packages: {
+            app: {
+                url: "./packages/app",
+                dependencies: {
+                    lodash: "lodash",
+                    react: "react",
+                },
+            },
+            lodash: {
+                url: "file:///path/to/project/node_modules/lodash",
+            },
+            react: {
+                url: "./node_modules/react",
+            },
+        },
+    };
+
+    const namedPackageMap: PackageMap = packageMap;
+
+    // $ExpectType Record<string, Package>
+    namedPackageMap.packages;
+    // $ExpectType string
+    namedPackageMap.packages.app.url;
+    // $ExpectType Record<string, string> | undefined
+    namedPackageMap.packages.app.dependencies;
+
+    const packageEntry: PackageMap.Package = {
+        url: "./packages/utils",
+        dependencies: {
+            "@myorg/core": "core",
+        },
+    };
+
+    packageEntry.dependencies?.["@myorg/core"]; // $ExpectType string | undefined
+
+    // @ts-expect-error Package map entries require a URL.
+    const missingUrl: PackageMap.Package = {};
+
+    const invalidDependency: PackageMap.Package = {
+        url: "./packages/utils",
+        dependencies: {
+            // @ts-expect-error Package map dependencies map to package ID strings.
+            "@myorg/core": 1,
+        },
+    };
+
+    void missingUrl;
+    void invalidDependency;
 }
 
 // Undocumented monkeypatching definitions


### PR DESCRIPTION
This PR adds types for the experimental [package map](https://github.com/nodejs/node/pull/62239/) feature recently merged in Node.js. 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
