### PR TITLE
google-apps-scripts: Add support for Tables to Sheets API.

### DIFF
--- a/types/google-apps-script/apis/sheets_v4.d.ts
+++ b/types/google-apps-script/apis/sheets_v4.d.ts
@@ -768,6 +768,7 @@ declare namespace GoogleAppsScript {
             }
             interface GetSpreadsheetByDataFilterRequest {
                 dataFilters?: Sheets.Schema.DataFilter[] | undefined;
+                excludeTablesInBandedRanges?: boolean | undefined;
                 includeGridData?: boolean | undefined;
             }
             interface GradientRule {

--- a/types/google-apps-script/apis/sheets_v4.d.ts
+++ b/types/google-apps-script/apis/sheets_v4.d.ts
@@ -226,6 +226,11 @@ declare namespace GoogleAppsScript {
                     resource: Schema.GetSpreadsheetByDataFilterRequest,
                     spreadsheetId: string,
                 ): Sheets.Schema.Spreadsheet;
+                getByDataFilter(
+                    resource: Schema.GetSpreadsheetByDataFilterRequest,
+                    spreadsheetId: string,
+                    optionalArgs: object,
+                ): Sheets.Schema.Spreadsheet;
             }
         }
         namespace Schema {
@@ -275,10 +280,17 @@ declare namespace GoogleAppsScript {
             interface AddSheetResponse {
                 properties?: Sheets.Schema.SheetProperties | undefined;
             }
+            interface AddTableRequest {
+                table?: Sheets.Schema.Table | undefined;
+            }
+            interface AddTableResponse {
+                table?: Sheets.Schema.Table | undefined;
+            }
             interface AppendCellsRequest {
                 fields?: string | undefined;
                 rows?: Sheets.Schema.RowData[] | undefined;
                 sheetId?: number | undefined;
+                tableId?: string | undefined;
             }
             interface AppendDimensionRequest {
                 dimension?: string | undefined;
@@ -352,6 +364,7 @@ declare namespace GoogleAppsScript {
                 criteria?: object | undefined;
                 range?: Sheets.Schema.GridRange | undefined;
                 sortSpecs?: Sheets.Schema.SortSpec[] | undefined;
+                tableId?: string | undefined;
             }
             interface BatchClearValuesByDataFilterRequest {
                 dataFilters?: Sheets.Schema.DataFilter[] | undefined;
@@ -637,6 +650,9 @@ declare namespace GoogleAppsScript {
             interface DeleteSheetRequest {
                 sheetId?: number | undefined;
             }
+            interface DeleteTableRequest {
+                tableId?: string | undefined;
+            }
             interface DeveloperMetadata {
                 location?: Sheets.Schema.DeveloperMetadataLocation | undefined;
                 metadataId?: number | undefined;
@@ -729,6 +745,7 @@ declare namespace GoogleAppsScript {
                 namedRangeId?: string | undefined;
                 range?: Sheets.Schema.GridRange | undefined;
                 sortSpecs?: Sheets.Schema.SortSpec[] | undefined;
+                tableId?: string | undefined;
                 title?: string | undefined;
             }
             interface FindReplaceRequest {
@@ -940,6 +957,7 @@ declare namespace GoogleAppsScript {
                 protectedRangeId?: number | undefined;
                 range?: Sheets.Schema.GridRange | undefined;
                 requestingUserCanEdit?: boolean | undefined;
+                tableId?: string | undefined;
                 unprotectedRanges?: Sheets.Schema.GridRange[] | undefined;
                 warningOnly?: boolean | undefined;
             }
@@ -960,6 +978,7 @@ declare namespace GoogleAppsScript {
                 addNamedRange?: Sheets.Schema.AddNamedRangeRequest | undefined;
                 addProtectedRange?: Sheets.Schema.AddProtectedRangeRequest | undefined;
                 addSheet?: Sheets.Schema.AddSheetRequest | undefined;
+                addTable?: Sheets.Schema.AddTableRequest | undefined;
                 appendCells?: Sheets.Schema.AppendCellsRequest | undefined;
                 appendDimension?: Sheets.Schema.AppendDimensionRequest | undefined;
                 autoFill?: Sheets.Schema.AutoFillRequest | undefined;
@@ -979,6 +998,7 @@ declare namespace GoogleAppsScript {
                 deleteProtectedRange?: Sheets.Schema.DeleteProtectedRangeRequest | undefined;
                 deleteRange?: Sheets.Schema.DeleteRangeRequest | undefined;
                 deleteSheet?: Sheets.Schema.DeleteSheetRequest | undefined;
+                deleteTable?: Sheets.Schema.DeleteTableRequest | undefined;
                 duplicateFilterView?: Sheets.Schema.DuplicateFilterViewRequest | undefined;
                 duplicateSheet?: Sheets.Schema.DuplicateSheetRequest | undefined;
                 findReplace?: Sheets.Schema.FindReplaceRequest | undefined;
@@ -1008,6 +1028,7 @@ declare namespace GoogleAppsScript {
                 updateProtectedRange?: Sheets.Schema.UpdateProtectedRangeRequest | undefined;
                 updateSheetProperties?: Sheets.Schema.UpdateSheetPropertiesRequest | undefined;
                 updateSpreadsheetProperties?: Sheets.Schema.UpdateSpreadsheetPropertiesRequest | undefined;
+                updateTable?: Sheets.Schema.UpdateTableRequest | undefined;
             }
             interface Response {
                 addBanding?: Sheets.Schema.AddBandingResponse | undefined;
@@ -1017,6 +1038,7 @@ declare namespace GoogleAppsScript {
                 addNamedRange?: Sheets.Schema.AddNamedRangeResponse | undefined;
                 addProtectedRange?: Sheets.Schema.AddProtectedRangeResponse | undefined;
                 addSheet?: Sheets.Schema.AddSheetResponse | undefined;
+                addTable?: Sheets.Schema.AddTableResponse | undefined;
                 createDeveloperMetadata?: Sheets.Schema.CreateDeveloperMetadataResponse | undefined;
                 deleteConditionalFormatRule?: Sheets.Schema.DeleteConditionalFormatRuleResponse | undefined;
                 deleteDeveloperMetadata?: Sheets.Schema.DeleteDeveloperMetadataResponse | undefined;
@@ -1057,6 +1079,7 @@ declare namespace GoogleAppsScript {
                 properties?: Sheets.Schema.SheetProperties | undefined;
                 protectedRanges?: Sheets.Schema.ProtectedRange[] | undefined;
                 rowGroups?: Sheets.Schema.DimensionGroup[] | undefined;
+                tables?: Sheets.Schema.Table[] | undefined;
             }
             interface SheetProperties {
                 gridProperties?: Sheets.Schema.GridProperties | undefined;
@@ -1100,6 +1123,28 @@ declare namespace GoogleAppsScript {
                 locale?: string | undefined;
                 timeZone?: string | undefined;
                 title?: string | undefined;
+            }
+            interface Table {
+                columnProperties?: Sheets.Schema.TableColumnProperties[] | undefined;
+                name?: string | undefined;
+                range?: Sheets.Schema.GridRange | undefined;
+                rowsProperties?: Sheets.Schema.TableRowsProperties | undefined;
+                tableId?: string | undefined;
+            }
+            interface TableColumnDataValidationRule {
+                condition?: Sheets.Schema.BooleanCondition | undefined;
+            }
+            interface TableColumnProperties {
+                columnIndex?: number | undefined;
+                columnName?: string | undefined;
+                columnType?: string | undefined;
+                dataValidationRule?: Sheets.Schema.TableColumnDataValidationRule | undefined;
+            }
+            interface TableRowsProperties {
+                firstBandColorStyle?: Sheets.Schema.ColorStyle | undefined;
+                footerColorStyle?: Sheets.Schema.ColorStyle | undefined;
+                headerColorStyle?: Sheets.Schema.ColorStyle | undefined;
+                secondBandColorStyle?: Sheets.Schema.ColorStyle | undefined;
             }
             interface TextFormat {
                 bold?: boolean | undefined;
@@ -1235,6 +1280,10 @@ declare namespace GoogleAppsScript {
                 fields?: string | undefined;
                 properties?: Sheets.Schema.SpreadsheetProperties | undefined;
             }
+            interface UpdateTableRequest {
+                fields?: string | undefined;
+                table?: Sheets.Schema.Table | undefined;
+            }
             interface UpdateValuesByDataFilterResponse {
                 dataFilter?: Sheets.Schema.DataFilter | undefined;
                 updatedCells?: number | undefined;
@@ -1305,6 +1354,8 @@ declare namespace GoogleAppsScript {
         newAddProtectedRangeRequest(): Sheets.Schema.AddProtectedRangeRequest;
         // Create a new instance of AddSheetRequest
         newAddSheetRequest(): Sheets.Schema.AddSheetRequest;
+        // Create a new instance of AddTableRequest
+        newAddTableRequest(): Sheets.Schema.AddTableRequest;
         // Create a new instance of AppendCellsRequest
         newAppendCellsRequest(): Sheets.Schema.AppendCellsRequest;
         // Create a new instance of AppendDimensionRequest
@@ -1417,6 +1468,8 @@ declare namespace GoogleAppsScript {
         newDeleteRangeRequest(): Sheets.Schema.DeleteRangeRequest;
         // Create a new instance of DeleteSheetRequest
         newDeleteSheetRequest(): Sheets.Schema.DeleteSheetRequest;
+        // Create a new instance of DeleteTableRequest
+        newDeleteTableRequest(): Sheets.Schema.DeleteTableRequest;
         // Create a new instance of DeveloperMetadata
         newDeveloperMetadata(): Sheets.Schema.DeveloperMetadata;
         // Create a new instance of DeveloperMetadataLocation
@@ -1539,6 +1592,14 @@ declare namespace GoogleAppsScript {
         newSpreadsheet(): Sheets.Schema.Spreadsheet;
         // Create a new instance of SpreadsheetProperties
         newSpreadsheetProperties(): Sheets.Schema.SpreadsheetProperties;
+        // Create a new instance of Table
+        newTable(): Sheets.Schema.Table;
+        // Create a new instance of TableColumnDataValidationRule
+        newTableColumnDataValidationRule(): Sheets.Schema.TableColumnDataValidationRule;
+        // Create a new instance of TableColumnProperties
+        newTableColumnProperties(): Sheets.Schema.TableColumnProperties;
+        // Create a new instance of TableRowsProperties
+        newTableRowsProperties(): Sheets.Schema.TableRowsProperties;
         // Create a new instance of TextFormat
         newTextFormat(): Sheets.Schema.TextFormat;
         // Create a new instance of TextFormatRun
@@ -1583,6 +1644,8 @@ declare namespace GoogleAppsScript {
         newUpdateSheetPropertiesRequest(): Sheets.Schema.UpdateSheetPropertiesRequest;
         // Create a new instance of UpdateSpreadsheetPropertiesRequest
         newUpdateSpreadsheetPropertiesRequest(): Sheets.Schema.UpdateSpreadsheetPropertiesRequest;
+        // Create a new instance of UpdateTableRequest
+        newUpdateTableRequest(): Sheets.Schema.UpdateTableRequest;
         // Create a new instance of ValueRange
         newValueRange(): Sheets.Schema.ValueRange;
         // Create a new instance of WaterfallChartColumnStyle

--- a/types/google-apps-script/test/google-apps-script-apis-tests.ts
+++ b/types/google-apps-script/test/google-apps-script-apis-tests.ts
@@ -60,6 +60,128 @@ function testSheets() {
     const spreadsheets = sheets.Spreadsheets;
     // $ExpectType Spreadsheet
     const create = spreadsheets.create({});
+    // $ExpectType Spreadsheet
+    const get1 = Sheets.Spreadsheets.get("spreeadsheet_id");
+    // $ExpectType Spreadsheet
+    const get2 = Sheets.Spreadsheets.get("spreeadsheet_id", {});
+    // $ExpectType Spreadsheet
+    const getByDataFilter1 = Sheets.Spreadsheets.getByDataFilter(
+        Sheets.newGetSpreadsheetByDataFilterRequest(),
+        "spreeadsheet_id",
+    );
+    // $ExpectType Spreadsheet
+    const getByDataFilter2 = Sheets.Spreadsheets.getByDataFilter(
+        Sheets.newGetSpreadsheetByDataFilterRequest(),
+        "spreeadsheet_id",
+        {},
+    );
+}
+
+function testSheetShallow() {
+    if (!Sheets) return;
+    // $ExpectType Spreadsheet
+    const spreadsheet = Sheets.Spreadsheets.get("spreeadsheet_id");
+    // $ExpectType Sheet
+    const sheet = spreadsheet.sheets![0]!;
+    // $ExpectType BandedRange[];
+    const bandedRanges = sheet.bandedRanges!;
+    // $ExpectType BasicFilter;
+    const basicFilter = sheet.basicFilter!;
+    // $ExpectType EmbeddedChart[]
+    const charts = sheet.charts!;
+    // $ExpectType DimensionGroup[]
+    const columnGroups = sheet.columnGroups!;
+    // $ExpectType ConditionalFormatRule[]
+    const conditionalFormats = sheet.conditionalFormats!;
+    // $ExpectType GridData[]
+    const data = sheet.data!;
+    // $ExpectType DeveloperMetadata[]
+    const developerMetadata = sheet.developerMetadata!;
+    // $ExpectType FilterView[]
+    const filterViews = sheet.filterViews!;
+    // $ExpectType GridRange[]
+    const merges = sheet.merges!;
+    // $ExpectType SheetProperties
+    const properties = sheet.properties!;
+    // $ExpectType ProtectedRange[]
+    const protectedRanges = sheet.protectedRanges!;
+    // $ExpectType DimensionGroup[]
+    const rowGroups = sheet.rowGroups!;
+    // TODO: ExpectType Slicer[] const slicers = sheet.slicers!;
+    // $ExpectType Table[]
+    const tables = sheet.tables!;
+}
+
+function testSheetsTables() {
+    if (!Sheets) return;
+    // $ExpectType AddTableRequest
+    const addTableReq = Sheets.newAddTableRequest();
+    // $ExpectType DeleteTableRequest
+    const deleteTableReq = Sheets.newDeleteTableRequest();
+    // $ExpectType Table
+    const table = Sheets.newTable();
+    // $ExpectType TableColumnDataValidationRule
+    const tableColumnDataValidationRule = Sheets.newTableColumnDataValidationRule();
+    // $ExpectType TableColumnProperties
+    const tableColumnProperties = Sheets.newTableColumnProperties();
+    // $ExpectType TableRowsProperties
+    const tableRowsProperties = Sheets.newTableRowsProperties();
+    // $ExpectType UpdateTableRequest
+    const updateTableReq = Sheets.newUpdateTableRequest();
+
+    // Test Table interface
+    tableColumnDataValidationRule.condition = { "values": [{ "userEnteredValue": "option1" }] };
+    tableColumnProperties.columnIndex = 1;
+    tableColumnProperties.columnName = "Col1";
+    tableColumnProperties.columnType = "ONE_OF_LIST";
+    tableColumnProperties.dataValidationRule = tableColumnDataValidationRule;
+    tableRowsProperties.firstBandColorStyle = { themeColor: "blue" };
+    tableRowsProperties.footerColorStyle = { themeColor: "cyan" };
+    tableRowsProperties.headerColorStyle = { themeColor: "magenta" };
+    tableRowsProperties.secondBandColorStyle = { themeColor: "mauve" };
+    table.columnProperties = [tableColumnProperties];
+    table.name = "Table1";
+    table.range = {
+        endColumnIndex: 3,
+        endRowIndex: 5,
+        sheetId: 1234,
+        startColumnIndex: 1,
+        startRowIndex: 1,
+    };
+    table.rowsProperties = tableRowsProperties;
+    table.tableId = "1729";
+
+    // Test table batch requests and response
+    const batchResp = Sheets.Spreadsheets.batchUpdate(
+        {
+            requests: [
+                {
+                    addTable: addTableReq,
+                },
+                {
+                    deleteTable: deleteTableReq,
+                },
+                {
+                    updateTable: updateTableReq,
+                },
+            ],
+        },
+        "spreadsheet_id",
+    );
+    // $ExpectType AddTableResponse
+    const addTableResp = batchResp.replies![0].addTable!;
+
+    // Test tableId in various types
+    // $ExpectType string
+    const tableId1 = Sheets.newAppendCellsRequest().tableId!;
+    // $ExpectType string
+    const tableId2 = Sheets.newBasicFilter().tableId!;
+    // $ExpectType string
+    const tableId3 = Sheets.newFilterView().tableId!;
+    // $ExpectType string
+    const tableId4 = Sheets.newProtectedRange().tableId!;
+    // $ExpectType string
+    const tableId5 = Sheets.newFilterView().tableId!;
 }
 
 function testSlides() {

--- a/types/google-apps-script/test/google-apps-script-apis-tests.ts
+++ b/types/google-apps-script/test/google-apps-script-apis-tests.ts
@@ -182,6 +182,10 @@ function testSheetsTables() {
     const tableId4 = Sheets.newProtectedRange().tableId!;
     // $ExpectType string
     const tableId5 = Sheets.newFilterView().tableId!;
+
+    // Test excludeTablesInBandedRanges field in one type
+    // $ExpectType boolean
+    const excludeTablesInBandedRanges = Sheets.newGetSpreadsheetByDataFilterRequest().excludeTablesInBandedRanges!;
 }
 
 function testSlides() {


### PR DESCRIPTION
Also, add `optionalArgs` variant to `Sheets.Spreadsheets.getByDataFilter` method.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x]  [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
  - Added test covering the changed code. Not too confident in the approach I took. Also, manually tested that code exercising the new and modified definitions ran correctly after transpilation.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/googleapis/google-api-nodejs-client/blob/main/src/apis/sheets/v4.ts
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
  - Not applicable -- existing `google-apps-script/apis/sheets_v4.d.ts` coverage of the full API is incomplete; this PR just fills in one gap. 

