### PR TITLE
[hotwired__turbo] Add nullable FrameElement.refresh

### DIFF
--- a/types/hotwired__turbo/hotwired__turbo-tests.ts
+++ b/types/hotwired__turbo/hotwired__turbo-tests.ts
@@ -47,6 +47,11 @@ turboFrame.src;
 turboFrame.src = "/messages";
 turboFrame.src = null;
 
+// $ExpectType "morph" | null
+turboFrame.refresh;
+turboFrame.refresh = "morph";
+turboFrame.refresh = null;
+
 const turboStream = document.querySelector("turbo-stream")!;
 
 // $ExpectType StreamElement

--- a/types/hotwired__turbo/index.d.ts
+++ b/types/hotwired__turbo/index.d.ts
@@ -1,5 +1,6 @@
 export class FrameElement extends HTMLElement {
     src: string | null;
+    refresh: "morph" | null;
     disabled: boolean;
     loading: "eager" | "lazy";
     loaded: Promise<void>;


### PR DESCRIPTION
Adds the `refresh` getter/setter (`string | null`), matching the FrameElement accessors in frame_element.js: `refresh` reads
getAttribute("refresh").


- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hotwired/turbo/blob/main/src/elements/frame_element.js#L78