### PR TITLE
[cyclonedx] Mark as confliting npm

### DIFF
--- a/types/cyclonedx/package.json
+++ b/types/cyclonedx/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "name": "@types/cyclonedx",
     "version": "1.4.9999",
-    "nonNpm": true,
+    "nonNpm": "conflict",
     "nonNpmDescription": "cyclonedx",
     "projects": [
         "https://github.com/CycloneDX/specification"


### PR DESCRIPTION
This package now exists as a placeholder, so mark as conflicting.