### PR TITLE
[svgcanvas] align TextMetrics and CanvasGradient with DOM types

### DIFF
--- a/types/svgcanvas/index.d.ts
+++ b/types/svgcanvas/index.d.ts
@@ -35,29 +35,20 @@ export interface C2SOptions {
 }
 
 /**
- * CanvasGradient for creating color gradients
- */
-export interface CanvasGradient {
-    /**
-     * Adds a color stop to the gradient
-     * @param offset - A number between 0 and 1
-     * @param color - A CSS color string
-     */
-    addColorStop(offset: number, color: string): void;
-}
-
-/**
  * CanvasPattern for creating pattern fills
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface CanvasPattern {}
 
 /**
- * TextMetrics - measurement results from measureText()
+ * @deprecated Use the global DOM CanvasGradient type instead.
  */
-export interface TextMetrics {
-    width: number;
-}
+export type CanvasGradient = globalThis.CanvasGradient;
+
+/**
+ * @deprecated Use the global DOM TextMetrics type instead.
+ */
+export type TextMetrics = globalThis.TextMetrics;
 
 /**
  * Context - implements most of CanvasRenderingContext2D API but generates SVG

--- a/types/svgcanvas/svgcanvas-tests.ts
+++ b/types/svgcanvas/svgcanvas-tests.ts
@@ -1,4 +1,4 @@
-import { C2SOptions, CanvasGradient, CanvasPattern, Context, Element } from "svgcanvas";
+import { Context, Element } from "svgcanvas";
 
 // Test Context construction
 // $ExpectType Context


### PR DESCRIPTION
The svgcanvas library's measureText() delegates directly to the underlying CanvasRenderingContext2D, which returns the full DOM TextMetrics object (not just { width: number }).

Replace the custom TextMetrics and CanvasGradient interfaces with @deprecated type aliases that point to the corresponding DOM types. This keeps the exported API surface stable for consumers while correcting the type definitions.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/zenozeng/svgcanvas/blob/master/context.js#L1007-L1009
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.