### PR TITLE
[sinon] Add restoreObject and bump to v22

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -1424,6 +1424,12 @@ declare namespace Sinon {
     interface SinonApi {
         expectation: SinonExpectationStatic;
 
+        /**
+         * Restores all methods of an object and returns the restored object.
+         * Throws an error if the object contains no restorable methods.
+         */
+        restoreObject<T extends object>(object: T): T;
+
         clock: {
             create(now: number | Date): FakeTimers.Clock;
         };

--- a/types/sinon/package.json
+++ b/types/sinon/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/sinon",
-    "version": "21.0.9999",
+    "version": "22.0.9999",
     "projects": [
         "https://sinonjs.org"
     ],

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -887,6 +887,18 @@ function testSetFormatter() {
     sinon.setFormatter((...args) => JSON.stringify(args));
 }
 
+function testRestoreObject() {
+    const obj = {
+        foo: () => {},
+    };
+    sinon.spy(obj, "foo");
+    const restored = sinon.restoreObject(obj); // $ExpectType { foo: () => void; }
+    restored.foo();
+
+    // @ts-expect-error
+    sinon.restoreObject(undefined);
+}
+
 async function testPromises() {
     const promise = sinon.promise();
     await promise.resolve(123);


### PR DESCRIPTION
Sinon v22 adds the top-level restoreObject(object) utility, which restores all sinon-wrapped methods on an object and returns it. Add the declaration, a test, and bump the version to 22.0.9999.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://sinonjs.org/concepts/utils#sinon-restoreobject-object
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

