### PR TITLE
feat(sharetribe-flex-integration-sdk): update type definitions to v1.13

### DIFF
--- a/types/sharetribe-flex-integration-sdk/index.d.ts
+++ b/types/sharetribe-flex-integration-sdk/index.d.ts
@@ -241,17 +241,42 @@ export interface Message {
 }
 
 /**
+ * Lifecycle state of a file resource
+ */
+export type FileState = "pendingUpload" | "pendingVerification" | "available" | "verificationFailed";
+
+/**
+ * A single automatic verification check performed on a file (e.g. `{ type: "malwareScan", result: "success" }`)
+ */
+export interface FileVerificationCheck {
+    type: string;
+    result: string;
+}
+
+/**
  * File attributes
  */
 export interface FileAttributes {
     name: string;
     size: number;
-    state: string;
-    verificationChecks: unknown[];
-    requiredVerificationChecks: unknown[];
+    state: FileState;
+    verificationChecks: FileVerificationCheck[];
+    requiredVerificationChecks: string[];
     createdAt: string;
     stateUpdatedAt: string;
     deleted: boolean;
+}
+
+/**
+ * File relationships
+ */
+export interface FileRelationships {
+    owner: {
+        data: ResourceReference;
+    };
+    marketplace: {
+        data: ResourceReference;
+    };
 }
 
 /**
@@ -261,16 +286,17 @@ export interface File {
     id: UUID;
     type: "file";
     attributes: FileAttributes;
+    relationships?: FileRelationships;
 }
 
 /**
- * File attachment relationships
+ * File attachment relationships. The `message` relationship is only present when the file is attached to a message.
  */
 export interface FileAttachmentRelationships {
     file: {
         data: ResourceReference;
     };
-    message: {
+    message?: {
         data: ResourceReference;
     };
 }
@@ -282,7 +308,7 @@ export interface FileAttachment {
     id: UUID;
     type: "fileAttachment";
     attributes: {
-        scope: string;
+        scope: "public";
         deleted: boolean;
     };
     relationships: FileAttachmentRelationships;

--- a/types/sharetribe-flex-integration-sdk/index.d.ts
+++ b/types/sharetribe-flex-integration-sdk/index.d.ts
@@ -241,6 +241,36 @@ export interface Message {
 }
 
 /**
+ * File attributes
+ */
+export interface FileAttributes {
+    filename?: string;
+    mimeType?: string;
+    size?: number;
+    contentType?: string;
+}
+
+/**
+ * File resource
+ */
+export interface File {
+    id: UUID;
+    type: "file";
+    attributes: FileAttributes;
+}
+
+/**
+ * File attachment resource (links a file to a transaction message)
+ */
+export interface FileAttachment {
+    id: UUID;
+    type: "fileAttachment";
+    attributes: {
+        createdAt?: string;
+    };
+}
+
+/**
  * Event attributes
  */
 export interface EventAttributes {
@@ -527,6 +557,13 @@ export interface IntegrationSdk {
             },
             options?: PerRequestOptions,
         ) => Promise<MutationResponse<User>>;
+        /**
+         * Mark a user's email as verified. The email must match the user's primary email or pending email.
+         */
+        verifyEmail: (
+            params: { id: UUID | string; email: string },
+            options?: PerRequestOptions,
+        ) => Promise<MutationResponse<User>>;
     };
 
     listings: {
@@ -740,6 +777,33 @@ export interface IntegrationSdk {
          * Show a specific stock reservation
          */
         show: (params: { id: UUID | string } & BaseQueryParams) => Promise<ShowResponse<StockReservation>>;
+    };
+
+    messages: {
+        /**
+         * Query transaction messages
+         */
+        query: (
+            params?: { transactionId?: UUID | string } & PaginationParams & BaseQueryParams,
+        ) => Promise<QueryResponse<Message>>;
+    };
+
+    files: {
+        /**
+         * Query files
+         */
+        query: (
+            params?: { transactionId?: UUID | string } & PaginationParams & BaseQueryParams,
+        ) => Promise<QueryResponse<File>>;
+    };
+
+    fileAttachments: {
+        /**
+         * Query file attachments
+         */
+        query: (
+            params?: { transactionId?: UUID | string } & PaginationParams & BaseQueryParams,
+        ) => Promise<QueryResponse<FileAttachment>>;
     };
 
     /**

--- a/types/sharetribe-flex-integration-sdk/index.d.ts
+++ b/types/sharetribe-flex-integration-sdk/index.d.ts
@@ -244,10 +244,14 @@ export interface Message {
  * File attributes
  */
 export interface FileAttributes {
-    filename?: string;
-    mimeType?: string;
-    size?: number;
-    contentType?: string;
+    name: string;
+    size: number;
+    state: string;
+    verificationChecks: unknown[];
+    requiredVerificationChecks: unknown[];
+    createdAt: string;
+    stateUpdatedAt: string;
+    deleted: boolean;
 }
 
 /**
@@ -260,14 +264,28 @@ export interface File {
 }
 
 /**
+ * File attachment relationships
+ */
+export interface FileAttachmentRelationships {
+    file: {
+        data: ResourceReference;
+    };
+    message: {
+        data: ResourceReference;
+    };
+}
+
+/**
  * File attachment resource (links a file to a transaction message)
  */
 export interface FileAttachment {
     id: UUID;
     type: "fileAttachment";
     attributes: {
-        createdAt?: string;
+        scope: string;
+        deleted: boolean;
     };
+    relationships: FileAttachmentRelationships;
 }
 
 /**

--- a/types/sharetribe-flex-integration-sdk/index.d.ts
+++ b/types/sharetribe-flex-integration-sdk/index.d.ts
@@ -286,7 +286,7 @@ export interface File {
     id: UUID;
     type: "file";
     attributes: FileAttributes;
-    relationships?: FileRelationships;
+    relationships: FileRelationships;
 }
 
 /**
@@ -825,10 +825,16 @@ export interface IntegrationSdk {
 
     messages: {
         /**
-         * Query transaction messages
+         * Query messages. Either `transactionId` or `ids` must be provided.
          */
         query: (
-            params?: { transactionId?: UUID | string } & PaginationParams & BaseQueryParams,
+            params:
+                & (
+                    | { transactionId: UUID | string; ids?: Array<UUID | string> }
+                    | { transactionId?: UUID | string; ids: Array<UUID | string> }
+                )
+                & PaginationParams
+                & BaseQueryParams,
         ) => Promise<QueryResponse<Message>>;
     };
 
@@ -837,7 +843,16 @@ export interface IntegrationSdk {
          * Query files
          */
         query: (
-            params?: { transactionId?: UUID | string } & PaginationParams & BaseQueryParams,
+            params?:
+                & {
+                    ids?: Array<UUID | string>;
+                    messageId?: UUID | string;
+                    ownerId?: UUID | string;
+                    createdAtStart?: Date | string;
+                    createdAtEnd?: Date | string;
+                }
+                & PaginationParams
+                & BaseQueryParams,
         ) => Promise<QueryResponse<File>>;
     };
 
@@ -846,7 +861,14 @@ export interface IntegrationSdk {
          * Query file attachments
          */
         query: (
-            params?: { transactionId?: UUID | string } & PaginationParams & BaseQueryParams,
+            params?:
+                & {
+                    ids?: Array<UUID | string>;
+                    fileIds?: Array<UUID | string>;
+                    messageId?: UUID | string;
+                }
+                & PaginationParams
+                & BaseQueryParams,
         ) => Promise<QueryResponse<FileAttachment>>;
     };
 

--- a/types/sharetribe-flex-integration-sdk/package.json
+++ b/types/sharetribe-flex-integration-sdk/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/sharetribe-flex-integration-sdk",
-    "version": "1.11.9999",
+    "version": "1.13.9999",
     "projects": [
         "https://github.com/sharetribe/flex-integration-sdk-js"
     ],

--- a/types/sharetribe-flex-integration-sdk/sharetribe-flex-integration-sdk-tests.ts
+++ b/types/sharetribe-flex-integration-sdk/sharetribe-flex-integration-sdk-tests.ts
@@ -118,21 +118,39 @@ sdk.users.verifyEmail({
     const userId: string = response.data.data.id.uuid;
 });
 
-// Query transaction messages (added in integration-sdk 1.13)
+// Query messages by transaction or by ids (added in integration-sdk 1.13)
 sdk.messages.query({ transactionId: "transaction-id" }).then((response) => {
     const firstMessage = response.data.data[0];
     if (firstMessage) {
         const content: string = firstMessage.attributes.content;
     }
 });
-
-// Query files and file attachments (added in integration-sdk 1.13)
-sdk.files.query({ transactionId: "transaction-id" }).then((response) => {
+sdk.messages.query({ ids: ["message-id"], include: ["sender"] }).then((response) => {
     const totalPages: number = response.data.meta.totalPages;
 });
 
-sdk.fileAttachments.query({ transactionId: "transaction-id" }).then((response) => {
-    const attachments = response.data.data;
+// Query files with the supported filters (added in integration-sdk 1.13)
+sdk.files.query({
+    ownerId: "user-id",
+    messageId: "message-id",
+    ids: ["file-id"],
+    createdAtStart: new Date("2024-01-01T00:00:00.000Z"),
+    createdAtEnd: "2024-12-31T23:59:59.000Z",
+    include: ["owner"],
+}).then((response) => {
+    const firstFile = response.data.data[0];
+    if (firstFile) {
+        const state: string = firstFile.attributes.state;
+        const ownerRef: string = firstFile.relationships.owner.data.id.uuid;
+    }
+});
+
+// Query file attachments by message or file ids (added in integration-sdk 1.13)
+sdk.fileAttachments.query({ messageId: "message-id", fileIds: ["file-id"], include: ["file"] }).then((response) => {
+    const firstAttachment = response.data.data[0];
+    if (firstAttachment) {
+        const scope: "public" = firstAttachment.attributes.scope;
+    }
 });
 
 const rateLimiterConfig = util.prodQueryLimiterConfig;

--- a/types/sharetribe-flex-integration-sdk/sharetribe-flex-integration-sdk-tests.ts
+++ b/types/sharetribe-flex-integration-sdk/sharetribe-flex-integration-sdk-tests.ts
@@ -110,5 +110,30 @@ sdk.stockAdjustments.create({
     const adjustmentId: string = response.data.data.id.uuid;
 });
 
+// Mark a user's email as verified (added in integration-sdk 1.12)
+sdk.users.verifyEmail({
+    id: "user-id",
+    email: "test@example.com",
+}).then((response) => {
+    const userId: string = response.data.data.id.uuid;
+});
+
+// Query transaction messages (added in integration-sdk 1.13)
+sdk.messages.query({ transactionId: "transaction-id" }).then((response) => {
+    const firstMessage = response.data.data[0];
+    if (firstMessage) {
+        const content: string = firstMessage.attributes.content;
+    }
+});
+
+// Query files and file attachments (added in integration-sdk 1.13)
+sdk.files.query({ transactionId: "transaction-id" }).then((response) => {
+    const totalPages: number = response.data.meta.totalPages;
+});
+
+sdk.fileAttachments.query({ transactionId: "transaction-id" }).then((response) => {
+    const attachments = response.data.data;
+});
+
 const rateLimiterConfig = util.prodQueryLimiterConfig;
 const rateLimiter = util.createRateLimiter(rateLimiterConfig);


### PR DESCRIPTION
Updates `@types/sharetribe-flex-integration-sdk` to match upstream [`sharetribe-flex-integration-sdk`](https://github.com/sharetribe/flex-integration-sdk-js) releases **v1.12** and **v1.13** (previously covered up to v1.11). I am a listed owner of this package.

### v1.12.0
- Add `users.verifyEmail({ id, email })` ([flex-integration-sdk-js#74](https://github.com/sharetribe/flex-integration-sdk-js/pull/74))

### v1.13.0
- Add `messages.query` ([flex-integration-sdk-js#76](https://github.com/sharetribe/flex-integration-sdk-js/pull/76))
- Add `files.query` and `fileAttachments.query` ([flex-integration-sdk-js#75](https://github.com/sharetribe/flex-integration-sdk-js/pull/75))
- New resource interfaces: `File`, `FileAttachment`

Version bumped to `1.13.9999` and the test file exercises the new endpoints.
