### PR TITLE
[chrome] add missing 'input' permission for ChromeOS

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -9182,6 +9182,7 @@ declare namespace chrome {
             | "identity"
             | "identity.email"
             | "idle"
+            | "input"
             | "loginState"
             | "management"
             | "nativeMessaging"


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/api/input/ime#permissions
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

> You must declare the "input" permission in the [extension manifest](https://developer.chrome.com/docs/extensions/reference/manifest) to use the input.ime API.