### PR TITLE
[hotwired__turbo] Make `FrameElement.src` nullable

### DIFF
--- a/types/hotwired__turbo/hotwired__turbo-tests.ts
+++ b/types/hotwired__turbo/hotwired__turbo-tests.ts
@@ -42,6 +42,11 @@ turboFrame.loading = "slow";
 
 turboFrame.reload().catch(console.error);
 
+// $ExpectType string | null
+turboFrame.src;
+turboFrame.src = "/messages";
+turboFrame.src = null;
+
 const turboStream = document.querySelector("turbo-stream")!;
 
 // $ExpectType StreamElement

--- a/types/hotwired__turbo/index.d.ts
+++ b/types/hotwired__turbo/index.d.ts
@@ -1,5 +1,5 @@
 export class FrameElement extends HTMLElement {
-    src: string;
+    src: string | null;
     disabled: boolean;
     loading: "eager" | "lazy";
     loaded: Promise<void>;


### PR DESCRIPTION
## What

`FrameElement.src` is currently typed as `string`, but it is nullable on both read and write.

## Why

Looking at Turbo's [`frame_element.js`](https://github.com/hotwired/turbo/blob/v8.0.23/src/elements/frame_element.js#L58-L74):

```js
get src() {
  return this.getAttribute("src")
}

set src(value) {
  if (value) {
    this.setAttribute("src", value)
  } else {
    this.removeAttribute("src")
  }
}
```

- The **getter** returns `getAttribute("src")`, which is `null` for a frame without a `src` attribute — a normal state for eager/lazy frames before a source is set.
- The **setter** accepts `null` (or any falsy value) and removes the attribute, which is the idiomatic way to clear a frame's source.

Turbo's own bundled [`.d.ts` (before they were dropped in Turbo 8) declared this as `string | null`](https://npmx.dev/package-code/@hotwired/turbo/v/7.3.0/dist%2Ftypes%2Felements%2Fframe_element.d.ts#L34-L35). The current definition narrows it to `string`, which both forces spurious non-null assumptions when reading `.src` and rejects the valid `frame.src = null` / `frame.src = ""` clearing pattern.

## Changes

- Widen `FrameElement.src` from `string` to `string | null`.
- Add tests asserting the `string | null` type and that both `string` and `null` are assignable to the setter.


---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://github.com/hotwired/turbo/blob/v8.0.23/src/elements/frame_element.js#L58-L74
  - https://npmx.dev/package-code/@hotwired/turbo/v/7.3.0/dist%2Ftypes%2Felements%2Fframe_element.d.ts#L34-L35
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
