### PR TITLE
[tabulator-tables] Fix `setHeaderFilterValue` method signature

### DIFF
--- a/types/tabulator-tables/index.d.ts
+++ b/types/tabulator-tables/index.d.ts
@@ -3140,7 +3140,7 @@ declare class Tabulator {
     getFilters: (includeHeaderFilters?: boolean) => Filter[];
 
     /** You can programmatically set the header filter value of a column by calling the setHeaderFilterValue function, This function takes any of the standard column component look up options as its first parameter, with the value for the header filter as the second option. */
-    setHeaderFilterValue: (column: ColumnLookup, value: string) => void;
+    setHeaderFilterValue: (column: ColumnLookup, value: string | string[]) => void;
 
     /** You can programmatically set the focus on a header filter element by calling the setHeaderFilterFocus function, This function takes any of the standard column component look up options as its first parameter. */
     setHeaderFilterFocus: (column: ColumnLookup) => void;

--- a/types/tabulator-tables/tabulator-tables-tests.ts
+++ b/types/tabulator-tables/tabulator-tables-tests.ts
@@ -875,10 +875,22 @@ table = new Tabulator("#example-table", {
                 return value >= params.legalAge;
             },
             accessorHtmlOutputParams: { legalAge: 18 },
+            headerFilter: "input",
+        },
+        {
+            title: "Name2",
+            field: "name2",
+            headerFilter: "list",
+            headerFilterParams: {
+                multiselect: true,
+                values: ["value1", "value2", "value3"],
+            },
         },
     ],
 });
 const filterVal = table.getHeaderFilterValue("name");
+table.setHeaderFilterValue("name", "value");
+table.setHeaderFilterValue("name2", ["value1", "value3"]);
 table.recalc();
 const columns = table.getColumns(true);
 columns.forEach(col => col.getDefinition());


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [Header filtering](https://www.tabulator.info/docs/6.x/filter/#header)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

⚠️ Note that the documentation is not really explicit about the type signature. The use case is a header filter of type `list` with multiple selection allowed. In that case, Tabulator will expect an array of values. I added a test case that covers this use case but the types do not explicitly enforce this relation (I believe it would be very hard to do so given that 2 separate properties interact with one another...). But it's better than the current types that throw an error on valid code.