### PR TITLE
[hotwired__turbo] Fix missing stream types

### DIFF
--- a/types/hotwired__turbo/hotwired__turbo-tests.ts
+++ b/types/hotwired__turbo/hotwired__turbo-tests.ts
@@ -16,6 +16,8 @@ import {
     StreamMessage,
     StreamSource,
     TurboHistory,
+    TurboStreamAction,
+    TurboStreamActions,
     Visit,
     visit,
     VisitOptions,
@@ -101,6 +103,19 @@ StreamActions.log = function() {
     this;
     console.log(this.getAttribute("message"));
 };
+
+// Test TurboStreamActions / TurboStreamAction exports
+// $ExpectType TurboStreamActions
+StreamActions;
+
+const customStreamAction: TurboStreamAction = function() {
+    // $ExpectType StreamElement
+    this;
+};
+StreamActions.custom = customStreamAction;
+
+const allStreamActions: TurboStreamActions = StreamActions;
+allStreamActions.log;
 
 document.addEventListener("turbo:before-fetch-request", function(event) {
     // $ExpectType FetchRequestHeaders

--- a/types/hotwired__turbo/hotwired__turbo-tests.ts
+++ b/types/hotwired__turbo/hotwired__turbo-tests.ts
@@ -272,6 +272,12 @@ turboStream.templateElement = document.createElement("template");
 // @ts-expect-error - templateContent is readonly
 turboStream.templateContent = document.createDocumentFragment();
 
+// Test StreamElement.targetElements
+// $ExpectType Element[]
+turboStream.targetElements;
+// @ts-expect-error - targetElements is readonly
+turboStream.targetElements = [];
+
 const eventSource = new EventSource("https://example.com/stream");
 const webSocket = new WebSocket("wss://example.com/stream");
 

--- a/types/hotwired__turbo/index.d.ts
+++ b/types/hotwired__turbo/index.d.ts
@@ -306,9 +306,19 @@ export interface TurboSession {
     readonly restorationIdentifier: string;
 }
 
-export const StreamActions: {
-    [action: string]: (this: StreamElement) => void;
-};
+/**
+ * A stream action callback. Invoked with the matched `StreamElement` as
+ * `this`, allowing access to its attributes and target elements.
+ */
+export type TurboStreamAction = (this: StreamElement) => void;
+
+/**
+ * A map of action names to their {@link TurboStreamAction} callbacks, as
+ * used by {@link StreamActions}.
+ */
+export type TurboStreamActions = Record<string, TurboStreamAction>;
+
+export const StreamActions: TurboStreamActions;
 
 export type Action = "advance" | "replace" | "restore";
 export interface VisitOptions {
@@ -464,9 +474,7 @@ export interface TurboGlobal {
     navigator: Navigator;
     cache: Cache;
     config: TurboConfig;
-    StreamActions: {
-        [action: string]: (this: StreamElement) => void;
-    };
+    StreamActions: TurboStreamActions;
 }
 
 declare global {

--- a/types/hotwired__turbo/index.d.ts
+++ b/types/hotwired__turbo/index.d.ts
@@ -51,6 +51,13 @@ export class StreamElement extends HTMLElement {
      * Gets a cloned copy of the template's content.
      */
     readonly templateContent: DocumentFragment;
+
+    /**
+     * Gets the list of elements the stream action will be applied to,
+     * resolved from the `target` (an element ID) or `targets` (a CSS
+     * selector) attribute.
+     */
+    readonly targetElements: Element[];
 }
 
 export class StreamSourceElement extends HTMLElement {


### PR DESCRIPTION
Two small gaps in `@types/hotwired__turbo` surfaced while building types for a downstream PR ([marcoroth/turbo_power#332](https://github.com/marcoroth/turbo_power/pull/332)), worked around locally and worth upstreaming here.

### 1. `StreamElement.targetElements`

`StreamElement` exposes a `targetElements` getter that resolves the elements targeted by the `target` (element ID) or `targets` (CSS selector) attribute, but it was missing from the definitions. Added as `readonly targetElements: Element[]`.

Source: [`stream_element.js`](https://github.com/hotwired/turbo/blob/main/src/elements/stream_element.js) — the `targetElements` getter returns `targetElementsById` / `targetElementsByQuery` (both `Element[]`).

### 2. `TurboStreamAction` / `TurboStreamActions` exports

There was no named type for a stream action callback or for the `StreamActions` registry — consumers had to redeclare the inline `(this: StreamElement) => void` signature. Added:

```ts
export type TurboStreamAction = (this: StreamElement) => void;
export type TurboStreamActions = Record<string, TurboStreamAction>;
```

and used them to type both the `StreamActions` named export and `Turbo.StreamActions`.

Source: [`stream_actions.js`](https://github.com/hotwired/turbo/blob/main/src/core/streams/stream_actions.js) — `StreamActions` is an object of action callbacks invoked with the `StreamElement` as `this`.

Each fix is a separate commit with matching test cases added to `hotwired__turbo-tests.ts`.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [hotwired/turbo `src/elements/stream_element.js`](https://github.com/hotwired/turbo/blob/main/src/elements/stream_element.js) and [`src/core/streams/stream_actions.js`](https://github.com/hotwired/turbo/blob/main/src/core/streams/stream_actions.js)
