### PR TITLE
chore: remove pnpm overrides field

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,10 +46,5 @@
         "risk": "^0.0.4",
         "typescript": "next"
     },
-    "pnpm": {
-        "overrides": {
-            "fflate": "0.8.2"
-        }
-    },
     "type": "module"
 }


### PR DESCRIPTION
Infra change, to get rid of the annoying warning message.

> The "pnpm" field in package.json is no longer read by pnpm. The following keys were ignored: "pnpm.overrides". See https://pnpm.io/settings for the new home of each setting.

From the warning, I suspect the override field is no longer useful and hence no longer needed.
