### PR TITLE
[hotwired__turbo] Fix morph attribute `mutationType` values

### DIFF
--- a/types/hotwired__turbo/hotwired__turbo-tests.ts
+++ b/types/hotwired__turbo/hotwired__turbo-tests.ts
@@ -150,6 +150,13 @@ document.addEventListener("turbo:submit-end", function(event) {
     }
 });
 
+document.addEventListener("turbo:before-morph-attribute", function(event) {
+    // $ExpectType string
+    event.detail.attributeName;
+    // $ExpectType "update" | "remove"
+    event.detail.mutationType;
+});
+
 // Test start() function
 start();
 

--- a/types/hotwired__turbo/index.d.ts
+++ b/types/hotwired__turbo/index.d.ts
@@ -506,7 +506,7 @@ export type TurboMorphElementEvent = CustomEvent<{
 
 export type TurboBeforeMorphAttributeEvent = CustomEvent<{
     attributeName: string;
-    mutationType: "updated" | "removed";
+    mutationType: "update" | "remove";
 }>;
 
 export type TurboBeforeFrameMorphEvent = CustomEvent<{


### PR DESCRIPTION
Fixes the `mutationType` union on `turbo:before-morph-attribute`: Idiomorph emits `"update"` / `"remove"`, not `"updated"` / `"removed"`. Adds a test asserting the corrected literal types.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [idiomorph.js](https://github.com/bigskysoftware/idiomorph/blob/main/src/idiomorph.js#L22)
