### PR TITLE
Update @types/commerce7__admin-ui for 2.0.X major release

### DIFF
--- a/types/commerce7__admin-ui/commerce7__admin-ui-tests.tsx
+++ b/types/commerce7__admin-ui/commerce7__admin-ui-tests.tsx
@@ -4,9 +4,11 @@ import {
     Breadcrumbs,
     Button,
     ButtonMenu,
+    c7Colors,
     Card,
     CardLink,
     Checkbox,
+    CheckboxGroup,
     Columns,
     Commerce7AdminUI,
     ContextMenu,
@@ -42,6 +44,7 @@ import {
     Textarea,
     VividIcon,
 } from "@commerce7/admin-ui";
+import type { Moment } from "moment";
 import * as React from "react";
 
 const { Breadcrumb } = Breadcrumbs;
@@ -73,7 +76,7 @@ export function TestComponent() {
 
     const [checked, setChecked] = React.useState(false);
 
-    const [date, setDate] = React.useState<any>();
+    const [date, setDate] = React.useState("");
 
     const [radioChecked, setRadioChecked] = React.useState("");
 
@@ -83,9 +86,20 @@ export function TestComponent() {
 
     const [textAreaValue, setTextAreaValue] = React.useState("");
 
+    const handleMenuClick = (_event: React.MouseEvent<HTMLButtonElement>) => {};
+
+    const handleDateChange = (e: Moment | string) => {
+        setDate(typeof e === "string" ? e : e.format("MMM D, YYYY"));
+    };
+
+    const isFutureDate = (currentDate: Moment) => !currentDate.isBefore(new Date(), "day");
+
     return (
         <Commerce7AdminUI>
-            <Alert>This is an alert</Alert>
+            <Alert dataTestId="alert">This is an alert</Alert>
+            <Alert variant="tip" href="https://commerce7.com" icon="lightBulb">
+                This is a tip alert
+            </Alert>
 
             <Avatar label="JH" />
 
@@ -140,7 +154,21 @@ export function TestComponent() {
             <Picture src="https://images.pexels.com/photos/391213/pexels-photo-391213.jpeg" alt="Wine" height={300} />
             <Picture src="https://images.pexels.com/photos/391213/pexels-photo-391213.jpeg" alt="Wine" height={200} />
 
-            <ProgressBar progress={50} />
+            <ProgressBar progress={50} color={c7Colors.blue400} />
+            <div
+                style={{
+                    height: 50,
+                }}
+            >
+                <ProgressBar
+                    progress={50}
+                    content={{
+                        text: "Open Rate",
+                        progress: 50,
+                        circleColor: "#42ACF0",
+                    }}
+                />
+            </div>
 
             <Region borderBottom>
                 <Heading>Region with border below</Heading>
@@ -156,36 +184,43 @@ export function TestComponent() {
             <Tag variant="warning">Warning</Tag>
             <Tag variant="error">Error</Tag>
             <Tag variant="success">Success</Tag>
+            <Tag variant="tip" endIcon="network" onDelete={() => {}}>
+                Tip
+            </Tag>
 
             <Button>Button</Button>
+            <Button endIcon="arrowRight">Continue</Button>
 
-            <ButtonMenu>
-                <ButtonMenuItem icon="export">
+            <ButtonMenu label="Actions" size="small" onClick={handleMenuClick}>
+                <ButtonMenuItem icon="export" onClick={handleMenuClick}>
                     Export
                 </ButtonMenuItem>
-                <ButtonMenuItem icon="trash">
+                <ButtonMenuItem icon="trash" onClick={handleMenuClick}>
                     Delete
                 </ButtonMenuItem>
             </ButtonMenu>
 
             <ContextMenu>
-                <ContextMenuItem icon="export">
+                <ContextMenuItem icon="export" onClick={handleMenuClick}>
                     Export
                 </ContextMenuItem>
             </ContextMenu>
 
             <ContextMenu>
-                <ContextMenuItem icon="export">
+                <ContextMenuItem icon="export" onClick={handleMenuClick}>
                     Export
                 </ContextMenuItem>
                 <ContextMenuMoreActions>
-                    <ContextMenuItem icon="trash">
+                    <ContextMenuItem icon="trash" onClick={handleMenuClick}>
                         Delete
                     </ContextMenuItem>
                 </ContextMenuMoreActions>
             </ContextMenu>
 
             <LinkButton href="https://commerce7.com">Button</LinkButton>
+            <LinkButton href="https://commerce7.com" endIcon="newTab" loading>
+                Loading Link Button
+            </LinkButton>
 
             <SelectButton>Basic</SelectButton>
             <SelectButton loading>Loading</SelectButton>
@@ -369,10 +404,37 @@ export function TestComponent() {
             </TabBody>
 
             <Checkbox label="Subscribe" id="subscribe" checked={checked} onChange={() => setChecked(!checked)} />;
+            <CheckboxGroup label="Subscriptions" variant="button" size="large">
+                <Checkbox
+                    icon="email"
+                    label="Email"
+                    id="email"
+                    checked={checked}
+                    onChange={() => setChecked(!checked)}
+                    variant="button"
+                    size="large"
+                >
+                    Email
+                </Checkbox>
+            </CheckboxGroup>
 
             <DataDisplay label="First Name">Jim Smith</DataDisplay>
 
-            <DatePicker label="Date" id="date" value={date} onChange={(e) => setDate(e)} />
+            <DatePicker
+                label="Date"
+                id="date"
+                value={date}
+                onChange={handleDateChange}
+                allowClear
+                isValidDate={isFutureDate}
+            />
+            <DatePicker
+                label="Day Format Date Picker"
+                id="day-date"
+                value={date}
+                onChange={handleDateChange}
+                variant="dayFormat"
+            />
 
             <RadioGroup label="Account Type">
                 <Radio
@@ -402,6 +464,12 @@ export function TestComponent() {
                 }, {
                     label: "White",
                     value: "white",
+                }, {
+                    label: "Grouped",
+                    options: [{
+                        label: "Sparkling",
+                        value: "sparkling",
+                    }],
                 }]}
             />
 
@@ -419,11 +487,15 @@ export function TestComponent() {
                 onChange={(e) => setTextAreaValue(e.target.value)}
             />
 
-            <DisplayIcon icon="cart" />
+            <DisplayIcon icon="cart" variant="tip" />
 
-            <Icon icon="cart" />
+            <Icon icon="alignRight" />
+            <Icon icon="calenderCross" />
+            <Icon icon="network" variant="info" />
+            <Icon icon="users" variant="text" />
 
             <VividIcon icon="cart" color="blue" />
+            <VividIcon icon="sparkle" color="gray" />
 
             <Heading level={1}>
                 Heading 1
@@ -459,18 +531,22 @@ export function TestComponent() {
                     {
                         color: "#42ACF0",
                         title: "Guest",
+                        value: "",
                     },
                     {
                         color: "#DF5F5F",
                         title: "First-time",
+                        value: "",
                     },
                     {
                         color: "#BF9D36",
                         title: "Repeat",
+                        value: "",
                     },
                     {
                         color: "#239C82",
                         title: "Club Member",
+                        value: "",
                     },
                 ]}
             />
@@ -506,7 +582,7 @@ export function TestComponent() {
                     </Tr>
                 </Thead>
                 <Tbody>
-                    <Tr>
+                    <Tr onClick={() => {}}>
                         <Td>Jim Smith</Td>
                         <Td>22</Td>
                         <Td>Male</Td>

--- a/types/commerce7__admin-ui/index.d.ts
+++ b/types/commerce7__admin-ui/index.d.ts
@@ -300,16 +300,16 @@ export interface BreadcrumbProps {
     dataTestId?: string | undefined;
 }
 
-export class Breadcrumb extends React.Component<BreadcrumbProps> {}
-
 export interface BreadcrumbsProps {
     className?: string | undefined;
     children: React.ReactNode;
     dataTestId?: string | undefined;
 }
 
-export class Breadcrumbs extends React.Component<BreadcrumbsProps> {
-    static Breadcrumb: typeof Breadcrumb;
+export class Breadcrumbs extends React.Component<BreadcrumbsProps> {}
+
+export namespace Breadcrumbs {
+    class Breadcrumb extends React.Component<BreadcrumbProps> {}
 }
 
 export interface CardProps {
@@ -326,8 +326,6 @@ export interface ColumnProps {
     span?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | "none" | "auto" | undefined;
 }
 
-export class Column extends React.Component<ColumnProps> {}
-
 export interface ColumnsProps {
     children: React.ReactNode;
     justify?: string | undefined;
@@ -337,8 +335,10 @@ export interface ColumnsProps {
     dataTestId?: string | undefined;
 }
 
-export class Columns extends React.Component<ColumnsProps> {
-    static Column: typeof Column;
+export class Columns extends React.Component<ColumnsProps> {}
+
+export namespace Columns {
+    class Column extends React.Component<ColumnProps> {}
 }
 
 export interface InfoCardGridProps {
@@ -346,8 +346,6 @@ export interface InfoCardGridProps {
     className?: string | undefined;
     dataTestId?: string | undefined;
 }
-
-export class InfoCardGrid extends React.Component<InfoCardGridProps> {}
 
 export interface InfoCardProps {
     children?: React.ReactNode | undefined;
@@ -362,8 +360,10 @@ export interface InfoCardProps {
     img?: string | undefined;
 }
 
-export class InfoCard extends React.Component<InfoCardProps> {
-    static InfoCardGrid: typeof InfoCardGrid;
+export class InfoCard extends React.Component<InfoCardProps> { }
+
+export namespace InfoCard {
+    class InfoCardGrid extends React.Component<InfoCardGridProps> {}
 }
 
 export interface LineBreakProps {
@@ -378,14 +378,10 @@ export interface ModalBodyProps {
     className?: string | undefined;
 }
 
-export class ModalBody extends React.Component<ModalBodyProps> {}
-
 export interface ModalFooterProps {
     children: React.ReactNode;
     className?: string | undefined;
 }
-
-export class ModalFooter extends React.Component<ModalFooterProps> {}
 
 export interface ModalProps {
     children?: React.ReactNode | undefined;
@@ -398,9 +394,11 @@ export interface ModalProps {
     disableFocusLock?: boolean | undefined;
 }
 
-export class Modal extends React.Component<ModalProps> {
-    static ModalBody: typeof ModalBody;
-    static ModalFooter: typeof ModalFooter;
+export class Modal extends React.Component<ModalProps> { }
+
+export namespace Modal {
+    class ModalBody extends React.Component<ModalBodyProps> {}
+    class ModalFooter extends React.Component<ModalFooterProps> {}
 }
 
 export interface NoRecordsProps {
@@ -504,8 +502,6 @@ export interface ContextMenuItemProps {
     dataTestId?: string | undefined;
 }
 
-export class ButtonMenuItem extends React.Component<ContextMenuItemProps> {}
-
 export interface ButtonMenuProps {
     children: React.ReactNode;
     className?: string | undefined;
@@ -517,11 +513,11 @@ export interface ButtonMenuProps {
     onClick?: ((event: React.MouseEvent<HTMLButtonElement>) => void) | undefined;
 }
 
-export class ButtonMenu extends React.Component<ButtonMenuProps> {
-    static ButtonMenuItem: typeof ButtonMenuItem;
-}
+export class ButtonMenu extends React.Component<ButtonMenuProps> {}
 
-export class ContextMenuItem extends React.Component<ContextMenuItemProps> {}
+export namespace ButtonMenu {
+    class ButtonMenuItem extends React.Component<ContextMenuItemProps> {}
+}
 
 export interface ContextMenuMoreActionsProps {
     children: React.ReactNode;
@@ -531,17 +527,17 @@ export interface ContextMenuMoreActionsProps {
     dataTestId?: string | undefined;
 }
 
-export class ContextMenuMoreActions extends React.Component<ContextMenuMoreActionsProps> {}
-
 export interface ContextMenuProps {
     children: React.ReactNode;
     className?: string | undefined;
     dataTestId?: string | undefined;
 }
 
-export class ContextMenu extends React.Component<ContextMenuProps> {
-    static ContextMenuItem: typeof ContextMenuItem;
-    static ContextMenuMoreActions: typeof ContextMenuMoreActions;
+export class ContextMenu extends React.Component<ContextMenuProps> {}
+
+export namespace ContextMenu {
+    class ContextMenuItem extends React.Component<ContextMenuItemProps> {}
+    class ContextMenuMoreActions extends React.Component<ContextMenuMoreActionsProps> {}
 }
 
 export interface LinkButtonProps {
@@ -602,8 +598,6 @@ export interface SubNavProps {
     dataTestId?: string | undefined;
 }
 
-export class SubNav extends React.Component<SubNavProps> {}
-
 export interface NavLinkProps {
     children?: React.ReactNode | undefined;
     className?: string | undefined;
@@ -616,8 +610,6 @@ export interface NavLinkProps {
     [key: string]: any;
 }
 
-export class NavLink extends React.Component<NavLinkProps> {}
-
 export interface SubNavLinkProps {
     children?: React.ReactNode | undefined;
     className?: string | undefined;
@@ -629,8 +621,6 @@ export interface SubNavLinkProps {
     [key: string]: any;
 }
 
-export class SubNavLink extends React.Component<SubNavLinkProps> {}
-
 export interface NavProps {
     children?: React.ReactNode | undefined;
     className?: string | undefined;
@@ -638,10 +628,12 @@ export interface NavProps {
     dataTestId?: string | undefined;
 }
 
-export class Nav extends React.Component<NavProps> {
-    static SubNav: typeof SubNav;
-    static NavLink: typeof NavLink;
-    static SubNavLink: typeof SubNavLink;
+export class Nav extends React.Component<NavProps> {}
+
+export namespace Nav {
+    class SubNav extends React.Component<SubNavProps> {}
+    class NavLink extends React.Component<NavLinkProps> {}
+    class SubNavLink extends React.Component<SubNavLinkProps> {}
 }
 
 export interface StepProps {
@@ -656,16 +648,16 @@ export interface StepProps {
     icon?: IconName | undefined;
 }
 
-export class Step extends React.Component<StepProps> {}
-
 export interface StepperProps {
     children?: React.ReactNode | undefined;
     className?: string | undefined;
     dataTestId?: string | undefined;
 }
 
-export class Stepper extends React.Component<StepperProps> {
-    static Step: typeof Step;
+export class Stepper extends React.Component<StepperProps> {}
+
+export namespace Stepper {
+    class Step extends React.Component<StepProps> {}
 }
 
 export interface SubMenuItemProps {
@@ -679,8 +671,6 @@ export interface SubMenuItemProps {
     [key: string]: any;
 }
 
-export class SubMenuItem extends React.Component<SubMenuItemProps> {}
-
 export interface SubMenuProps {
     children?: React.ReactNode | undefined;
     className?: string | undefined;
@@ -689,8 +679,10 @@ export interface SubMenuProps {
     activeClassName?: string | undefined;
 }
 
-export class SubMenu extends React.Component<SubMenuProps> {
-    static SubMenuItem: typeof SubMenuItem;
+export class SubMenu extends React.Component<SubMenuProps> {}
+
+export namespace SubMenu {
+    class SubMenuItem extends React.Component<SubMenuItemProps> {}
 }
 
 export interface TabProps {
@@ -704,15 +696,11 @@ export interface TabProps {
     [key: string]: any;
 }
 
-export class Tab extends React.Component<TabProps> {}
-
 export interface TabBodyProps {
     children?: React.ReactNode | undefined;
     className?: string | undefined;
     dataTestId?: string | undefined;
 }
-
-export class TabBody extends React.Component<TabBodyProps> {}
 
 export interface TabsProps {
     children?: React.ReactNode | undefined;
@@ -720,9 +708,11 @@ export interface TabsProps {
     dataTestId?: string | undefined;
 }
 
-export class Tabs extends React.Component<TabsProps> {
-    static Tab: typeof Tab;
-    static TabBody: typeof TabBody;
+export class Tabs extends React.Component<TabsProps> {}
+
+export namespace Tabs {
+    class Tab extends React.Component<TabProps> {}
+    class TabBody extends React.Component<TabBodyProps> {}
 }
 
 export interface CheckboxProps {
@@ -1025,15 +1015,11 @@ export interface TheadProps {
     dataTestId?: string | undefined;
 }
 
-export class Thead extends React.Component<TheadProps> {}
-
 export interface TbodyProps {
     children?: React.ReactNode | undefined;
     className?: string | undefined;
     dataTestId?: string | undefined;
 }
-
-export class Tbody extends React.Component<TbodyProps> {}
 
 export interface ThProps {
     align?: "left" | "center" | "right" | undefined;
@@ -1042,8 +1028,6 @@ export interface ThProps {
     colSpan?: number | undefined;
     dataTestId?: string | undefined;
 }
-
-export class Th extends React.Component<ThProps> {}
 
 export interface TdProps {
     children?: React.ReactNode | undefined;
@@ -1054,8 +1038,6 @@ export interface TdProps {
     dataTestId?: string | undefined;
 }
 
-export class Td extends React.Component<TdProps> {}
-
 export interface TrProps {
     children?: React.ReactNode | undefined;
     className?: string | undefined;
@@ -1063,15 +1045,11 @@ export interface TrProps {
     dataTestId?: string | undefined;
 }
 
-export class Tr extends React.Component<TrProps> {}
-
 export interface TfootProps {
     children: React.ReactNode;
     className?: string | undefined;
     dataTestId?: string | undefined;
 }
-
-export class Tfoot extends React.Component<TfootProps> {}
 
 export interface TableProps {
     children?: React.ReactNode | undefined;
@@ -1079,11 +1057,13 @@ export interface TableProps {
     dataTestId?: string | undefined;
 }
 
-export class Table extends React.Component<TableProps> {
-    static Thead: typeof Thead;
-    static Tbody: typeof Tbody;
-    static Th: typeof Th;
-    static Td: typeof Td;
-    static Tr: typeof Tr;
-    static Tfoot: typeof Tfoot;
+export class Table extends React.Component<TableProps> {}
+
+export namespace Table {
+    class Thead extends React.Component<TheadProps> {}
+    class Tbody extends React.Component<TbodyProps> {}
+    class Th extends React.Component<ThProps> {}
+    class Td extends React.Component<TdProps> {}
+    class Tr extends React.Component<TrProps> {}
+    class Tfoot extends React.Component<TfootProps> {}
 }

--- a/types/commerce7__admin-ui/index.d.ts
+++ b/types/commerce7__admin-ui/index.d.ts
@@ -10,7 +10,7 @@ export type FormButtonSize = "small" | "medium" | "large";
 export type FormButtonVariant = "button" | "default";
 export type InputMode = "text" | "decimal" | "numeric" | "tel" | "search" | "email" | "url";
 export type InputType = "text" | "number" | "password" | "email" | "color";
-export type IconVariant = "default" | "success" | "error" | "text" | "info" | "warning";
+export type IconVariant = "default" | "success" | "error" | "text" | "info" | "warning" | "tip" | "white";
 export type DisplayIconVariant = "default" | "success" | "warning" | "error" | "tip" | "info";
 export type StatusVariant = "default" | "info" | "error" | "warning" | "success" | "tip";
 
@@ -272,7 +272,7 @@ export interface AlertProps {
     component?: ComponentOverride | undefined;
     variant?: StatusVariant | undefined;
     size?: ButtonSize | undefined;
-    icon?: IconName | string | undefined;
+    icon?: IconName | undefined;
     dataTestId?: string | undefined;
     href?: string | undefined;
     [key: string]: any;
@@ -294,7 +294,7 @@ export class Avatar extends React.Component<AvatarProps> {}
 export interface BreadcrumbProps {
     children: React.ReactNode;
     className?: string | undefined;
-    onClick?: (() => void) | null | undefined;
+    onClick?: React.MouseEventHandler<HTMLElement> | null | undefined;
     component?: React.ElementType | undefined;
     href?: string | undefined;
     dataTestId?: string | undefined;
@@ -353,7 +353,7 @@ export interface InfoCardProps {
     children?: React.ReactNode | undefined;
     className?: string | undefined;
     dataTestId?: string | undefined;
-    icon?: IconName | string | undefined;
+    icon?: IconName | undefined;
     label?: React.ReactNode | undefined;
     title?: React.ReactNode | undefined;
     subtitle?: React.ReactNode | undefined;
@@ -406,10 +406,10 @@ export class Modal extends React.Component<ModalProps> {
 export interface NoRecordsProps {
     title?: string | undefined;
     description?: string | undefined;
-    icon?: IconName | string | undefined;
+    icon?: IconName | undefined;
     className?: string | undefined;
     dataTestId?: string | undefined;
-    iconVariant?: Exclude<DisplayIconVariant, "tip"> | undefined;
+    iconVariant?: DisplayIconVariant | undefined;
 }
 
 export class NoRecords extends React.Component<NoRecordsProps> {}
@@ -469,8 +469,8 @@ export interface TagProps {
     onClick?: ((event: React.MouseEvent<HTMLElement>) => void) | undefined;
     onDelete?: ((event: React.MouseEvent<HTMLButtonElement>) => void) | undefined;
     variant?: StatusVariant | undefined;
-    startIcon?: IconName | string | undefined;
-    endIcon?: IconName | string | undefined;
+    startIcon?: IconName | undefined;
+    endIcon?: IconName | undefined;
     dataTestId?: string | undefined;
 }
 
@@ -483,8 +483,8 @@ export interface ButtonProps {
     loading?: boolean | undefined;
     onClick?: ((event: React.MouseEvent<HTMLButtonElement>) => void) | undefined;
     size?: ButtonSize | undefined;
-    startIcon?: IconName | string | undefined;
-    endIcon?: IconName | string | undefined;
+    startIcon?: IconName | undefined;
+    endIcon?: IconName | undefined;
     type?: ButtonType | undefined;
     variant?: ButtonVariant | undefined;
     dataTestId?: string | undefined;
@@ -498,9 +498,9 @@ export interface ContextMenuItemProps {
     children: React.ReactNode;
     className?: string | undefined;
     disabled?: boolean | undefined;
-    icon?: IconName | string | undefined;
+    icon?: IconName | undefined;
     img?: string | undefined;
-    onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
+    onClick?: ((event: React.MouseEvent<HTMLButtonElement>) => void) | undefined;
     dataTestId?: string | undefined;
 }
 
@@ -554,8 +554,8 @@ export interface LinkButtonProps {
     href?: string | undefined;
     rel?: string | undefined;
     size?: ButtonSize | undefined;
-    startIcon?: IconName | string | undefined;
-    endIcon?: IconName | string | undefined;
+    startIcon?: IconName | undefined;
+    endIcon?: IconName | undefined;
     target?: string | undefined;
     variant?: ButtonVariant | undefined;
     dataTestId?: string | undefined;
@@ -575,7 +575,7 @@ export interface SelectButtonProps {
     type?: ButtonType | undefined;
     dataTestId?: string | undefined;
     size?: FormButtonSize | undefined;
-    icon?: IconName | string | undefined;
+    icon?: IconName | undefined;
     as?: any;
 }
 
@@ -586,7 +586,7 @@ export interface CardLinkProps {
     children: React.ReactNode;
     component?: ComponentOverride | undefined;
     href?: string | undefined;
-    icon?: IconName | string | undefined;
+    icon?: IconName | undefined;
     description?: string | undefined;
     label?: string | undefined;
     dataTestId?: string | undefined;
@@ -608,7 +608,7 @@ export interface NavLinkProps {
     children?: React.ReactNode | undefined;
     className?: string | undefined;
     dataTestId?: string | undefined;
-    icon?: IconName | string | undefined;
+    icon?: IconName | undefined;
     component?: ComponentOverride | undefined;
     onClick?: ((event: React.MouseEvent<HTMLElement>) => void) | undefined;
     href?: string | undefined;
@@ -653,7 +653,7 @@ export interface StepProps {
     onClick?: ((event: React.MouseEvent<HTMLElement>) => void) | undefined;
     href?: string | undefined;
     activeClassName?: string | undefined;
-    icon?: IconName | string | undefined;
+    icon?: IconName | undefined;
 }
 
 export class Step extends React.Component<StepProps> {}
@@ -739,7 +739,7 @@ export interface CheckboxProps {
     dataTestId?: string | undefined;
     variant?: FormButtonVariant | undefined;
     size?: FormButtonSize | undefined;
-    icon?: IconName | string | undefined;
+    icon?: IconName | undefined;
     children?: React.ReactNode | undefined;
 }
 
@@ -776,14 +776,14 @@ export interface DatePickerProps {
     errorMessage?: string | null | undefined;
     id?: string | undefined;
     inline?: boolean | undefined;
-    isValidDate?: ((currentDate: Moment) => boolean) | undefined;
+    isValidDate?: ((currentDate: Moment, selectedDate?: Moment) => boolean) | undefined;
     label?: string | null | undefined;
     onChange: (date: Moment | string) => void;
     onBlur?: ((event: React.FocusEvent<HTMLInputElement>) => void) | undefined;
     onFocus?: ((event: React.FocusEvent<HTMLInputElement>) => void) | undefined;
     placeholder?: string | undefined;
     required?: boolean | undefined;
-    value: string;
+    value?: Date | string | Moment | undefined;
     dataTestId?: string | null | undefined;
     variant?: "default" | "dayFormat" | undefined;
 }
@@ -796,8 +796,8 @@ export interface InputProps {
     className?: string | undefined;
     description?: string | undefined;
     disabled?: boolean | undefined;
-    startIcon?: IconName | string | undefined;
-    endIcon?: IconName | string | undefined;
+    startIcon?: IconName | undefined;
+    endIcon?: IconName | undefined;
     suffix?: string | undefined;
     errorMessage?: string | undefined;
     id?: string | undefined;
@@ -830,7 +830,7 @@ export interface RadioProps {
     dataTestId?: string | undefined;
     variant?: FormButtonVariant | undefined;
     size?: FormButtonSize | undefined;
-    icon?: IconName | string | undefined;
+    icon?: IconName | undefined;
     children?: React.ReactNode | undefined;
 }
 
@@ -867,7 +867,7 @@ export interface SelectProps {
     options?: OptionItem[] | undefined;
     placeholder?: string | undefined;
     required?: boolean | undefined;
-    value: string | number;
+    value?: string | number | undefined;
     dataTestId?: string | undefined;
 }
 
@@ -911,7 +911,7 @@ export class Textarea extends React.Component<TextareaProps> {}
 
 export interface DisplayIconProps {
     className?: string | undefined;
-    icon: IconName | string;
+    icon: IconName;
     label?: string | undefined;
     onClick?: ((event: React.MouseEvent<HTMLButtonElement>) => void) | undefined;
     variant?: DisplayIconVariant | undefined;
@@ -922,11 +922,11 @@ export class DisplayIcon extends React.Component<DisplayIconProps> {}
 
 export interface IconProps {
     className?: string | undefined;
-    icon: IconName | string;
+    icon: IconName;
     label?: string | undefined;
     onClick?: ((event: React.MouseEvent<HTMLButtonElement>) => void) | undefined;
     size?: number | undefined;
-    variant?: IconVariant | string | undefined;
+    variant?: IconVariant | undefined;
     dataTestId?: string | undefined;
 }
 
@@ -934,7 +934,7 @@ export class Icon extends React.Component<IconProps> {}
 
 export interface VividIconProps {
     className?: string | undefined;
-    icon: IconName | string;
+    icon: IconName;
     label?: string | undefined;
     onClick?: ((event: React.MouseEvent<HTMLButtonElement>) => void) | undefined;
     color?: "pink" | "blue" | "green" | "teal" | "orange" | "purple" | "gray" | undefined;
@@ -972,7 +972,7 @@ export class Text extends React.Component<TextProps> {}
 
 export interface LegendItem {
     title?: string | undefined;
-    value: string | number;
+    value?: string | number | undefined;
     color: string;
 }
 

--- a/types/commerce7__admin-ui/index.d.ts
+++ b/types/commerce7__admin-ui/index.d.ts
@@ -360,7 +360,7 @@ export interface InfoCardProps {
     img?: string | undefined;
 }
 
-export class InfoCard extends React.Component<InfoCardProps> { }
+export class InfoCard extends React.Component<InfoCardProps> {}
 
 export namespace InfoCard {
     class InfoCardGrid extends React.Component<InfoCardGridProps> {}
@@ -394,7 +394,7 @@ export interface ModalProps {
     disableFocusLock?: boolean | undefined;
 }
 
-export class Modal extends React.Component<ModalProps> { }
+export class Modal extends React.Component<ModalProps> {}
 
 export namespace Modal {
     class ModalBody extends React.Component<ModalBodyProps> {}

--- a/types/commerce7__admin-ui/index.d.ts
+++ b/types/commerce7__admin-ui/index.d.ts
@@ -1,9 +1,25 @@
+import type { Moment } from "moment";
 import * as React from "react";
 
-export class Commerce7AdminUI extends React.Component<{
+export type ComponentOverride = React.ComponentType<any> | string;
+export type ButtonSize = "default" | "small";
+export type ButtonVariant = "primary" | "secondary" | "text" | "link";
+export type ButtonType = "button" | "submit";
+export type ButtonMenuVariant = "primary" | "secondary" | "text";
+export type FormButtonSize = "small" | "medium" | "large";
+export type FormButtonVariant = "button" | "default";
+export type InputMode = "text" | "decimal" | "numeric" | "tel" | "search" | "email" | "url";
+export type InputType = "text" | "number" | "password" | "email" | "color";
+export type IconVariant = "default" | "success" | "error" | "text" | "info" | "warning";
+export type DisplayIconVariant = "default" | "success" | "warning" | "error" | "tip" | "info";
+export type StatusVariant = "default" | "info" | "error" | "warning" | "success" | "tip";
+
+export interface Commerce7AdminUIProps {
     mode?: "light" | "dark" | undefined;
     children?: React.ReactNode | undefined;
-}> {}
+}
+
+export class Commerce7AdminUI extends React.Component<Commerce7AdminUIProps> {}
 
 export type IconName =
     | "add"
@@ -12,7 +28,7 @@ export type IconName =
     | "adjust"
     | "alignCenter"
     | "alignLeft"
-    | "alighRight"
+    | "alignRight"
     | "app"
     | "application"
     | "applicationSwitcher"
@@ -25,14 +41,18 @@ export type IconName =
     | "arrowUp"
     | "availability"
     | "bag"
+    | "balloon"
     | "bell"
     | "book"
+    | "bounce"
     | "brush"
     | "bundle"
     | "button"
     | "buttonLine"
+    | "cake"
     | "calendar"
-    | "calendarCross"
+    | "calenderAdd"
+    | "calenderCross"
     | "car"
     | "carrot"
     | "cart"
@@ -50,10 +70,12 @@ export type IconName =
     | "close"
     | "closeCircle"
     | "club"
+    | "code"
     | "coin"
     | "combine"
     | "comment"
     | "complianceCheck"
+    | "construction"
     | "copy"
     | "customer"
     | "dashboard"
@@ -79,11 +101,15 @@ export type IconName =
     | "export"
     | "eye"
     | "eyeCrossed"
+    | "fileExport"
+    | "fileImport"
     | "filter"
     | "flag"
+    | "form"
     | "gift"
     | "giftCard"
     | "gradHat"
+    | "group"
     | "hammer"
     | "hand"
     | "heart"
@@ -91,6 +117,7 @@ export type IconName =
     | "history"
     | "image"
     | "imagePlaceholder"
+    | "import"
     | "infoCircle"
     | "inventory"
     | "language"
@@ -102,6 +129,7 @@ export type IconName =
     | "locationBottom"
     | "locationPage"
     | "locationTop"
+    | "lock"
     | "logOut"
     | "loyalty"
     | "map"
@@ -109,15 +137,19 @@ export type IconName =
     | "marketing"
     | "megaAdmin"
     | "menu"
+    | "merge"
     | "minus"
+    | "moon"
     | "moreActions"
     | "move"
+    | "network"
     | "newTab"
     | "note"
     | "notification"
     | "onboarding"
     | "package"
     | "paperPlane"
+    | "pauseCircle"
     | "percent"
     | "phone"
     | "platter"
@@ -126,11 +158,14 @@ export type IconName =
     | "pos"
     | "posProfile"
     | "pound"
+    | "power"
     | "print"
     | "process"
     | "product"
+    | "qr"
     | "questionCircle"
     | "rand"
+    | "receipt"
     | "redo"
     | "redoLarge"
     | "reload"
@@ -138,14 +173,19 @@ export type IconName =
     | "report"
     | "reservation"
     | "rocket"
+    | "screen"
     | "search"
     | "security"
+    | "seedling"
+    | "send"
     | "setting"
     | "shuffle"
     | "smartphone"
+    | "sparkle"
     | "split"
     | "star"
     | "store"
+    | "sun"
     | "support"
     | "switchUser"
     | "sync"
@@ -156,7 +196,11 @@ export type IconName =
     | "textAlignLeft"
     | "textAlignRight"
     | "textBold"
+    | "textCase"
     | "textItalic"
+    | "textSize"
+    | "thumbsDown"
+    | "thumbsUp"
     | "ticket"
     | "time"
     | "title"
@@ -167,335 +211,521 @@ export type IconName =
     | "undoLarge"
     | "upload"
     | "user"
+    | "users"
     | "video"
     | "wallet"
     | "wand"
     | "warning"
-    | "wine";
+    | "wine"
+    | "write";
 
-export class Alert extends React.Component<{
+export const c7Colors: {
+    white: string;
+    black: string;
+    yellow100: string;
+    yellow200: string;
+    yellow300: string;
+    green100: string;
+    green200: string;
+    green300: string;
+    red100: string;
+    red200: string;
+    red300: string;
+    orange100: string;
+    orange200: string;
+    orange300: string;
+    purple100: string;
+    purple200: string;
+    purple300: string;
+    violet100: string;
+    violet200: string;
+    violet300: string;
+    blue100: string;
+    blue200: string;
+    blue300: string;
+    blue400: string;
+    blue500: string;
+    blue600: string;
+    blueberry100: string;
+    blueberry200: string;
+    blueberry300: string;
+    slate100: string;
+    slate200: string;
+    slate300: string;
+    slate400: string;
+    gray100: string;
+    gray200: string;
+    gray300: string;
+    gray400: string;
+    gray500: string;
+    gray600: string;
+    gray700: string;
+    gray750: string;
+    gray800: string;
+    gray900: string;
+    gray950: string;
+};
+
+export interface AlertProps {
     children?: React.ReactNode | undefined;
     className?: string | undefined;
-    variant?: "default" | "info" | "error" | "warning" | "success" | undefined;
-    size?: "default" | "small" | undefined;
-    icon?: IconName | undefined;
-}> {}
+    component?: ComponentOverride | undefined;
+    variant?: StatusVariant | undefined;
+    size?: ButtonSize | undefined;
+    icon?: IconName | string | undefined;
+    dataTestId?: string | undefined;
+    href?: string | undefined;
+    [key: string]: any;
+}
 
-export class Avatar extends React.Component<{
+export class Alert extends React.Component<AlertProps> {}
+
+export interface AvatarProps {
     className?: string | undefined;
     label?: string | undefined;
     imageSrc?: string | undefined;
     imageAlt?: string | undefined;
     size?: "tiny" | "small" | "default" | "large" | undefined;
-}> {}
+    dataTestId?: string | undefined;
+}
 
-export class Breadcrumb extends React.Component<{
-    children?: React.ReactNode;
+export class Avatar extends React.Component<AvatarProps> {}
+
+export interface BreadcrumbProps {
+    children: React.ReactNode;
     className?: string | undefined;
-    onClick?: (() => void) | undefined;
-    component?: any;
+    onClick?: (() => void) | null | undefined;
+    component?: React.ElementType | undefined;
     href?: string | undefined;
-}> {}
+    dataTestId?: string | undefined;
+}
 
-export class Breadcrumbs extends React.Component<{
+export class Breadcrumb extends React.Component<BreadcrumbProps> {}
+
+export interface BreadcrumbsProps {
     className?: string | undefined;
-    children?: React.ReactNode | undefined;
-}> {
+    children: React.ReactNode;
+    dataTestId?: string | undefined;
+}
+
+export class Breadcrumbs extends React.Component<BreadcrumbsProps> {
     static Breadcrumb: typeof Breadcrumb;
 }
 
-export class Card extends React.Component<{
+export interface CardProps {
     variant?: "default" | "white" | undefined;
     className?: string | undefined;
     children: React.ReactNode;
-}> {}
+    dataTestId?: string | null | undefined;
+}
 
-export class Column extends React.Component<{
+export class Card extends React.Component<CardProps> {}
+
+export interface ColumnProps {
     children?: React.ReactNode | undefined;
     span?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | "none" | "auto" | undefined;
-}> {}
+}
 
-export class Columns extends React.Component<{
+export class Column extends React.Component<ColumnProps> {}
+
+export interface ColumnsProps {
     children: React.ReactNode;
-    justify?: React.CSSProperties["justifyContent"] | undefined;
-    align?: React.CSSProperties["alignItems"] | undefined;
-    wrap?: "nowrap" | "wrap" | "wrap-reverse" | undefined;
+    justify?: string | undefined;
+    align?: string | undefined;
+    wrap?: string | undefined;
     className?: string | undefined;
-}> {
+    dataTestId?: string | undefined;
+}
+
+export class Columns extends React.Component<ColumnsProps> {
     static Column: typeof Column;
 }
 
-export class InfoCardGrid extends React.Component<{
+export interface InfoCardGridProps {
     children?: React.ReactNode | undefined;
     className?: string | undefined;
-}> {}
+    dataTestId?: string | undefined;
+}
 
-export class InfoCard extends React.Component<{
+export class InfoCardGrid extends React.Component<InfoCardGridProps> {}
+
+export interface InfoCardProps {
     children?: React.ReactNode | undefined;
     className?: string | undefined;
-    icon?: IconName | undefined;
+    dataTestId?: string | undefined;
+    icon?: IconName | string | undefined;
     label?: React.ReactNode | undefined;
     title?: React.ReactNode | undefined;
     subtitle?: React.ReactNode | undefined;
-    variant?: "default" | "success" | "error" | "warning" | "info" | undefined;
+    variant?: StatusVariant | undefined;
+    iconVariant?: StatusVariant | undefined;
     img?: string | undefined;
-}> {
+}
+
+export class InfoCard extends React.Component<InfoCardProps> {
     static InfoCardGrid: typeof InfoCardGrid;
 }
 
-export class LineBreak extends React.Component<{
+export interface LineBreakProps {
     className?: string | undefined;
-}> {}
+    dataTestId?: string | undefined;
+}
 
-export class ModalBody extends React.Component<{
+export class LineBreak extends React.Component<LineBreakProps> {}
+
+export interface ModalBodyProps {
     children: React.ReactNode;
     className?: string | undefined;
-}> {}
+}
 
-export class ModalFooter extends React.Component<{
+export class ModalBody extends React.Component<ModalBodyProps> {}
+
+export interface ModalFooterProps {
     children: React.ReactNode;
     className?: string | undefined;
-}> {}
+}
 
-export class Modal extends React.Component<{
+export class ModalFooter extends React.Component<ModalFooterProps> {}
+
+export interface ModalProps {
     children?: React.ReactNode | undefined;
     className?: string | undefined;
     disableBodyScroll?: boolean | undefined;
-    onClose?: (() => void) | undefined;
+    onClose?: (() => void) | null | undefined;
     title?: string | undefined;
     visible?: boolean | undefined;
-}> {
+    dataTestId?: string | undefined;
+    disableFocusLock?: boolean | undefined;
+}
+
+export class Modal extends React.Component<ModalProps> {
     static ModalBody: typeof ModalBody;
     static ModalFooter: typeof ModalFooter;
 }
 
-export class NoRecords extends React.Component<{
+export interface NoRecordsProps {
     title?: string | undefined;
     description?: string | undefined;
-    icon?: IconName | undefined;
+    icon?: IconName | string | undefined;
     className?: string | undefined;
-}> {}
+    dataTestId?: string | undefined;
+    iconVariant?: Exclude<DisplayIconVariant, "tip"> | undefined;
+}
 
-export class Picture extends React.Component<{
+export class NoRecords extends React.Component<NoRecordsProps> {}
+
+export interface PictureSource {
+    src?: string | undefined;
+    webp?: string | undefined;
+    avif?: string | undefined;
+}
+
+export interface PictureProps {
     className?: string | undefined;
+    dataTestId?: string | undefined;
     height?: number | undefined;
-    src?: string | { src: string; webp: string; avif: string } | undefined;
-    alt?: string | undefined;
-}> {}
+    src?: string | PictureSource | undefined;
+    alt: string;
+}
 
-export class ProgressBar extends React.Component<{
+export class Picture extends React.Component<PictureProps> {}
+
+export interface ProgressBarContent {
+    text?: string | undefined;
+    circleColor?: string | undefined;
+    progress?: number | undefined;
+}
+
+export interface ProgressBarProps {
     progress?: number | undefined;
     className?: string | undefined;
-    content?: { text: string; circleColor: string; progress: number } | undefined;
+    content?: ProgressBarContent | undefined;
     color?: string | undefined;
-}> {}
+    dataTestId?: string | undefined;
+}
 
-export class Region extends React.Component<{
+export class ProgressBar extends React.Component<ProgressBarProps> {}
+
+export interface RegionProps {
     children: React.ReactNode;
     className?: string | undefined;
     borderBottom?: boolean | undefined;
-}> {}
+    dataTestId?: string | undefined;
+}
 
-export class Spinner extends React.Component<{
+export class Region extends React.Component<RegionProps> {}
+
+export interface SpinnerProps {
     label?: string | undefined;
     className?: string | undefined;
-}> {}
+    dataTestId?: string | undefined;
+}
 
-export class Tag extends React.Component<{
+export class Spinner extends React.Component<SpinnerProps> {}
+
+export interface TagProps {
     className?: string | undefined;
     children?: React.ReactNode | undefined;
-    onClick?: (() => void) | undefined;
-    onDelete?: (() => void) | undefined;
-    variant?: "default" | "info" | "warning" | "error" | "success" | undefined;
-    startIcon?: IconName | undefined;
-    endIcon?: IconName | undefined;
-}> {}
+    onClick?: ((event: React.MouseEvent<HTMLElement>) => void) | undefined;
+    onDelete?: ((event: React.MouseEvent<HTMLButtonElement>) => void) | undefined;
+    variant?: StatusVariant | undefined;
+    startIcon?: IconName | string | undefined;
+    endIcon?: IconName | string | undefined;
+    dataTestId?: string | undefined;
+}
 
-export class Button extends React.Component<{
+export class Tag extends React.Component<TagProps> {}
+
+export interface ButtonProps {
     children?: React.ReactNode | undefined;
     className?: string | undefined;
     disabled?: boolean | undefined;
     loading?: boolean | undefined;
-    onClick?: (() => void) | undefined;
-    size?: "default" | "small" | undefined;
-    startIcon?: IconName | undefined;
-    type?: "button" | "submit" | undefined;
-    variant?: "primary" | "secondary" | "text" | "link" | undefined;
+    onClick?: ((event: React.MouseEvent<HTMLButtonElement>) => void) | undefined;
+    size?: ButtonSize | undefined;
+    startIcon?: IconName | string | undefined;
+    endIcon?: IconName | string | undefined;
+    type?: ButtonType | undefined;
+    variant?: ButtonVariant | undefined;
+    dataTestId?: string | undefined;
     formNoValidate?: boolean | undefined;
-}> {}
-
-export class ButtonMenuItem extends React.Component<{
-    children: React.ReactNode;
-    className?: string | undefined;
-    disabled?: boolean | undefined;
-    label?: string | undefined;
-    size?: "default" | "small" | undefined;
-    variant?: "primary" | "secondary" | "text" | undefined;
-    onClick?: (() => void) | undefined;
-    icon?: IconName | undefined;
-}> {}
-
-export class ButtonMenu extends React.Component<{
-    children: React.ReactNode;
-    className?: string | undefined;
-}> {
-    static ButtonMenuItem: typeof ButtonMenuItem;
 }
 
-export class ContextMenuItem extends React.Component<{
+export class Button extends React.Component<ButtonProps> {}
+
+export interface ContextMenuItemProps {
     alt?: string | undefined;
     children: React.ReactNode;
     className?: string | undefined;
     disabled?: boolean | undefined;
-    icon?: IconName | undefined;
+    icon?: IconName | string | undefined;
     img?: string | undefined;
-    onClick?: (() => void) | undefined;
-}> {}
+    onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
+    dataTestId?: string | undefined;
+}
 
-export class ContextMenuMoreActions extends React.Component<{
+export class ButtonMenuItem extends React.Component<ContextMenuItemProps> {}
+
+export interface ButtonMenuProps {
+    children: React.ReactNode;
+    className?: string | undefined;
+    disabled?: boolean | undefined;
+    label?: string | undefined;
+    size?: ButtonSize | undefined;
+    variant?: ButtonMenuVariant | undefined;
+    dataTestId?: string | undefined;
+    onClick?: ((event: React.MouseEvent<HTMLButtonElement>) => void) | undefined;
+}
+
+export class ButtonMenu extends React.Component<ButtonMenuProps> {
+    static ButtonMenuItem: typeof ButtonMenuItem;
+}
+
+export class ContextMenuItem extends React.Component<ContextMenuItemProps> {}
+
+export interface ContextMenuMoreActionsProps {
     children: React.ReactNode;
     className?: string | undefined;
     label?: string | undefined;
     disabled?: boolean | undefined;
-}> {}
+    dataTestId?: string | undefined;
+}
 
-export class ContextMenu extends React.Component<{
+export class ContextMenuMoreActions extends React.Component<ContextMenuMoreActionsProps> {}
+
+export interface ContextMenuProps {
     children: React.ReactNode;
     className?: string | undefined;
-}> {
+    dataTestId?: string | undefined;
+}
+
+export class ContextMenu extends React.Component<ContextMenuProps> {
     static ContextMenuItem: typeof ContextMenuItem;
     static ContextMenuMoreActions: typeof ContextMenuMoreActions;
 }
 
-export class LinkButton extends React.Component<{
+export interface LinkButtonProps {
     children?: React.ReactNode | undefined;
     className?: string | undefined;
-    component?: any;
+    component?: ComponentOverride | undefined;
     disabled?: boolean | undefined;
     download?: boolean | undefined;
+    loading?: boolean | undefined;
     href?: string | undefined;
     rel?: string | undefined;
-    size?: "default" | "small" | undefined;
-    startIcon?: IconName | undefined;
+    size?: ButtonSize | undefined;
+    startIcon?: IconName | string | undefined;
+    endIcon?: IconName | string | undefined;
     target?: string | undefined;
-    variant?: "primary" | "secondary" | "text" | "link" | undefined;
-}> {}
+    variant?: ButtonVariant | undefined;
+    dataTestId?: string | undefined;
+    onClick?: ((event: React.MouseEvent<HTMLAnchorElement>) => void) | undefined;
+    [key: string]: any;
+}
 
-export class SelectButton extends React.Component<{
+export class LinkButton extends React.Component<LinkButtonProps> {}
+
+export interface SelectButtonProps {
     children?: React.ReactNode | undefined;
     className?: string | undefined;
     disabled?: boolean | undefined;
     loading?: boolean | undefined;
     selected?: boolean | undefined;
-    onClick?: (() => void) | undefined;
-    type?: "button" | "submit" | undefined;
-    size?: "small" | "medium" | "large" | undefined;
-    icon?: IconName | undefined;
-}> {}
+    onClick?: ((event: React.MouseEvent<HTMLButtonElement>) => void) | undefined;
+    type?: ButtonType | undefined;
+    dataTestId?: string | undefined;
+    size?: FormButtonSize | undefined;
+    icon?: IconName | string | undefined;
+    as?: any;
+}
 
-export class CardLink extends React.Component<{
+export class SelectButton extends React.Component<SelectButtonProps> {}
+
+export interface CardLinkProps {
     className?: string | undefined;
     children: React.ReactNode;
-    component?: any;
+    component?: ComponentOverride | undefined;
     href?: string | undefined;
-    icon?: IconName | undefined;
+    icon?: IconName | string | undefined;
     description?: string | undefined;
     label?: string | undefined;
-}> {}
+    dataTestId?: string | undefined;
+    [key: string]: any;
+}
 
-export class SubNav extends React.Component<{
+export class CardLink extends React.Component<CardLinkProps> {}
+
+export interface SubNavProps {
     children?: React.ReactNode | undefined;
     className?: string | undefined;
     isOpen?: boolean | undefined;
-}> {}
+    dataTestId?: string | undefined;
+}
 
-export class NavLink extends React.Component<{
+export class SubNav extends React.Component<SubNavProps> {}
+
+export interface NavLinkProps {
     children?: React.ReactNode | undefined;
     className?: string | undefined;
-    icon?: IconName | undefined;
-    component?: any;
-    onClick?: (() => void) | undefined;
+    dataTestId?: string | undefined;
+    icon?: IconName | string | undefined;
+    component?: ComponentOverride | undefined;
+    onClick?: ((event: React.MouseEvent<HTMLElement>) => void) | undefined;
     href?: string | undefined;
     activeClassName?: string | undefined;
-}> {}
+    [key: string]: any;
+}
 
-export class SubNavLink extends React.Component<{
+export class NavLink extends React.Component<NavLinkProps> {}
+
+export interface SubNavLinkProps {
     children?: React.ReactNode | undefined;
     className?: string | undefined;
-    component?: any;
-    onClick?: (() => void) | undefined;
+    component?: ComponentOverride | undefined;
+    dataTestId?: string | undefined;
+    onClick?: ((event: React.MouseEvent<HTMLElement>) => void) | undefined;
     href?: string | undefined;
     activeClassName?: string | undefined;
-}> {}
+    [key: string]: any;
+}
 
-export class Nav extends React.Component<{
+export class SubNavLink extends React.Component<SubNavLinkProps> {}
+
+export interface NavProps {
     children?: React.ReactNode | undefined;
     className?: string | undefined;
-}> {
+    isOpen?: boolean | undefined;
+    dataTestId?: string | undefined;
+}
+
+export class Nav extends React.Component<NavProps> {
     static SubNav: typeof SubNav;
     static NavLink: typeof NavLink;
     static SubNavLink: typeof SubNavLink;
 }
 
-export class Step extends React.Component<{
+export interface StepProps {
     step?: number | undefined;
     description?: string | undefined;
     className?: string | undefined;
-    component?: any;
-    onClick?: (() => void) | undefined;
+    dataTestId?: string | undefined;
+    component?: ComponentOverride | undefined;
+    onClick?: ((event: React.MouseEvent<HTMLElement>) => void) | undefined;
     href?: string | undefined;
     activeClassName?: string | undefined;
-    icon?: IconName | undefined;
-}> {}
+    icon?: IconName | string | undefined;
+}
 
-export class Stepper extends React.Component<{
+export class Step extends React.Component<StepProps> {}
+
+export interface StepperProps {
     children?: React.ReactNode | undefined;
     className?: string | undefined;
-}> {
+    dataTestId?: string | undefined;
+}
+
+export class Stepper extends React.Component<StepperProps> {
     static Step: typeof Step;
 }
 
-export class SubMenuItem extends React.Component<{
+export interface SubMenuItemProps {
     children?: React.ReactNode | undefined;
     activeClassName?: string | undefined;
     className?: string | undefined;
-    component?: any;
-    onClick?: (() => void) | undefined;
+    component?: ComponentOverride | undefined;
+    onClick?: ((event: React.MouseEvent<HTMLElement>) => void) | undefined;
     href?: string | undefined;
-}> {}
+    dataTestId?: string | undefined;
+    [key: string]: any;
+}
 
-export class SubMenu extends React.Component<{
+export class SubMenuItem extends React.Component<SubMenuItemProps> {}
+
+export interface SubMenuProps {
     children?: React.ReactNode | undefined;
     className?: string | undefined;
+    dataTestId?: string | undefined;
     borderBottom?: boolean | undefined;
     activeClassName?: string | undefined;
-}> {
+}
+
+export class SubMenu extends React.Component<SubMenuProps> {
     static SubMenuItem: typeof SubMenuItem;
 }
 
-export class Tab extends React.Component<{
+export interface TabProps {
     children?: React.ReactNode | undefined;
     className?: string | undefined;
-    component?: any;
-    onClick?: (() => void) | undefined;
+    dataTestId?: string | undefined;
+    component?: ComponentOverride | undefined;
+    onClick?: ((event: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => void) | undefined;
     href?: string | undefined;
     activeClassName?: string | undefined;
-}> {}
+    [key: string]: any;
+}
 
-export class TabBody extends React.Component<{
+export class Tab extends React.Component<TabProps> {}
+
+export interface TabBodyProps {
     children?: React.ReactNode | undefined;
     className?: string | undefined;
-}> {}
+    dataTestId?: string | undefined;
+}
 
-export class Tabs extends React.Component<{
+export class TabBody extends React.Component<TabBodyProps> {}
+
+export interface TabsProps {
     children?: React.ReactNode | undefined;
     className?: string | undefined;
-}> {
+    dataTestId?: string | undefined;
+}
+
+export class Tabs extends React.Component<TabsProps> {
     static Tab: typeof Tab;
     static TabBody: typeof TabBody;
 }
 
-export class Checkbox extends React.Component<{
+export interface CheckboxProps {
     checked: boolean;
     className?: string | undefined;
     description?: string | undefined;
@@ -503,76 +733,89 @@ export class Checkbox extends React.Component<{
     errorMessage?: string | undefined;
     id?: string | undefined;
     label?: string | undefined;
-    onChange?: (() => void) | undefined;
+    onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
     required?: boolean | undefined;
     value?: string | undefined;
-    variant?: "button" | "default" | undefined;
-    size?: "small" | "medium" | "large" | undefined;
-    icon?: IconName | undefined;
-}> {}
+    dataTestId?: string | undefined;
+    variant?: FormButtonVariant | undefined;
+    size?: FormButtonSize | undefined;
+    icon?: IconName | string | undefined;
+    children?: React.ReactNode | undefined;
+}
 
-export class CheckboxGroup extends React.Component<{
+export class Checkbox extends React.Component<CheckboxProps> {}
+
+export interface CheckboxGroupProps {
     children: React.ReactNode;
     className?: string | undefined;
     errorMessage?: string | undefined;
     label?: string | undefined;
     required?: boolean | undefined;
+    dataTestId?: string | undefined;
     variant?: "button" | null | undefined;
-    size?: "small" | "medium" | "large" | undefined;
-}> {}
+    size?: FormButtonSize | undefined;
+}
 
-export class DataDisplay extends React.Component<{
+export class CheckboxGroup extends React.Component<CheckboxGroupProps> {}
+
+export interface DataDisplayProps {
     children?: React.ReactNode | undefined;
     className?: string | undefined;
     label: string;
-}> {}
+    dataTestId?: string | undefined;
+}
 
-export class DatePicker extends React.Component<{
+export class DataDisplay extends React.Component<DataDisplayProps> {}
+
+export interface DatePickerProps {
     allowClear?: boolean | undefined;
     autoFocus?: boolean | undefined;
-    children?: React.ReactNode | undefined;
-    description?: string | undefined;
+    className?: string | undefined;
+    description?: string | null | undefined;
     disabled?: boolean | undefined;
-    errorMessage?: string | undefined;
+    errorMessage?: string | null | undefined;
     id?: string | undefined;
     inline?: boolean | undefined;
-    isValidDate?: ((d: Date) => boolean) | undefined;
-    label?: string | undefined;
-    onChange: (d: Date) => void;
-    onBlur?: (() => void) | undefined;
-    onFocus?: (() => void) | undefined;
+    isValidDate?: ((currentDate: Moment) => boolean) | undefined;
+    label?: string | null | undefined;
+    onChange: (date: Moment | string) => void;
+    onBlur?: ((event: React.FocusEvent<HTMLInputElement>) => void) | undefined;
+    onFocus?: ((event: React.FocusEvent<HTMLInputElement>) => void) | undefined;
     placeholder?: string | undefined;
     required?: boolean | undefined;
     value: string;
-}> {}
+    dataTestId?: string | null | undefined;
+    variant?: "default" | "dayFormat" | undefined;
+}
 
-export class Input extends React.Component<{
+export class DatePicker extends React.Component<DatePickerProps> {}
+
+export interface InputProps {
     autoFocus?: boolean | undefined;
     autoComplete?: string | undefined;
     className?: string | undefined;
     description?: string | undefined;
     disabled?: boolean | undefined;
-    startIcon?: IconName | undefined;
-    endIcon?: IconName | undefined;
+    startIcon?: IconName | string | undefined;
+    endIcon?: IconName | string | undefined;
     suffix?: string | undefined;
     errorMessage?: string | undefined;
     id?: string | undefined;
     label?: string | undefined;
-    inputMode?: "text" | "decimal" | "numeric" | "tel" | "search" | "email" | "url" | undefined;
-    onBlur?: (() => void) | undefined;
-    onChange?: ((e: React.ChangeEvent<HTMLInputElement>) => void) | undefined;
-    // onChange is marked as required in the docs, but Input elements are shown elsewhere
-    // in the docs with this property omitted
-    onFocus?: (() => void) | undefined;
+    inputMode?: InputMode | undefined;
+    onBlur?: ((event: React.FocusEvent<HTMLInputElement>) => void) | undefined;
+    onChange?: ((event: React.ChangeEvent<HTMLInputElement>) => void) | undefined;
+    onFocus?: ((event: React.FocusEvent<HTMLInputElement>) => void) | undefined;
     placeholder?: string | undefined;
     required?: boolean | undefined;
-    type?: "text" | "number" | "password" | "email" | "color" | undefined;
+    type?: InputType | undefined;
     value?: string | number | undefined;
-    // value is marked as required in the docs, but Input elements are shown elsewhere
-    // in the docs with this property omitted
-}> {}
+    dataTestId?: string | undefined;
+}
 
-export class Radio extends React.Component<{
+export class Input extends React.Component<InputProps> {}
+
+export interface RadioProps {
     checked: boolean;
     className?: string | undefined;
     description?: string | undefined;
@@ -580,34 +823,39 @@ export class Radio extends React.Component<{
     errorMessage?: string | undefined;
     id?: string | undefined;
     label?: string | undefined;
-    onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-    onClick?: (() => void) | undefined;
+    onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+    onClick?: ((event: React.MouseEvent<HTMLElement>) => void) | undefined;
     required?: boolean | undefined;
     value: string;
-    variant?: "button" | "default" | undefined;
-    size?: "small" | "medium" | "large" | undefined;
-    icon?: IconName | undefined;
-}> {}
+    dataTestId?: string | undefined;
+    variant?: FormButtonVariant | undefined;
+    size?: FormButtonSize | undefined;
+    icon?: IconName | string | undefined;
+    children?: React.ReactNode | undefined;
+}
 
-export class RadioGroup extends React.Component<{
+export class Radio extends React.Component<RadioProps> {}
+
+export interface RadioGroupProps {
     children: React.ReactNode;
-    checked?: boolean | undefined;
     className?: string | undefined;
-    description?: string | undefined;
-    disabled?: boolean | undefined;
     errorMessage?: string | undefined;
-    id?: string | undefined;
     label?: string | undefined;
-    onChange?: (() => void) | undefined;
-    onClick?: (() => void) | undefined;
     required?: boolean | undefined;
-    value?: string | undefined;
-    variant?: "button" | "default" | undefined;
-    size?: "small" | "medium" | "large" | undefined;
-    icon?: IconName | undefined;
-}> {}
+    dataTestId?: string | undefined;
+    variant?: FormButtonVariant | undefined;
+    size?: FormButtonSize | undefined;
+}
 
-export class Select extends React.Component<{
+export class RadioGroup extends React.Component<RadioGroupProps> {}
+
+export interface OptionItem {
+    value?: string | number | undefined;
+    label: string;
+    options?: OptionItem[] | undefined;
+}
+
+export interface SelectProps {
     autoFocus?: boolean | undefined;
     className?: string | undefined;
     description?: string | undefined;
@@ -615,14 +863,17 @@ export class Select extends React.Component<{
     errorMessage?: string | undefined;
     id?: string | undefined;
     label?: string | undefined;
-    onChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
-    options?: Array<{ value: string | number; label: string }> | undefined;
+    onChange: (event: React.ChangeEvent<HTMLSelectElement>) => void;
+    options?: OptionItem[] | undefined;
     placeholder?: string | undefined;
     required?: boolean | undefined;
-    value?: string | number | undefined;
-}> {}
+    value: string | number;
+    dataTestId?: string | undefined;
+}
 
-export class Switch extends React.Component<{
+export class Select extends React.Component<SelectProps> {}
+
+export interface SwitchProps {
     checked: boolean;
     className?: string | undefined;
     description?: string | undefined;
@@ -630,12 +881,15 @@ export class Switch extends React.Component<{
     errorMessage?: string | undefined;
     id?: string | undefined;
     label?: string | undefined;
-    onChange: () => void;
+    onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
     required?: boolean | undefined;
     value?: string | undefined;
-}> {}
+    dataTestId?: string | undefined;
+}
 
-export class Textarea extends React.Component<{
+export class Switch extends React.Component<SwitchProps> {}
+
+export interface TextareaProps {
     autoFocus?: boolean | undefined;
     className?: string | undefined;
     description?: string | undefined;
@@ -644,48 +898,63 @@ export class Textarea extends React.Component<{
     height?: number | undefined;
     id?: string | undefined;
     label?: string | undefined;
-    onBlur?: (() => void) | undefined;
-    onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
-    onFocus?: (() => void) | undefined;
+    onBlur?: ((event: React.FocusEvent<HTMLTextAreaElement>) => void) | undefined;
+    onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
+    onFocus?: ((event: React.FocusEvent<HTMLTextAreaElement>) => void) | undefined;
     placeholder?: string | undefined;
     required?: boolean | undefined;
-    value: string | number;
-}> {}
+    value: string;
+    dataTestId?: string | undefined;
+}
 
-export class DisplayIcon extends React.Component<{
-    className?: string | undefined;
-    icon: IconName;
-    label?: string;
-    onClick?: (() => void) | undefined;
-    variant?: "default" | "success" | "warning" | "error" | undefined;
-}> {}
+export class Textarea extends React.Component<TextareaProps> {}
 
-export class Icon extends React.Component<{
+export interface DisplayIconProps {
     className?: string | undefined;
-    icon: IconName;
-    label?: string;
-    onClick?: (() => void) | undefined;
+    icon: IconName | string;
+    label?: string | undefined;
+    onClick?: ((event: React.MouseEvent<HTMLButtonElement>) => void) | undefined;
+    variant?: DisplayIconVariant | undefined;
+    dataTestId?: string | undefined;
+}
+
+export class DisplayIcon extends React.Component<DisplayIconProps> {}
+
+export interface IconProps {
+    className?: string | undefined;
+    icon: IconName | string;
+    label?: string | undefined;
+    onClick?: ((event: React.MouseEvent<HTMLButtonElement>) => void) | undefined;
     size?: number | undefined;
-    variant?: "default" | "success" | "warning" | "error" | undefined;
-}> {}
+    variant?: IconVariant | string | undefined;
+    dataTestId?: string | undefined;
+}
 
-export class VividIcon extends React.Component<{
+export class Icon extends React.Component<IconProps> {}
+
+export interface VividIconProps {
     className?: string | undefined;
-    icon: IconName;
-    label?: string;
-    onClick?: (() => void) | undefined;
-    color?: "pink" | "blue" | "green" | "teal" | "orange" | "purple" | undefined;
-}> {}
+    icon: IconName | string;
+    label?: string | undefined;
+    onClick?: ((event: React.MouseEvent<HTMLButtonElement>) => void) | undefined;
+    color?: "pink" | "blue" | "green" | "teal" | "orange" | "purple" | "gray" | undefined;
+    dataTestId?: string | undefined;
+}
 
-export class Heading extends React.Component<{
+export class VividIcon extends React.Component<VividIconProps> {}
+
+export interface HeadingProps {
     level?: 1 | 2 | 3 | 4 | undefined;
-    marginBottom?: string | undefined;
+    marginBottom?: string | null | undefined;
     children: React.ReactNode;
     className?: string | undefined;
-}> {}
+    dataTestId?: string | undefined;
+}
 
-export class Text extends React.Component<{
-    as?: string | undefined;
+export class Heading extends React.Component<HeadingProps> {}
+
+export interface TextProps {
+    as?: React.ElementType | undefined;
     block?: boolean | undefined;
     children?: React.ReactNode | undefined;
     className?: string | undefined;
@@ -696,72 +965,121 @@ export class Text extends React.Component<{
     uppercase?: boolean | undefined;
     secondary?: boolean | undefined;
     strikeThrough?: boolean | undefined;
-}> {}
+    dataTestId?: string | undefined;
+}
 
-export class Legend extends React.Component<{
-    data: Array<{ title: string; value?: string | number; color: string }>;
+export class Text extends React.Component<TextProps> {}
+
+export interface LegendItem {
+    title?: string | undefined;
+    value: string | number;
+    color: string;
+}
+
+export interface LegendProps {
+    data: LegendItem[];
     isVertical?: boolean | undefined;
     width?: string | number | undefined;
     legendHeader?: string | undefined;
-}> {}
+}
 
-export class PieChart extends React.Component<{
+export class Legend extends React.Component<LegendProps> {}
+
+export interface PieChartProps {
     data: Array<{ name: string; value: string | number }>;
     colors: string[];
     width?: string | number | undefined;
     height?: string | number | undefined;
     innerRadius?: string | number | undefined;
     outerRadius?: string | number | undefined;
-    margin?: { top?: number; bottom?: number; left?: number; right?: number } | undefined;
-    label?: React.ReactNode | undefined;
-    legendWrapperStyle?: any;
+    margin?:
+        | {
+            top?: number | undefined;
+            bottom?: number | undefined;
+            left?: number | undefined;
+            right?: number | undefined;
+        }
+        | undefined;
+    label?: any;
+    legendWrapperStyle?: React.CSSProperties | null | undefined;
     legend?: React.ReactNode | undefined;
-    legendProps?: any;
-    tooltip?: React.ReactNode | undefined;
+    legendProps?:
+        | {
+            width?: number | undefined;
+            verticalAlign?: "top" | "middle" | "bottom" | undefined;
+            align?: "left" | "center" | "right" | undefined;
+            layout?: "horizontal" | "vertical" | undefined;
+        }
+        | null
+        | undefined;
+    tooltip?: React.ReactElement | undefined;
     hideLegend?: boolean | undefined;
     hideTooltip?: boolean | undefined;
-}> {}
+}
 
-export class Thead extends React.Component<{
+export class PieChart extends React.Component<PieChartProps> {}
+
+export interface TheadProps {
     children: React.ReactNode;
     className?: string | undefined;
-}> {}
+    dataTestId?: string | undefined;
+}
 
-export class Tbody extends React.Component<{
+export class Thead extends React.Component<TheadProps> {}
+
+export interface TbodyProps {
     children?: React.ReactNode | undefined;
     className?: string | undefined;
-}> {}
+    dataTestId?: string | undefined;
+}
 
-export class Th extends React.Component<{
+export class Tbody extends React.Component<TbodyProps> {}
+
+export interface ThProps {
     align?: "left" | "center" | "right" | undefined;
     children?: React.ReactNode | undefined;
     className?: string | undefined;
     colSpan?: number | undefined;
-}> {}
+    dataTestId?: string | undefined;
+}
 
-export class Td extends React.Component<{
+export class Th extends React.Component<ThProps> {}
+
+export interface TdProps {
     children?: React.ReactNode | undefined;
     className?: string | undefined;
     colSpan?: number | undefined;
-    onClick?: (() => void) | undefined;
+    onClick?: ((event: React.MouseEvent<HTMLTableCellElement>) => void) | undefined;
     align?: "left" | "center" | "right" | undefined;
-}> {}
+    dataTestId?: string | undefined;
+}
 
-export class Tr extends React.Component<{
+export class Td extends React.Component<TdProps> {}
+
+export interface TrProps {
     children?: React.ReactNode | undefined;
     className?: string | undefined;
-    onClick?: (() => void) | undefined;
-}> {}
+    onClick?: ((event: React.MouseEvent<HTMLTableRowElement>) => void) | undefined;
+    dataTestId?: string | undefined;
+}
 
-export class Tfoot extends React.Component<{
+export class Tr extends React.Component<TrProps> {}
+
+export interface TfootProps {
     children: React.ReactNode;
     className?: string | undefined;
-}> {}
+    dataTestId?: string | undefined;
+}
 
-export class Table extends React.Component<{
+export class Tfoot extends React.Component<TfootProps> {}
+
+export interface TableProps {
     children?: React.ReactNode | undefined;
     className?: string | undefined;
-}> {
+    dataTestId?: string | undefined;
+}
+
+export class Table extends React.Component<TableProps> {
     static Thead: typeof Thead;
     static Tbody: typeof Tbody;
     static Th: typeof Th;

--- a/types/commerce7__admin-ui/package.json
+++ b/types/commerce7__admin-ui/package.json
@@ -4,7 +4,7 @@
     "version": "2.0.9999",
     "projects": [
         "https://www.npmjs.com/package/@commerce7/admin-ui",
-        "https://admin-ui-docs.commerce7.com/?path=/docs/c7-admin-ui--docs"
+        "https://admin-ui-docs.commerce7.com/?path=/docs/c7-admin-ui--documentation"
     ],
     "devDependencies": {
         "@types/commerce7__admin-ui": "workspace:."

--- a/types/commerce7__admin-ui/package.json
+++ b/types/commerce7__admin-ui/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/commerce7__admin-ui",
-    "version": "1.11.9999",
+    "version": "2.0.9999",
     "projects": [
         "https://www.npmjs.com/package/@commerce7/admin-ui",
         "https://admin-ui-docs.commerce7.com/?path=/docs/c7-admin-ui--docs"
@@ -10,7 +10,8 @@
         "@types/commerce7__admin-ui": "workspace:."
     },
     "dependencies": {
-        "@types/react": "*"
+        "@types/react": "*",
+        "moment": "^2.30.1"
     },
     "owners": [
         {


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://admin-ui-docs.commerce7.com/?path=/docs/release-notes--documentation
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

While writing this pull request message, I found their changelog linked above, and for the major version 2.0.0, it says they switched entirely to typescript, but the node package doesn't have any types included. I am guessing this is just a packaging oversight. Since I already completed the work for this pull request, I will submit it. I will also ask them about the possibility of publishing native types, and if/when that happens we can remove this package entirely. 

### AI Agent Assisted
I did use codex GPT-5.5 xhigh for updating the existing type definitions for this package. It was very helpful at inspecting the minified javascript from @commerce7/admin-ui and verifying implementation details like when parameters are passed unmodified to react, so the react types can be used in the type declaration. It also found a significant issue where subcomponents were also exported as top level components, which was incorrect. That all being said, all the generated code was reviewed by me, and a lot of the issues found by codex were fixed by hand. I stand by the code in this PR. 