### PR TITLE
[safie-sdk] Update to v1.9

### DIFF
--- a/types/safie-sdk/index.d.ts
+++ b/types/safie-sdk/index.d.ts
@@ -82,6 +82,48 @@ declare namespace Safie {
     }
 
     /**
+     * SDK全体の設定に関する機能群
+     */
+    namespace Config {
+        /**
+         * テーマの設定に関する機能群
+         */
+        namespace Theme {
+            /** 設定可能なテーマ種別 */
+            type ThemeType = "light" | "dark" | "system";
+            /**
+             * テーマを設定します。
+             * #### 概要
+             * - SDK全体のテーマを設定します
+             * - 現在アクティブな全てのSDKコンポーネント（StreamingPlayer, Timeline等）に即時反映されます
+             * - "system"を指定するとOSのカラースキーム設定がリアルタイムに反映されます
+             * - 設定しない場合、デフォルトとして"light"が適用されます
+             * @param theme テーマ種別
+             * @throws {@link ErrorDetail} `ThemeType`以外の値を指定した場合にスローされます
+             * @example
+             * ```js
+             * //ダークテーマに設定
+             * Safie.Config.Theme.set('dark');
+             * //OSのカラースキームに追従
+             * Safie.Config.Theme.set('system');
+             * ```
+             */
+            function set(theme: ThemeType): void;
+            /**
+             * 現在設定されているテーマ種別を返します。
+             * #### 概要
+             * - 現在設定されているテーマ種別を返します
+             * @returns 設定されているテーマ種別
+             * @example
+             * ```js
+             * const theme = Safie.Config.Theme.get();
+             * ```
+             */
+            function get(): ThemeType;
+        }
+    }
+
+    /**
      * デバイス情報の操作に関する機能群
      */
     namespace Devices {
@@ -122,10 +164,9 @@ declare namespace Safie {
                 serverConnecting: boolean;
             };
             /**
-             * @hidden
-             * デバイスのcapability情報
+             * デバイスの機能情報のリスト
              */
-            capabilities?: string[];
+            capabilities: string[];
         }
         /**
          * デバイス一覧取得の結果
@@ -305,6 +346,7 @@ declare namespace Safie {
          * @param options.limit 返却するリストの最大件数 (規定値: 20, 最大値: 100)
          * @param options.offset 返却するリストのオフセット (規定値: 0)
          * @param options.itemId デバイスに設定されているオプションによる絞り込み
+         * @param options.deviceIds デバイスIDによる絞り込み
          * @returns
          * @throws {@link ErrorDetail}
          * @example
@@ -317,6 +359,7 @@ declare namespace Safie {
             limit?: number;
             offset?: number;
             itemId?: number;
+            deviceIds?: string[];
         }): Promise<QueryDevicesResult>;
         /**
          * サムネイル取得
@@ -725,8 +768,6 @@ declare namespace Safie {
          * ストリーミングプレイヤー
          * #### 概要
          * 映像のストリーミング再生を行うプレイヤーです。
-         * #### 制限:
-         * - ハイブリッド録画プランを利用のデバイスにおいて、通信を開始後にSafie Developersのアプリケーションの変更及びデバイスオプションの削除を行っても、視聴中は反映されません。
          * #### 必要な権限:
          * - ライブ + 録画(VOD配信、タイムライン連携時の場合)
          * #### 必要なOAuth2.0 scope:

--- a/types/safie-sdk/package.json
+++ b/types/safie-sdk/package.json
@@ -12,6 +12,10 @@
         {
             "name": "Safie Inc.",
             "githubUsername": "SafieDev"
+        },
+        {
+            "name": "Yusuke Oba",
+            "githubUsername": "yusuke-oba1"
         }
     ],
     "nonNpm": true,

--- a/types/safie-sdk/package.json
+++ b/types/safie-sdk/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/safie-sdk",
-    "version": "1.8.9999",
+    "version": "1.9.9999",
     "projects": [
         "https://developers.safie.link/"
     ],

--- a/types/safie-sdk/safie-sdk-tests.ts
+++ b/types/safie-sdk/safie-sdk-tests.ts
@@ -11,9 +11,21 @@ async function testAuth(): Promise<void> {
     await Safie.Auth.removeToken();
 }
 
+function testConfig(): void {
+    // SDK全体のテーマ設定（v1.9で追加）
+    const themeTypes: Safie.Config.Theme.ThemeType[] = ["light", "dark", "system"];
+    themeTypes.forEach(theme => {
+        Safie.Config.Theme.set(theme);
+    });
+    const currentTheme: Safie.Config.Theme.ThemeType = Safie.Config.Theme.get();
+    console.log(currentTheme);
+}
+
 async function testDevices(): Promise<void> {
     const devicesAll: Safie.Devices.QueryDevicesResult = await Safie.Devices.queryDevices();
     await Safie.Devices.queryDevices({ limit: 30, offset: 10, itemId: 1 });
+    // デバイスIDによる絞り込み（v1.9で追加）
+    await Safie.Devices.queryDevices({ deviceIds: ["device1", "device2"] });
     devicesAll.list.forEach((device: Safie.Devices.Device) => {
         const id: string = device.deviceId;
         const modelName: string = device.model.description;
@@ -21,7 +33,9 @@ async function testDevices(): Promise<void> {
         const name: string = device.setting.name;
         const streaming: boolean = device.status.videoStreaming;
         const connected: boolean = device.status.serverConnecting;
-        console.log(id, modelName, serial, name, streaming, connected);
+        // デバイスの機能情報のリスト
+        const capabilities: string[] = device.capabilities;
+        console.log(id, modelName, serial, name, streaming, connected, capabilities);
     });
 
     const thumbnail: Blob = await Safie.Devices.queryThumbnail({ deviceId: "device" });
@@ -290,6 +304,7 @@ function testErrorHandling(error: Safie.ErrorDetail): void {
 
 // 全テスト関数を参照することで未使用警告を抑止する
 testAuth();
+testConfig();
 testDevices();
 testPlayer();
 testTimeline();


### PR DESCRIPTION
Updates `@types/safie-sdk` to track Safie Developers JavaScript SDK v1.9.

## Changes
- Add `Safie.Config.Theme` namespace (`set` / `get`, `ThemeType = 'light' | 'dark' | 'system'`)
- Add `deviceIds` filter option to `Safie.Devices.queryDevices`
- Expose `Device.capabilities` as a documented `string[]` field (previously `@hidden` / optional)
- Remove an obsolete hybrid-recording limitation note from the player config docs
- Add `yusuke-oba1` as an individual package owner alongside the existing `SafieDev` org

`safie-sdk-tests.ts` is updated to exercise the new APIs.

## Checklist
- [x] Bumped the version in `package.json` (`1.8.9999` → `1.9.9999`)
- [x] Tested locally: `dprint check` and `tsc` pass
- This is a non-npm package; the source SDK is published at https://developers.safie.link/

> Opened as a draft for internal review before requesting maintainer review.