### PR TITLE
[chrome] update since Chrome 150

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -381,22 +381,53 @@ declare namespace chrome {
      * Permissions: "alarms"
      */
     export namespace alarms {
-        interface AlarmCreateInfo {
-            /** Length of time in minutes after which the {@link onAlarm} event should fire.  */
-            delayInMinutes?: number | undefined;
-            /** If set, the onAlarm event should fire every `periodInMinutes` minutes after the initial event specified by `when` or `delayInMinutes`. If not set, the alarm will only fire once. */
-            periodInMinutes?: number | undefined;
-            /** Time at which the alarm should fire, in milliseconds past the epoch (e.g. `Date.now() + n`). */
-            when?: number | undefined;
-        }
+        type AlarmCreateInfo =
+            & {
+                /**
+                 * Whether the alarm should persist across sessions (browser restarts). In Chrome, this defaults to true to match historical behavior, but you should set this explicitly to maximize compatibility across browsers.
+                 * @since Chrome 150
+                 */
+                persistAcrossSessions?: boolean | undefined;
+            }
+            & (
+                | {
+                    /** Length of time in minutes after which the {@link onAlarm} event should fire.  */
+                    delayInMinutes: number;
+                    /** If set, the onAlarm event should fire every `periodInMinutes` minutes after the initial event specified by `when` or `delayInMinutes`. If not set, the alarm will only fire once. */
+                    periodInMinutes?: number | undefined;
+                    /** Time at which the alarm should fire, in milliseconds past the epoch (e.g. `Date.now() + n`). */
+                    when?: never | undefined;
+                }
+                | {
+                    /** Length of time in minutes after which the {@link onAlarm} event should fire.  */
+                    delayInMinutes?: number | undefined;
+                    /** If set, the onAlarm event should fire every `periodInMinutes` minutes after the initial event specified by `when` or `delayInMinutes`. If not set, the alarm will only fire once. */
+                    periodInMinutes: number;
+                    /** Time at which the alarm should fire, in milliseconds past the epoch (e.g. `Date.now() + n`). */
+                    when?: number | undefined;
+                }
+                | {
+                    /** Length of time in minutes after which the {@link onAlarm} event should fire.  */
+                    delayInMinutes?: never | undefined;
+                    /** If set, the onAlarm event should fire every `periodInMinutes` minutes after the initial event specified by `when` or `delayInMinutes`. If not set, the alarm will only fire once. */
+                    periodInMinutes?: number | undefined;
+                    /** Time at which the alarm should fire, in milliseconds past the epoch (e.g. `Date.now() + n`). */
+                    when: number;
+                }
+            );
 
         interface Alarm {
-            /** If not null, the alarm is a repeating alarm and will fire again in `periodInMinutes` minutes. */
-            periodInMinutes?: number;
-            /** Time at which this alarm was scheduled to fire, in milliseconds past the epoch (e.g. `Date.now() + n`). For performance reasons, the alarm may have been delayed an arbitrary amount beyond this. */
-            scheduledTime: number;
             /** Name of this alarm. */
             name: string;
+            /** If not null, the alarm is a repeating alarm and will fire again in `periodInMinutes` minutes. */
+            periodInMinutes?: number;
+            /**
+             * Whether the alarm should persist across sessions (browser restarts).
+             * @since Chrome 150
+             */
+            persistAcrossSessions: boolean;
+            /** Time at which this alarm was scheduled to fire, in milliseconds past the epoch (e.g. `Date.now() + n`). For performance reasons, the alarm may have been delayed an arbitrary amount beyond this. */
+            scheduledTime: number;
         }
 
         /**
@@ -7604,7 +7635,7 @@ declare namespace chrome {
          * Creates a new offscreen document for the extension.
          * @param parameters The parameters describing the offscreen document to create.
          *
-         * Can return its result via Promise in Manifest V3.
+         * Can return its result via Promise.
          */
         function createDocument(parameters: CreateParameters): Promise<void>;
         function createDocument(parameters: CreateParameters, callback: () => void): void;
@@ -7612,7 +7643,7 @@ declare namespace chrome {
         /**
          * Closes the currently-open offscreen document for the extension.
          *
-         * Can return its result via Promise in Manifest V3.
+         * Can return its result via Promise.
          */
         function closeDocument(): Promise<void>;
         function closeDocument(callback: () => void): void;
@@ -7620,7 +7651,8 @@ declare namespace chrome {
         /**
          * Determines whether the extension has an active document.
          *
-         * Can return its result via Promise in Manifest V3.
+         * Can return its result via Promise.
+         * @since Chrome 150
          */
         function hasDocument(): Promise<boolean>;
         function hasDocument(callback: (result: boolean) => void): void;

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -2587,12 +2587,17 @@ async function testAlarms() {
         delayInMinutes: 1,
         periodInMinutes: 1,
         when: 1,
+        persistAcrossSessions: true,
     };
 
     chrome.alarms.create(alarmCreateInfo); // $ExpectType Promise<void>
     chrome.alarms.create("name", alarmCreateInfo); // $ExpectType Promise<void>
     chrome.alarms.create(alarmCreateInfo, () => {}); // $ExpectType void
     chrome.alarms.create("name", alarmCreateInfo, () => {}); // $ExpectType void
+    // @ts-expect-error Must set at least one of when, delayInMinutes, or periodInMinutes.
+    chrome.alarms.create("name", { persistAcrossSessions: true }, () => {});
+    // @ts-expect-error Cannot set both when and delayInMinutes.
+    chrome.alarms.create("name", { when: 1, delayInMinutes: 1 }, () => {});
     // @ts-expect-error
     chrome.alarms.create("name", alarmCreateInfo, () => {}).then(() => {});
 
@@ -2601,6 +2606,7 @@ async function testAlarms() {
         alarm.name; // $ExpectType string
         alarm.periodInMinutes; // $ExpectType number | undefined
         alarm.scheduledTime; // $ExpectType number
+        alarm.persistAcrossSessions; // $ExpectType boolean
     });
     // @ts-expect-error
     chrome.alarms.getAll(() => {}).then(() => {});
@@ -2631,6 +2637,7 @@ async function testAlarms() {
         alarm.name; // $ExpectType string
         alarm.periodInMinutes; // $ExpectType number | undefined
         alarm.scheduledTime; // $ExpectType number
+        alarm.persistAcrossSessions; // $ExpectType boolean
     });
     chrome.alarms.get("name", (alarm) => { // $ExpectType void
         alarm; // $ExpectType Alarm | undefined
@@ -2638,6 +2645,7 @@ async function testAlarms() {
         alarm.name; // $ExpectType string
         alarm.periodInMinutes; // $ExpectType number | undefined
         alarm.scheduledTime; // $ExpectType number
+        alarm.persistAcrossSessions; // $ExpectType boolean
     });
     // @ts-expect-error
     chrome.alarms.get("name", () => {}).then(() => {});
@@ -2646,6 +2654,7 @@ async function testAlarms() {
         alarm.name; // $ExpectType string
         alarm.periodInMinutes; // $ExpectType number | undefined
         alarm.scheduledTime; // $ExpectType number
+        alarm.persistAcrossSessions; // $ExpectType boolean
     });
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/api/alarms#type
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Notes: 
- update `chrome.alarms.Alarm` : add `persistAcrossSessions` key
- update `chrome.alarms.AlarmCreateInfo`  : 
  - add optionnal `persistAcrossSessions` key
    <img width="762" height="112" alt="alarm2" src="https://github.com/user-attachments/assets/a39b027d-2c0f-4444-a299-61e29a06340b" />
  - Restriction types
    <img width="711" height="117" alt="alarm error" src="https://github.com/user-attachments/assets/3854a60b-5d44-4b8d-82f3-3ed0f0fb5d9e" />

   
- update JSDoc of `chrome.offscreen`