### PR TITLE
[dom-mediacapture-transform] Add discardedFrames and totalFrames to MediaStreamTrackProcessor.

### DIFF
--- a/types/dom-mediacapture-transform/dom-mediacapture-transform-tests.ts
+++ b/types/dom-mediacapture-transform/dom-mediacapture-transform-tests.ts
@@ -118,6 +118,12 @@ async function topLevel() {
         // field.
         const processor = new MediaStreamTrackProcessor({ track: generator });
 
+        // $ExpectType number
+        processor.discardedFrames;
+
+        // $ExpectType number
+        processor.totalFrames;
+
         // $ExpectType ReadableStreamDefaultReader<VideoFrame>
         const reader = processor.readable.getReader();
 

--- a/types/dom-mediacapture-transform/index.d.ts
+++ b/types/dom-mediacapture-transform/index.d.ts
@@ -42,6 +42,13 @@ interface MediaStreamTrackProcessor<T extends AudioData | VideoFrame> {
     readonly readable: ReadableStream<T>;
     /** Allows sending control signals to the MediaStreamTrack provided to the constructor. */
     readonly writableControl: WritableStream<MediaStreamTrackSignal>;
+    /** The number of frames discarded by this MediaStreamTrackProcessor. */
+    readonly discardedFrames: number;
+    /**
+     * The number of frames received by this MediaStreamTrackProcessor including
+     * discarded frames.
+     */
+    readonly totalFrames: number;
 }
 
 declare var MediaStreamTrackProcessor: {


### PR DESCRIPTION
Adds `totalFrames` and `discardedFrames` properties to the `MediaStreamTrackProcessor` interface to align with the official specification (https://www.w3.org/TR/mediacapture-transform/#track-processor-interface).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.w3.org/TR/mediacapture-transform/#track-processor-interface
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.