### PR TITLE
[sharedb] bump to v6

### DIFF
--- a/types/sharedb/package.json
+++ b/types/sharedb/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/sharedb",
-    "version": "5.1.9999",
+    "version": "6.0.9999",
     "projects": [
         "https://github.com/share/sharedb"
     ],


### PR DESCRIPTION
The [major version bump][1] was just dropping support for Node.js v20 - no API changes.

[1]: https://github.com/share/sharedb/releases/tag/v6.0.0

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
