### PR TITLE
feat(sharetribe-flex-sdk): update type definitions to v1.24

### DIFF
--- a/types/sharetribe-flex-sdk/index.d.ts
+++ b/types/sharetribe-flex-sdk/index.d.ts
@@ -545,6 +545,85 @@ export interface StripeCustomer {
 }
 
 /**
+ * Attributes shared by file resources
+ */
+export interface FileResourceAttributes {
+    filename?: string;
+    mimeType?: string;
+    size?: number;
+    contentType?: string;
+}
+
+/**
+ * A file owned by the current user
+ */
+export interface OwnFile {
+    id: UUID;
+    type: "ownFile";
+    attributes: FileResourceAttributes;
+}
+
+/**
+ * A file accessible to the current user (e.g. attached to a transaction)
+ */
+export interface File {
+    id: UUID;
+    type: "file";
+    attributes: FileResourceAttributes;
+}
+
+/**
+ * A presigned upload target returned by `sdk.fileUploads.create()`
+ */
+export interface FileUpload {
+    id: UUID;
+    type: "fileUpload";
+    attributes: {
+        url: string;
+        method: string;
+        headers: Record<string, string>;
+        contentType?: string;
+    };
+}
+
+/**
+ * A short-lived download URL for a file owned by the current user
+ */
+export interface OwnFileDownload {
+    id: UUID;
+    type: "ownFileDownload";
+    attributes: {
+        url: string;
+        method?: string;
+        headers?: Record<string, string>;
+        contentType?: string;
+    };
+}
+
+/**
+ * A short-lived download URL for a file accessible to the current user
+ */
+export interface FileDownload {
+    id: UUID;
+    type: "fileDownload";
+    attributes: {
+        url: string;
+        method?: string;
+        headers?: Record<string, string>;
+        contentType?: string;
+    };
+}
+
+/**
+ * File metadata extracted by `file.metadata()`, suitable for `sdk.ownFiles.create()`
+ */
+export interface FileMetadata {
+    name: string;
+    mimeType: string;
+    size: number;
+}
+
+/**
  * Common query parameters for GET requests
  */
 export interface BaseQueryParams {
@@ -1182,6 +1261,61 @@ export interface MarketplaceSdk {
         queryAssets: (params?: PaginationParams) => Promise<QueryResponse>;
     };
 
+    ownFiles: {
+        /**
+         * Register a file with the Marketplace API (first step of the upload flow)
+         */
+        create: (
+            params: { name: string; mimeType: string; size: number },
+            queryParams?: { expand?: boolean },
+            opts?: PerRequestOptions,
+        ) => Promise<MutationResponse<OwnFile>>;
+        /**
+         * Show a file owned by the current user
+         */
+        show: (params: { id: UUID | string } & BaseQueryParams) => Promise<ShowResponse<OwnFile>>;
+    };
+
+    files: {
+        /**
+         * Show a file accessible to the current user
+         */
+        show: (params: { id: UUID | string } & BaseQueryParams) => Promise<ShowResponse<File>>;
+    };
+
+    fileUploads: {
+        /**
+         * Request a presigned upload URL for a registered file
+         */
+        create: (
+            params: { fileId: UUID | string },
+            queryParams?: { expand?: boolean },
+            opts?: PerRequestOptions,
+        ) => Promise<MutationResponse<FileUpload>>;
+    };
+
+    ownFileDownloads: {
+        /**
+         * Request a short-lived download URL for a file owned by the current user
+         */
+        create: (
+            params: { fileId: UUID | string },
+            queryParams?: { expand?: boolean },
+            opts?: PerRequestOptions,
+        ) => Promise<MutationResponse<OwnFileDownload>>;
+    };
+
+    fileDownloads: {
+        /**
+         * Request a short-lived download URL for a file accessible to the current user
+         */
+        create: (
+            params: { fileId: UUID | string },
+            queryParams?: { expand?: boolean },
+            opts?: PerRequestOptions,
+        ) => Promise<MutationResponse<FileDownload>>;
+    };
+
     /**
      * Authentication methods
      */
@@ -1222,3 +1356,41 @@ export interface SdkConfig {
  * @returns Configured SDK instance
  */
 export function createInstance(config: SdkConfig): MarketplaceSdk;
+
+/**
+ * Query string utilities
+ */
+export namespace util {
+    /**
+     * Serialize an object into a Sharetribe query string fragment, e.g. `{ a: "foo", b: 150 }` => `"a:foo;b:150"`.
+     * Used for parameters such as `meta_*` query filters.
+     */
+    function objectQueryString(obj: Record<string, unknown>): string;
+    /**
+     * Serialize query parameters into a URL query string, handling Sharetribe types such as `UUID` and `LatLng`.
+     */
+    function queryString(params: Record<string, unknown>): string;
+}
+
+/**
+ * Helpers for the file upload flow
+ */
+export namespace file {
+    /**
+     * Extract the metadata needed for `sdk.ownFiles.create()` from a browser `File` object.
+     * @param file - A browser `File` object, e.g. from an `<input type="file">` element
+     */
+    function metadata(file: unknown): FileMetadata;
+    /**
+     * Upload a file directly to cloud storage using a presigned URL obtained from
+     * `sdk.fileUploads.create()`. This bypasses the SDK interceptor pipeline.
+     * @returns A promise that resolves when the upload is complete
+     */
+    function upload(params: {
+        url: string;
+        file: unknown;
+        method?: string;
+        headers?: Record<string, string>;
+        onUploadProgress?: (progressEvent: unknown) => void;
+    }): Promise<unknown>;
+}

--- a/types/sharetribe-flex-sdk/index.d.ts
+++ b/types/sharetribe-flex-sdk/index.d.ts
@@ -545,13 +545,14 @@ export interface StripeCustomer {
 }
 
 /**
- * Attributes shared by file resources
+ * Attributes of a file owned by the current user
  */
-export interface FileResourceAttributes {
-    filename?: string;
-    mimeType?: string;
-    size?: number;
-    contentType?: string;
+export interface OwnFileAttributes {
+    name: string;
+    size: number;
+    state: string;
+    createdAt: string;
+    stateUpdatedAt: string;
 }
 
 /**
@@ -560,7 +561,17 @@ export interface FileResourceAttributes {
 export interface OwnFile {
     id: UUID;
     type: "ownFile";
-    attributes: FileResourceAttributes;
+    attributes: OwnFileAttributes;
+}
+
+/**
+ * Attributes of a file accessible to the current user (e.g. attached to a transaction)
+ */
+export interface FileAttributes {
+    name: string;
+    size: number;
+    state: string;
+    deleted: boolean;
 }
 
 /**
@@ -569,7 +580,7 @@ export interface OwnFile {
 export interface File {
     id: UUID;
     type: "file";
-    attributes: FileResourceAttributes;
+    attributes: FileAttributes;
 }
 
 /**
@@ -579,10 +590,11 @@ export interface FileUpload {
     id: UUID;
     type: "fileUpload";
     attributes: {
+        fileId: UUID;
         url: string;
         method: string;
         headers: Record<string, string>;
-        contentType?: string;
+        expiresAt: string;
     };
 }
 
@@ -593,10 +605,9 @@ export interface OwnFileDownload {
     id: UUID;
     type: "ownFileDownload";
     attributes: {
+        fileId: UUID;
         url: string;
-        method?: string;
-        headers?: Record<string, string>;
-        contentType?: string;
+        expiresAt: string;
     };
 }
 
@@ -607,10 +618,9 @@ export interface FileDownload {
     id: UUID;
     type: "fileDownload";
     attributes: {
+        fileId: UUID;
         url: string;
-        method?: string;
-        headers?: Record<string, string>;
-        contentType?: string;
+        expiresAt: string;
     };
 }
 
@@ -1368,8 +1378,11 @@ export namespace util {
     function objectQueryString(obj: Record<string, unknown>): string;
     /**
      * Serialize query parameters into a URL query string, handling Sharetribe types such as `UUID` and `LatLng`.
+     * Parameters may be passed as a string, an object, or an array combining the two.
      */
-    function queryString(params: Record<string, unknown>): string;
+    function queryString(
+        params: string | Record<string, unknown> | Array<string | Record<string, unknown>>,
+    ): string;
 }
 
 /**

--- a/types/sharetribe-flex-sdk/index.d.ts
+++ b/types/sharetribe-flex-sdk/index.d.ts
@@ -545,12 +545,17 @@ export interface StripeCustomer {
 }
 
 /**
+ * Lifecycle state of a file resource
+ */
+export type FileState = "pendingUpload" | "pendingVerification" | "available" | "verificationFailed";
+
+/**
  * Attributes of a file owned by the current user
  */
 export interface OwnFileAttributes {
     name: string;
     size: number;
-    state: string;
+    state: FileState;
     createdAt: string;
     stateUpdatedAt: string;
 }
@@ -570,7 +575,7 @@ export interface OwnFile {
 export interface FileAttributes {
     name: string;
     size: number;
-    state: string;
+    state: FileState;
     deleted: boolean;
 }
 

--- a/types/sharetribe-flex-sdk/package.json
+++ b/types/sharetribe-flex-sdk/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/sharetribe-flex-sdk",
-    "version": "1.22.9999",
+    "version": "1.24.9999",
     "projects": [
         "https://github.com/sharetribe/flex-sdk-js"
     ],

--- a/types/sharetribe-flex-sdk/sharetribe-flex-sdk-tests.ts
+++ b/types/sharetribe-flex-sdk/sharetribe-flex-sdk-tests.ts
@@ -1,4 +1,13 @@
-import { createInstance, Marketplace, ShowResponse } from "sharetribe-flex-sdk";
+import {
+    createInstance,
+    file,
+    FileUpload,
+    Marketplace,
+    MutationResponse,
+    OwnFile,
+    ShowResponse,
+    util,
+} from "sharetribe-flex-sdk";
 
 const sdk = createInstance({ clientId: "client-id" });
 
@@ -11,3 +20,25 @@ sdk.assetByAlias({ path: "/assets", alias: "logo" }).then((result: { status?: nu
     const status: number | undefined = result.status;
     const data: unknown = result.data;
 });
+
+// File upload flow (added in flex-sdk 1.24)
+const meta = file.metadata("file-like-object");
+const fileName: string = meta.name;
+
+sdk.ownFiles.create({ name: meta.name, mimeType: meta.mimeType, size: meta.size }).then(
+    (response: MutationResponse<OwnFile>) => {
+        const fileId = response.data.data.id;
+        return sdk.fileUploads.create({ fileId }).then((uploadResponse: MutationResponse<FileUpload>) => {
+            const { method, url, headers } = uploadResponse.data.data.attributes;
+            return file.upload({ method, url, headers, file: "file-like-object" });
+        });
+    },
+);
+
+sdk.fileDownloads.create({ fileId: "a5d04285-07da-4fa0-b80b-ebabb8bac9e5" }).then(response => {
+    const downloadUrl: string = response.data.data.attributes.url;
+});
+
+// Query string utilities (added in flex-sdk 1.23)
+const qs: string = util.queryString({ ok: true });
+const oqs: string = util.objectQueryString({ a: "foo", b: 150 });


### PR DESCRIPTION
Updates `@types/sharetribe-flex-sdk` to match upstream [`sharetribe-flex-sdk`](https://github.com/sharetribe/flex-sdk-js) releases **v1.23** and **v1.24** (previously covered up to v1.22). I am a listed owner of this package.

### v1.23.0
- Add `util.queryString` for query parameter serialization
- Add `util.objectQueryString` (object query string fragments, e.g. `meta_*` filters)

### v1.24.0 — file uploads and downloads ([flex-sdk-js#205](https://github.com/sharetribe/flex-sdk-js/pull/205))
- New endpoints: `ownFiles.create`, `ownFiles.show`, `files.show`, `fileUploads.create`, `ownFileDownloads.create`, `fileDownloads.create`
- New file resource interfaces: `OwnFile`, `File`, `FileUpload`, `OwnFileDownload`, `FileDownload`, `FileMetadata`
- New `file` helper namespace: `file.metadata(file)` and `file.upload({ method, url, headers, file, onUploadProgress })`

Method parameters follow the SDK's bundled `docs/file-uploads-and-downloads.md`. Version bumped to `1.24.9999` and the test file exercises the new endpoints, helpers, and util functions.
