### PR TITLE
[multer] Add fieldNestingDepth limit option

### DIFF
--- a/types/multer/index.d.ts
+++ b/types/multer/index.d.ts
@@ -200,6 +200,8 @@ declare namespace multer {
             fieldSize?: number | undefined;
             /** Maximum number of non-file form fields. (Default: Infinity) */
             fields?: number | undefined;
+            /** Maximum number of nesting levels for field names, e.g. `a[b][c]` has 2 levels. (Default: Infinity) */
+            fieldNestingDepth?: number | undefined;
             /** Maximum size of each file in bytes. (Default: Infinity) */
             fileSize?: number | undefined;
             /** Maximum number of file fields. (Default: Infinity) */

--- a/types/multer/multer-tests.ts
+++ b/types/multer/multer-tests.ts
@@ -28,6 +28,23 @@ const upload_with_defParamCharset = multer({
 upload_with_defParamCharset; // $ExpectType Multer
 assert.strictEqual(upload_with_defParamCharset.constructor.name, "Multer");
 
+const upload_with_limits = multer({
+    dest: "uploads/",
+    limits: {
+        fieldNameSize: 100,
+        fieldSize: 1048576,
+        fields: 10,
+        fieldNestingDepth: 2,
+        fileSize: Infinity,
+        files: Infinity,
+        parts: Infinity,
+        headerPairs: 2000,
+    },
+});
+
+upload_with_limits; // $ExpectType Multer
+assert.strictEqual(upload_with_limits.constructor.name, "Multer");
+
 const app = express();
 
 app.post(

--- a/types/multer/package.json
+++ b/types/multer/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/multer",
-    "version": "2.1.9999",
+    "version": "2.2.9999",
     "projects": [
         "https://github.com/expressjs/multer"
     ],


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/expressjs/multer/commit/a192b5278f240967f5eb13dd1e9a413b4e1b6533 (released in multer 2.2.0; documented in the [limits table of the README](https://github.com/expressjs/multer#limits))
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

multer 2.2.0 added a `fieldNestingDepth` option to `limits` (part of the fix for CVE-2026-5038, DoS via deeply nested multipart field names). This adds the missing property and bumps the types version to 2.2.