### PR TITLE
node: swap diagnostics_channel ContextType/StoreType

### DIFF
--- a/types/node/diagnostics_channel.d.ts
+++ b/types/node/diagnostics_channel.d.ts
@@ -304,7 +304,7 @@ declare module "node:diagnostics_channel" {
             },
         ) => void;
     }
-    interface TracingChannelCollection<ContextType extends object, StoreType = ContextType> {
+    interface TracingChannelCollection<ContextType extends object = object, StoreType = ContextType> {
         start: Channel<ContextType, StoreType>;
         end: Channel<ContextType, StoreType>;
         asyncStart: Channel<ContextType, StoreType>;

--- a/types/node/diagnostics_channel.d.ts
+++ b/types/node/diagnostics_channel.d.ts
@@ -33,7 +33,10 @@ declare module "node:diagnostics_channel" {
      * @param name The channel name
      * @return The named channel object
      */
-    function channel(name: string | symbol): Channel;
+    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+    function channel<ContextType = any, StoreType = ContextType>(
+        name: string | symbol,
+    ): Channel<ContextType, StoreType>;
     type ChannelListener = (message: unknown, name: string | symbol) => void;
     /**
      * Register a message handler to subscribe to this channel. This message handler
@@ -96,12 +99,9 @@ declare module "node:diagnostics_channel" {
      * @param nameOrChannels Channel name or object containing all the `TracingChannel Channels`
      * @return Collection of channels to trace with
      */
-    function tracingChannel<
-        StoreType = unknown,
-        ContextType extends object = StoreType extends object ? StoreType : object,
-    >(
-        nameOrChannels: string | TracingChannelCollection<StoreType, ContextType>,
-    ): TracingChannel<StoreType, ContextType>;
+    function tracingChannel<ContextType extends object = object, StoreType = ContextType>(
+        nameOrChannels: string | TracingChannelCollection<ContextType, StoreType>,
+    ): TracingChannel<ContextType, StoreType>;
     /**
      * The class `Channel` represents an individual named channel within the data
      * pipeline. It is used to track subscribers and to publish messages when there
@@ -111,7 +111,7 @@ declare module "node:diagnostics_channel" {
      * with `new Channel(name)` is not supported.
      * @since v15.1.0, v14.17.0
      */
-    class Channel<StoreType = unknown, ContextType = StoreType> {
+    class Channel<ContextType = any, StoreType = ContextType> {
         readonly name: string | symbol;
         /**
          * Check if there are active subscribers to this channel. This is helpful if
@@ -304,12 +304,12 @@ declare module "node:diagnostics_channel" {
             },
         ) => void;
     }
-    interface TracingChannelCollection<StoreType = unknown, ContextType = StoreType> {
-        start: Channel<StoreType, ContextType>;
-        end: Channel<StoreType, ContextType>;
-        asyncStart: Channel<StoreType, ContextType>;
-        asyncEnd: Channel<StoreType, ContextType>;
-        error: Channel<StoreType, ContextType>;
+    interface TracingChannelCollection<ContextType extends object, StoreType = ContextType> {
+        start: Channel<ContextType, StoreType>;
+        end: Channel<ContextType, StoreType>;
+        asyncStart: Channel<ContextType, StoreType>;
+        asyncEnd: Channel<ContextType, StoreType>;
+        error: Channel<ContextType, StoreType>;
     }
     /**
      * The class `TracingChannel` is a collection of `TracingChannel Channels` which
@@ -320,12 +320,9 @@ declare module "node:diagnostics_channel" {
      * @since v19.9.0
      * @experimental
      */
-    class TracingChannel<StoreType = unknown, ContextType extends object = {}> implements TracingChannelCollection {
-        start: Channel<StoreType, ContextType>;
-        end: Channel<StoreType, ContextType>;
-        asyncStart: Channel<StoreType, ContextType>;
-        asyncEnd: Channel<StoreType, ContextType>;
-        error: Channel<StoreType, ContextType>;
+    interface TracingChannel<ContextType extends object = object, StoreType = ContextType>
+        extends TracingChannelCollection<ContextType, StoreType>
+    {
         /**
          * Helper to subscribe a collection of functions to the corresponding channels.
          * This is the same as calling `channel.subscribe(onMessage)` on each channel

--- a/types/node/node-tests/diagnostics_channel.ts
+++ b/types/node/node-tests/diagnostics_channel.ts
@@ -25,22 +25,21 @@ unsubscribe(Symbol.for("test-symbol"), listener);
 const hasSubs = hasSubscribers("test");
 
 {
-    const channelsByName = tracingChannel<number, { requestId: number }>("my-channel");
-    channelsByName.start; // $ExpectType Channel<number, { requestId: number; }>
+    const channelsByName = tracingChannel<{ requestId: number }, number>("my-channel");
+    channelsByName.start; // $ExpectType Channel<{ requestId: number }, number>
 
-    type MyChannel = Channel<number, { requestId: number }>;
     const channelsByCollection = tracingChannel({
-        start: channel("tracing:my-channel:start") as MyChannel,
-        end: channel("tracing:my-channel:end") as MyChannel,
-        asyncStart: channel("tracing:my-channel:asyncStart") as MyChannel,
-        asyncEnd: channel("tracing:my-channel:asyncEnd") as MyChannel,
-        error: channel("tracing:my-channel:error") as MyChannel,
+        start: channel<{ requestId: number }, number>("tracing:my-channel:start"),
+        end: channel<{ requestId: number }, number>("tracing:my-channel:end"),
+        asyncStart: channel<{ requestId: number }, number>("tracing:my-channel:asyncStart"),
+        asyncEnd: channel<{ requestId: number }, number>("tracing:my-channel:asyncEnd"),
+        error: channel<{ requestId: number }, number>("tracing:my-channel:error"),
     });
-    channelsByCollection.start; // $ExpectType Channel<number, { requestId: number; }>
+    channelsByCollection.start; // $ExpectType Channel<{ requestId: number }, number>
 }
 
 {
-    const channels = tracingChannel<number, { requestId: number }>("my-channel");
+    const channels = tracingChannel<{ requestId: number }, number>("my-channel");
     const store = new AsyncLocalStorage<number>();
 
     channels.start.bindStore(store);


### PR DESCRIPTION
Thirteenth-hour breaking change proposal for v26. I had been trying to hack around this for the next round of diagnostics\_channel changes in v26.1, but the more I've considered it, the more this seems to be a change that really should be made.

A diagnostics channel has two "typey" concepts.
- The first is the _context_, which is the persistent variable that gets passed with a diagnostics event. This is the only type that is apparent for most users.
- The second is how context data actually gets _stored_ in the underlying AsyncLocalStorage. By default, and in the majority of real-world usage, diagnostics channels store the context variable itself, and in these cases the store type is identical to the context type. However, channels do support an optional "transform" callback when manually binding an underlying store, which transforms the context variable into a different variable to be stored, in which case the two types differ.

TL;DR: the context type is the "primary" type of a channel, and it's the context type that determines the default store type, not the other way around. Most tracing consumers will never see the store type in practice, as they won't interact directly with the underlying store.

At the moment, we type this relationship in reverse:
```ts
class Channel<StoreType = unknown, ContextType = StoreType> { ... }
```

In the default case and in the majority of real-world cases, there is no transform step and these two types are the same. However, it's the _context_ type which matters to subscribers. It's also the one which is constrained depending on the functionality of the channel; the store type, by contrast, is never constrained, as the local storage can store absolutely anything that a transform callback outputs.

All of this is no great drama when the context type is unconstrained, but becomes a problem when it needs to be, such as for TracingChannel and the newer channel types being introduced in v26. At the moment, we have the following:
```ts
class TracingChannel<StoreType = unknown, ContextType extends object = {}> { ... }
```

ContextType and StoreType should be defaulting to the same type here. However, because the constrained type parameter is in the wrong position, the relationship doesn't work. `TracingChannel<{ foo: 'bar' }>` should result in the context type being `{ foo: 'bar' }`, but it ends up defaulting to `{}`. In order to type-annotate a tracing channel, users have to manually provide a StoreType, despite this type being meaningless in almost all usage cases.

The obvious solution is to swap these type parameters around, reflecting their implementation semantics and making it far easier to type these correctly while honouring any required context constraints.
```ts
class TracingChannel<ContextType extends object = object, StoreType = ContextType> { ... }
```

As mentioned, the vast majority of real-world uses should already have the two type parameters being identical anyway, which this change will not affect. However, this is a breaking change in cases where users are using custom storage behaviour with the transform feature, which is rare but obviously does exist in the wild.