### PR TITLE
[k6] Fix Tester callback parameter type: Element → Selection

### DIFF
--- a/types/k6/html/index.d.ts
+++ b/types/k6/html/index.d.ts
@@ -370,10 +370,10 @@ export interface FormValue {
 export interface Tester {
     /**
      * @param index - Current index.
-     * @param element - Current element.
+     * @param element - Current selection.
      * @returns Whether element passes test.
      */
-    (index: number, element: Element): boolean;
+    (index: number, element: Selection): boolean;
 }
 
 /**

--- a/types/k6/test/html.ts
+++ b/types/k6/test/html.ts
@@ -37,7 +37,7 @@ import {
 } from "k6/html";
 
 const handler = (index: number, element: Element) => {};
-const tester = (index: number, element: Element) => true;
+const tester = (index: number, element: Selection) => true;
 const mapper = (index: number, selection: Selection) => null;
 
 let selection: Selection;


### PR DESCRIPTION
## Description

The `Tester` interface (the callback type for `Selection.filter()`, `.is()`, and `.not()`) declares its second parameter as `Element`:

```ts
export interface Tester {
    (index: number, element: Element): boolean;
}
```

At runtime, however, k6/html passes a **`Selection`** to these callbacks, not an `Element`. Code that calls `Element`-only methods (e.g. `querySelector`) inside the callback passes type-checking but throws at runtime with `TypeError: Object has no member 'querySelector'`.

The `Mapper` interface (for `.map()`) is already correctly typed as `Selection`. This PR aligns `Tester` to match.

Fixes the type mismatch documented in https://github.com/grafana/k6/issues/6088.

## Checklist

My changes:
- [ ] Don't change the runtime behavior of any code.
- [x] Include tests (or were verified not to require tests).
- [x] Are marked as breaking changes (if applicable). N/A — this is a bug fix; code that currently passes tsc with the wrong type will still pass; code that was correct at runtime but wrong in types gets correct types.

The package I'm changing:
- [x] Is not a new package.
- [x] Provides the typings for an npm package (published: `@types/k6`).
- [x] Has had major version changes handled (the fix is version-independent).