### PR TITLE
[@types/luxon] Fix DateTime#isValid typing to support type guards and narrowing

### DIFF
--- a/types/luxon/package.json
+++ b/types/luxon/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/luxon",
-    "version": "3.8.9999",
+    "version": "3.7.9999",
     "projects": [
         "https://github.com/moment/luxon#readme"
     ],

--- a/types/luxon/package.json
+++ b/types/luxon/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/luxon",
-    "version": "3.7.9999",
+    "version": "3.8.9999",
     "projects": [
         "https://github.com/moment/luxon#readme"
     ],

--- a/types/luxon/src/datetime.d.ts
+++ b/types/luxon/src/datetime.d.ts
@@ -954,7 +954,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
      * * The DateTime was created from invalid calendar information, such as the 13th month or February 30
      * * The DateTime was created by an operation on another invalid date
      */
-    get isValid(): IfValid<true, false, IsValid>;
+    get isValid(): IsValid;
 
     /**
      * Returns an error code if this DateTime is invalid, or null if the DateTime is valid

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -629,3 +629,17 @@ DateTime.fromISO("2021-09-13T07:52:27.697Z").toLocaleString({
     hour: "2-digit",
     day: "2-digit",
 });
+
+// Type Guard check
+function isValidDateTime(dt: DateTime): dt is DateTime<true> {
+    return dt.isValid;
+}
+
+function typeGuardCheck(dt: DateTime): void {
+    if (isValidDateTime(dt)) {
+        dt // $ExpectType DateTime<true>
+        return;
+    }
+
+    dt // $ExpectType DateTime<boolean>
+}

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -638,6 +638,7 @@ function isValidDateTime(dt: DateTime): dt is DateTime<true> {
 function typeGuardCheck(dt: DateTime): void {
     if (isValidDateTime(dt)) {
         dt // $ExpectType DateTime<true>
+        dt.toISO(); // $ExpectType string
         return;
     }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [URL](https://moment.github.io/luxon/api-docs/index.html#datetimeisvalid)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

## Summary

Change `DateTime#isValid` to return the generic validity parameter directly instead of using `IfValid`.

This enables TypeScript type guards and assertion functions to correctly narrow `DateTime<boolean>` to `DateTime<true>`.

It is unclear why `IfValid` prevents proper TypeScript control-flow narrowing, but using `IsValid` resolves the issue.

## Motivation

The current typing prevents proper narrowing with user-defined type guards.

Even when a type guard is applied, TypeScript does not preserve the result and instead narrows both branches to `DateTime<boolean>`, meaning the validity state encoded in the generic parameter is effectively lost during control-flow analysis.

This change restores proper interaction between `isValid` and the `DateTime<IsValid>` generic parameter.

## Tests

Added a type guard test confirming narrowing to `DateTime<true>`