### PR TITLE
[hotwired__turbo] Align types with the v8.0.23 implementation

### DIFF
--- a/types/hotwired__turbo/hotwired__turbo-tests.ts
+++ b/types/hotwired__turbo/hotwired__turbo-tests.ts
@@ -38,6 +38,9 @@ import {
     VisitOptions,
 } from "@hotwired/turbo";
 
+// @ts-expect-error - RequestMethod is an internal helper type, not a Turbo export
+type RequestMethodIsNotExported = import("@hotwired/turbo").RequestMethod;
+
 const turboFrame = document.querySelector("turbo-frame")!;
 
 // $ExpectType FrameElement
@@ -218,8 +221,11 @@ document.addEventListener("turbo:frame-missing", function(event) {
 
 document.addEventListener("turbo:submit-start", function(event) {
     event.detail.formSubmission.stop();
-    // $ExpectType string
+    // $ExpectType "GET" | "POST" | "PUT" | "PATCH" | "DELETE"
     event.detail.formSubmission.method;
+    event.detail.formSubmission.method = "post";
+    // @ts-expect-error - method assignments accept Turbo's lowercase verbs only
+    event.detail.formSubmission.method = "POST";
 });
 
 document.addEventListener("turbo:submit-end", function(event) {
@@ -432,7 +438,7 @@ FetchMethod.get;
 FetchMethod.delete;
 // $ExpectType "application/x-www-form-urlencoded"
 FetchEnctype.urlEncoded;
-// $ExpectType "get" | "post" | "put" | "patch" | "delete" | undefined
+// $ExpectType RequestMethod | undefined
 fetchMethodFromString("GET");
 // $ExpectType "application/x-www-form-urlencoded" | "multipart/form-data" | "text/plain"
 fetchEnctypeFromString("multipart/form-data");
@@ -457,11 +463,16 @@ const fetchRequestDelegate: FetchRequestDelegate = {
 const fetchRequest = new FetchRequest(fetchRequestDelegate, "post", new URL("https://example.com"), new FormData());
 // @ts-expect-error - a FetchRequest cannot be constructed without arguments
 new FetchRequest();
-// $ExpectType string
+// $ExpectType "GET" | "POST" | "PUT" | "PATCH" | "DELETE"
 fetchRequest.method;
 fetchRequest.method = "put";
 // @ts-expect-error - method assignments accept Turbo's lowercase verbs only
 fetchRequest.method = "PUT";
+// $ExpectType "GET" | "POST" | "PUT" | "PATCH" | "DELETE"
+fetchRequest.fetchOptions.method;
+fetchRequest.fetchOptions.method = "PUT";
+// @ts-expect-error - fetchOptions.method stores Turbo's uppercase verbs only
+fetchRequest.fetchOptions.method = "HEAD";
 // $ExpectType URLSearchParams
 fetchRequest.params;
 // $ExpectType URL

--- a/types/hotwired__turbo/hotwired__turbo-tests.ts
+++ b/types/hotwired__turbo/hotwired__turbo-tests.ts
@@ -20,12 +20,14 @@ import {
     NavigatorDelegate,
     PageRenderer,
     PageSnapshot,
+    PageView,
     ProgressBar,
     registerAdapter,
     renderStreamMessage,
     session,
     setConfirmMethod,
     setProgressBarDelay,
+    SnapshotCache,
     start,
     StreamActions,
     StreamMessage,
@@ -424,6 +426,48 @@ session.restorationIdentifier;
 session.started;
 // $ExpectType boolean
 session.enabled;
+
+// Test PageView via session.view
+// PageView and SnapshotCache are not runtime exports of @hotwired/turbo, only types
+// @ts-expect-error
+new PageView(session, document.documentElement);
+// @ts-expect-error
+new SnapshotCache(10);
+// $ExpectType PageView
+session.view;
+// $ExpectType PageView
+Turbo.session.view;
+// @ts-expect-error - view cannot be reassigned
+session.view = session.view;
+// $ExpectType URL
+session.view.lastRenderedLocation;
+session.view.lastRenderedLocation = new URL("https://example.com");
+// $ExpectType HTMLElement
+session.view.element;
+// $ExpectType boolean
+session.view.forceReloaded;
+// $ExpectType PageSnapshot
+session.view.snapshot;
+// $ExpectType Promise<PageSnapshot | undefined>
+session.view.cacheSnapshot();
+session.view.cacheSnapshot(PageSnapshot.fromHTMLString("<html><body></body></html>"));
+// $ExpectType PageSnapshot | undefined
+session.view.getCachedSnapshotForLocation(new URL("https://example.com"));
+session.view.clearSnapshotCache();
+
+// Test SnapshotCache via session.view.snapshotCache
+// $ExpectType SnapshotCache
+session.view.snapshotCache;
+// $ExpectType boolean
+session.view.snapshotCache.has(new URL("https://example.com"));
+// $ExpectType PageSnapshot | undefined
+session.view.snapshotCache.get(new URL("https://example.com"));
+// $ExpectType PageSnapshot
+session.view.snapshotCache.put(
+    new URL("https://example.com"),
+    PageSnapshot.fromHTMLString("<html><body></body></html>"),
+);
+session.view.snapshotCache.clear();
 
 // Test FrameLoadingStyle
 // $ExpectType "eager"

--- a/types/hotwired__turbo/hotwired__turbo-tests.ts
+++ b/types/hotwired__turbo/hotwired__turbo-tests.ts
@@ -281,7 +281,12 @@ navigator.delegate;
 navigator.delegate.adapter;
 
 // Test ProgressBar via BrowserAdapter cast
+// BrowserAdapter is not a runtime export of @hotwired/turbo, only a type
+// @ts-expect-error
+new BrowserAdapter();
 const browserAdapter = navigator.delegate.adapter as BrowserAdapter;
+const browserAdapterAsAdapter: Adapter = browserAdapter;
+browserAdapterAsAdapter.visitStarted;
 // $ExpectType ProgressBar
 browserAdapter.progressBar;
 browserAdapter.progressBar.setValue(0);
@@ -376,16 +381,16 @@ disconnectStreamSource(webSocket);
 // @ts-expect-error
 connectStreamSource({});
 
-const streamMessage = new StreamMessage(document.createDocumentFragment());
+const streamMessage: StreamMessage = { fragment: document.createDocumentFragment() };
 renderStreamMessage("<turbo-stream></turbo-stream>");
 renderStreamMessage(streamMessage);
 Turbo.renderStreamMessage("<turbo-stream></turbo-stream>");
 Turbo.renderStreamMessage(streamMessage);
 
-// $ExpectType "text/vnd.turbo-stream.html"
-StreamMessage.contentType;
-
-// $ExpectType StreamMessage
+// StreamMessage is not a runtime export of @hotwired/turbo, only a type
+// @ts-expect-error
+new StreamMessage(document.createDocumentFragment());
+// @ts-expect-error
 StreamMessage.wrap("<turbo-stream></turbo-stream>");
 
 // Test TurboHistory via session.history
@@ -465,7 +470,7 @@ fetchRequest.location;
 fetchRequest.isSafe;
 // $ExpectType Promise<FetchResponse | undefined>
 fetchRequest.perform();
-fetchRequest.acceptResponseType(StreamMessage.contentType);
+fetchRequest.acceptResponseType("text/vnd.turbo-stream.html");
 fetchRequest.cancel();
 
 // Test FetchResponse construction

--- a/types/hotwired__turbo/hotwired__turbo-tests.ts
+++ b/types/hotwired__turbo/hotwired__turbo-tests.ts
@@ -5,12 +5,27 @@ import {
     config,
     connectStreamSource,
     disconnectStreamSource,
+    fetch,
+    FetchEnctype,
+    fetchEnctypeFromString,
+    FetchMethod,
+    fetchMethodFromString,
+    FetchRequest,
+    FetchRequestDelegate,
+    FetchResponse,
+    FrameLoadingStyle,
+    FrameRenderer,
+    isSafe,
     navigator,
     NavigatorDelegate,
+    PageRenderer,
+    PageSnapshot,
     ProgressBar,
     registerAdapter,
     renderStreamMessage,
     session,
+    setConfirmMethod,
+    setProgressBarDelay,
     start,
     StreamActions,
     StreamMessage,
@@ -57,6 +72,16 @@ const turboStream = document.querySelector("turbo-stream")!;
 // $ExpectType StreamElement
 turboStream;
 
+// Attribute-backed getters are null when the attribute is absent
+// $ExpectType string | null
+turboStream.action;
+// $ExpectType string | null
+turboStream.target;
+// $ExpectType string | null
+turboStream.targets;
+// $ExpectType string | null
+turboStream.requestId;
+
 // @ts-expect-error
 turboStream.action = "123";
 // @ts-expect-error
@@ -80,6 +105,8 @@ visit("my-location", {
 });
 
 visit("my-location", { frame: "mine" });
+visit(new URL("https://example.com/messages"));
+visit(new URL("https://example.com/messages"), { action: "replace" });
 
 // $ExpectType TurboGlobal
 Turbo;
@@ -103,6 +130,7 @@ Turbo.visit("my-location", {
 });
 
 Turbo.visit("my-location", { frame: "mine" });
+Turbo.visit(new URL("https://example.com/messages"));
 
 // $ExpectType TurboSession
 Turbo.session;
@@ -137,7 +165,14 @@ document.addEventListener("turbo:before-fetch-request", function(event) {
 
 document.addEventListener("turbo:before-fetch-response", function(e) {
     let { fetchResponse } = e.detail;
+    // $ExpectType string | null
     fetchResponse.header("foo");
+    // $ExpectType string | null
+    fetchResponse.contentType;
+    // $ExpectType Promise<string | undefined>
+    fetchResponse.responseHTML;
+    // @ts-expect-error - statusCode is readonly
+    fetchResponse.statusCode = 200;
 });
 
 document.addEventListener("turbo:before-render", function(e) {
@@ -147,21 +182,44 @@ document.addEventListener("turbo:before-render", function(e) {
         // $ExpectType HTMLBodyElement
         newElement;
     };
+    e.detail.render = PageRenderer.renderElement;
     // $ExpectType (value?: unknown) => void
     e.detail.resume;
+    // $ExpectType "replace" | "morph"
+    e.detail.renderMethod;
+    // @ts-expect-error - isPreview is not part of the turbo:before-render detail
+    e.detail.isPreview;
+});
+
+document.addEventListener("turbo:render", function(e) {
+    // $ExpectType "replace" | "morph"
+    e.detail.renderMethod;
 });
 
 document.addEventListener("turbo:before-frame-render", function(e) {
     // $ExpectType (value?: unknown) => void
     e.detail.resume;
+    // $ExpectType "replace" | "morph"
+    e.detail.renderMethod;
+    e.detail.render = FrameRenderer.renderElement;
+});
+
+document.addEventListener("turbo:reload", function(e) {
+    // $ExpectType string
+    e.detail.reason;
+    // $ExpectType number | undefined
+    e.detail.context?.statusCode;
 });
 
 document.addEventListener("turbo:frame-missing", function(event) {
     event.detail.visit(event.detail.response, {});
+    event.detail.visit("/fallback");
 });
 
 document.addEventListener("turbo:submit-start", function(event) {
     event.detail.formSubmission.stop();
+    // $ExpectType string
+    event.detail.formSubmission.method;
 });
 
 document.addEventListener("turbo:submit-end", function(event) {
@@ -277,7 +335,7 @@ Turbo.config.drive.progressBarDelay = 300;
 Turbo.config.forms.mode = "optin";
 
 // Test config.forms.confirm is optional (undefined by default, can be set to undefined)
-// $ExpectType ((message: string, element: HTMLFormElement, submitter: HTMLElement | null) => Promise<boolean>) | undefined
+// $ExpectType ((message: string, element: HTMLFormElement, submitter: HTMLElement | null) => boolean | Promise<boolean>) | undefined
 config.forms.confirm;
 config.forms.confirm = undefined;
 
@@ -285,6 +343,7 @@ config.forms.confirm = undefined;
 config.forms.confirm = async (message, element, submitter) => {
     return window.confirm(message);
 };
+config.forms.confirm = window.confirm;
 
 // Test StreamElement.templateElement and templateContent
 // $ExpectType HTMLTemplateElement
@@ -354,3 +413,91 @@ session.restorationIdentifier;
 session.started;
 // $ExpectType boolean
 session.enabled;
+
+// Test FrameLoadingStyle
+// $ExpectType "eager"
+FrameLoadingStyle.eager;
+// $ExpectType "lazy"
+FrameLoadingStyle.lazy;
+
+// Test FetchMethod / FetchEnctype constants and helpers
+// $ExpectType "get"
+FetchMethod.get;
+// $ExpectType "delete"
+FetchMethod.delete;
+// $ExpectType "application/x-www-form-urlencoded"
+FetchEnctype.urlEncoded;
+// $ExpectType "get" | "post" | "put" | "patch" | "delete" | undefined
+fetchMethodFromString("GET");
+// $ExpectType "application/x-www-form-urlencoded" | "multipart/form-data" | "text/plain"
+fetchEnctypeFromString("multipart/form-data");
+// $ExpectType boolean
+isSafe("get");
+
+// Test Turbo's fetch wrapper
+// $ExpectType Promise<Response>
+fetch("/articles", { headers: { Accept: "text/html" } });
+fetch(new URL("https://example.com/articles"));
+
+// Test FetchRequest construction and members
+const fetchRequestDelegate: FetchRequestDelegate = {
+    prepareRequest(_request) {},
+    requestStarted(_request) {},
+    requestPreventedHandlingResponse(_request, _response) {},
+    requestSucceededWithResponse(_request, _response) {},
+    requestFailedWithResponse(_request, _response) {},
+    requestErrored(_request, _error) {},
+    requestFinished(_request) {},
+};
+const fetchRequest = new FetchRequest(fetchRequestDelegate, "post", new URL("https://example.com"), new FormData());
+// @ts-expect-error - a FetchRequest cannot be constructed without arguments
+new FetchRequest();
+// $ExpectType string
+fetchRequest.method;
+fetchRequest.method = "put";
+// @ts-expect-error - method assignments accept Turbo's lowercase verbs only
+fetchRequest.method = "PUT";
+// $ExpectType URLSearchParams
+fetchRequest.params;
+// $ExpectType URL
+fetchRequest.location;
+// $ExpectType boolean
+fetchRequest.isSafe;
+// $ExpectType Promise<FetchResponse | undefined>
+fetchRequest.perform();
+fetchRequest.acceptResponseType(StreamMessage.contentType);
+fetchRequest.cancel();
+
+// Test FetchResponse construction
+const fetchResponse = new FetchResponse(new Response());
+// @ts-expect-error - a FetchResponse cannot be constructed without a Response
+new FetchResponse();
+// $ExpectType Response
+fetchResponse.response;
+// $ExpectType string | null
+fetchResponse.header("Content-Type");
+
+// Test PageSnapshot
+const pageSnapshot = PageSnapshot.fromHTMLString("<html><body></body></html>");
+PageSnapshot.fromHTMLString();
+PageSnapshot.fromElement(document.body);
+PageSnapshot.fromDocument(document);
+// $ExpectType boolean
+pageSnapshot.isCacheable;
+// $ExpectType boolean
+pageSnapshot.isPreviewable;
+// $ExpectType boolean
+pageSnapshot.isVisitable;
+// $ExpectType URL
+pageSnapshot.rootLocation;
+// $ExpectType HTMLHeadElement
+pageSnapshot.headElement;
+// $ExpectType string | null
+pageSnapshot.lang;
+// $ExpectType PageSnapshot
+pageSnapshot.clone();
+
+// Test deprecated module-level functions
+setProgressBarDelay(300);
+setConfirmMethod(window.confirm);
+setConfirmMethod(async (message, _element, _submitter) => window.confirm(message));

--- a/types/hotwired__turbo/index.d.ts
+++ b/types/hotwired__turbo/index.d.ts
@@ -429,8 +429,43 @@ export interface TurboHistory {
     replace(location: URL, restorationIdentifier?: string): void;
 }
 
+/**
+ * An LRU cache of page snapshots, keyed by location.
+ *
+ * Note that Turbo does not export the `SnapshotCache` class at runtime —
+ * obtain the instance via `session.view.snapshotCache`.
+ */
+export interface SnapshotCache {
+    has(location: URL): boolean;
+    get(location: URL): PageSnapshot | undefined;
+    put(location: URL, snapshot: PageSnapshot): PageSnapshot;
+    clear(): void;
+}
+
+/**
+ * The session's view of the current page.
+ *
+ * Note that Turbo does not export the `PageView` class at runtime —
+ * obtain the instance via `session.view`.
+ */
+export interface PageView {
+    element: HTMLElement;
+    snapshotCache: SnapshotCache;
+    /**
+     * The location of the last rendered page. Keys the snapshot cache and
+     * page-refresh detection.
+     */
+    lastRenderedLocation: URL;
+    forceReloaded: boolean;
+    readonly snapshot: PageSnapshot;
+    cacheSnapshot(snapshot?: PageSnapshot): Promise<PageSnapshot | undefined>;
+    getCachedSnapshotForLocation(location: URL): PageSnapshot | undefined;
+    clearSnapshotCache(): void;
+}
+
 export interface TurboSession {
     readonly history: TurboHistory;
+    readonly view: PageView;
     adapter: Adapter;
     readonly enabled: boolean;
     readonly started: boolean;

--- a/types/hotwired__turbo/index.d.ts
+++ b/types/hotwired__turbo/index.d.ts
@@ -85,11 +85,15 @@ export interface StreamSource {
     ): void;
 }
 
-export class StreamMessage {
-    static readonly contentType: "text/vnd.turbo-stream.html";
+/**
+ * A stream message, as accepted by {@link renderStreamMessage}.
+ *
+ * Note that Turbo does not export the `StreamMessage` class at runtime, so
+ * this interface only describes instances (there is no constructor and no
+ * access to the static `wrap` method or `contentType` property).
+ */
+export interface StreamMessage {
     readonly fragment: DocumentFragment;
-    static wrap(message: StreamMessage | string): StreamMessage;
-    constructor(fragment: DocumentFragment);
 }
 
 export interface FetchRequestHeaders {
@@ -274,18 +278,14 @@ export interface Adapter {
     linkPrefetchingIsEnabledForLocation?(location: URL): boolean;
 }
 
-export class BrowserAdapter implements Adapter {
+/**
+ * The default adapter installed on the session.
+ *
+ * Note that Turbo does not export the `BrowserAdapter` class at runtime —
+ * obtain the instance via `session.adapter` or `navigator.delegate.adapter`.
+ */
+export interface BrowserAdapter extends Adapter {
     progressBar: ProgressBar;
-    visitProposedToLocation(location: URL, options?: VisitOptions): void;
-    visitStarted(visit: Visit): void;
-    visitCompleted(visit: Visit): void;
-    visitFailed(visit: Visit): void;
-    visitRequestStarted(visit: Visit): void;
-    visitRequestCompleted(visit: Visit): void;
-    visitRequestFailedWithStatusCode(visit: Visit, statusCode: number): void;
-    visitRequestFinished(visit: Visit): void;
-    visitRendered(visit: Visit): void;
-    pageInvalidated(reason: { reason: string }): void;
     formSubmissionStarted(formSubmission: FormSubmission): void;
     formSubmissionFinished(formSubmission: FormSubmission): void;
     linkPrefetchingIsEnabledForLocation(location: URL): boolean;

--- a/types/hotwired__turbo/index.d.ts
+++ b/types/hotwired__turbo/index.d.ts
@@ -1,3 +1,8 @@
+export const FrameLoadingStyle: {
+    readonly eager: "eager";
+    readonly lazy: "lazy";
+};
+
 export class FrameElement extends HTMLElement {
     src: string | null;
     refresh: "morph" | null;
@@ -23,25 +28,26 @@ export class StreamElement extends HTMLElement {
     removeDuplicateTargetSiblings(): void;
 
     /**
-     * The current action.
+     * The current action, or `null` if the `action` attribute is absent.
      */
-    readonly action: string;
+    readonly action: string | null;
 
     /**
      * The current target (an element ID) to which the result will
-     * be rendered.
+     * be rendered, or `null` if the `target` attribute is absent.
      */
-    readonly target: string;
+    readonly target: string | null;
 
     /**
-     * The current "targets" selector (a CSS selector)
+     * The current "targets" selector (a CSS selector), or `null` if the
+     * `targets` attribute is absent.
      */
-    readonly targets: string;
+    readonly targets: string | null;
 
     /**
      * Reads the request-id attribute
      */
-    readonly requestId: string;
+    readonly requestId: string | null;
 
     /**
      * Gets the main `<template>` element used for rendering.
@@ -90,31 +96,158 @@ export interface FetchRequestHeaders {
     [header: string]: string | undefined;
 }
 
+export const FetchMethod: {
+    readonly get: "get";
+    readonly post: "post";
+    readonly put: "put";
+    readonly patch: "patch";
+    readonly delete: "delete";
+};
+
+export const FetchEnctype: {
+    readonly urlEncoded: "application/x-www-form-urlencoded";
+    readonly multipart: "multipart/form-data";
+    readonly plain: "text/plain";
+};
+
+/**
+ * Parses a string into a lowercase HTTP method verb known to Turbo.
+ *
+ * @param method Method string to parse (case-insensitive)
+ * @returns The matching method, or `undefined` for unknown methods
+ */
+export function fetchMethodFromString(method: string): "get" | "post" | "put" | "patch" | "delete" | undefined;
+
+/**
+ * Parses a string into a form enctype, falling back to
+ * "application/x-www-form-urlencoded" for unknown values.
+ *
+ * @param encoding Enctype string to parse (case-insensitive)
+ */
+export function fetchEnctypeFromString(
+    encoding: string,
+): "application/x-www-form-urlencoded" | "multipart/form-data" | "text/plain";
+
+/**
+ * Determines whether the given HTTP method is "safe" (has no side effects
+ * on the server). Only "get" is considered safe.
+ *
+ * @param fetchMethod Method string to test (case-insensitive)
+ */
+export function isSafe(fetchMethod: string): boolean;
+
+/**
+ * Performs a `window.fetch` with an `X-Turbo-Request-Id` header appended,
+ * allowing the response to be correlated with Turbo's request tracking
+ * (e.g. to avoid a full page refresh for a request this client initiated).
+ *
+ * @param url Resource to fetch
+ * @param options Standard fetch options
+ */
+export function fetch(url: string | URL, options?: RequestInit): Promise<Response>;
+
+/**
+ * The object responsible for a {@link FetchRequest}'s lifecycle, receiving
+ * callbacks as the request progresses.
+ */
+export interface FetchRequestDelegate {
+    referrer?: URL;
+    prepareRequest(request: FetchRequest): void;
+    requestStarted(request: FetchRequest): void;
+    requestPreventedHandlingResponse(request: FetchRequest, response: FetchResponse): void;
+    requestSucceededWithResponse(request: FetchRequest, response: FetchResponse): void;
+    requestFailedWithResponse(request: FetchRequest, response: FetchResponse): void;
+    requestErrored(request: FetchRequest, error: Error): void;
+    requestFinished(request: FetchRequest): void;
+}
+
 export class FetchRequest {
+    constructor(
+        delegate: FetchRequestDelegate,
+        method: "get" | "post" | "put" | "patch" | "delete",
+        location: URL | string,
+        requestBody?: FormData | URLSearchParams,
+        target?: HTMLFormElement | HTMLAnchorElement | FrameElement | null,
+        enctype?: "application/x-www-form-urlencoded" | "multipart/form-data" | "text/plain",
+    );
+    abortController: AbortController;
+    readonly abortSignal: AbortSignal;
     body: FormData | URLSearchParams;
+    readonly defaultHeaders: FetchRequestHeaders;
+    delegate: FetchRequestDelegate;
     enctype: "application/x-www-form-urlencoded" | "multipart/form-data" | "text/plain";
+    readonly entries: Array<[string, FormDataEntryValue]>;
     fetchOptions: RequestInit;
     headers: FetchRequestHeaders;
-    method: "get" | "post" | "put" | "patch" | "delete";
-    params: URLSearchParams;
+    readonly isSafe: boolean;
+    readonly location: URL;
+    /**
+     * Reads back the HTTP method verb in UPPERCASE (e.g. "GET"), as stored
+     * on the underlying fetch options; assignments accept Turbo's lowercase
+     * method names.
+     */
+    get method(): string;
+    set method(value: "get" | "post" | "put" | "patch" | "delete");
+    readonly params: URLSearchParams;
     target: HTMLFormElement | HTMLAnchorElement | FrameElement | null;
     url: URL;
+    acceptResponseType(mimeType: string): void;
+    cancel(): void;
+    /**
+     * Performs the request. Resolves with the response, or `undefined` when
+     * the request was aborted via {@link cancel}.
+     */
+    perform(): Promise<FetchResponse | undefined>;
 }
 
 export class FetchResponse {
-    clientError: boolean;
-    contentType: string;
-    failed: boolean;
-    header(key: string): string | undefined;
-    isHTML: boolean;
-    location: URL;
-    redirected: boolean;
-    responseHTML: Promise<string>;
-    responseText: Promise<string>;
+    constructor(response: Response);
+    readonly clientError: boolean;
+    readonly contentType: string | null;
+    readonly failed: boolean;
+    header(key: string): string | null;
+    readonly isHTML: boolean;
+    readonly location: URL;
+    readonly redirected: boolean;
+    /** Resolves with the response body, or `undefined` for non-HTML responses. */
+    readonly responseHTML: Promise<string | undefined>;
+    readonly responseText: Promise<string>;
     response: Response;
-    serverError: boolean;
-    statusCode: number;
-    succeeded: boolean;
+    readonly serverError: boolean;
+    readonly statusCode: number;
+    readonly succeeded: boolean;
+}
+
+export class PageRenderer {
+    /**
+     * The default render method for page visits: replaces the current `<body>`
+     * with the new one. Can be reassigned via the `turbo:before-render`
+     * event's `detail.render`.
+     */
+    static renderElement(currentElement: HTMLBodyElement, newElement: HTMLBodyElement): void;
+}
+
+export class FrameRenderer {
+    /**
+     * The default render method for frame navigations: replaces the current
+     * frame's contents with the new frame's. Can be reassigned via the
+     * `turbo:before-frame-render` event's `detail.render`.
+     */
+    static renderElement(currentElement: FrameElement, newElement: FrameElement): void;
+}
+
+export class PageSnapshot {
+    static fromHTMLString(html?: string): PageSnapshot;
+    static fromElement(element: Element): PageSnapshot;
+    static fromDocument(document: Pick<Document, "documentElement" | "body" | "head">): PageSnapshot;
+
+    readonly headElement: HTMLHeadElement;
+    readonly isCacheable: boolean;
+    readonly isPreviewable: boolean;
+    readonly isVisitable: boolean;
+    readonly lang: string | null;
+    readonly rootLocation: URL;
+    clone(): PageSnapshot;
 }
 
 export interface Visit {
@@ -247,7 +380,7 @@ export interface FormsConfig {
     /** Form handling mode: "on" (default), "off", or "optin". */
     mode: "on" | "off" | "optin";
     /** Custom confirmation method. Falls back to window.confirm if not defined. */
-    confirm?: (message: string, element: HTMLFormElement, submitter: HTMLElement | null) => Promise<boolean>;
+    confirm?: (message: string, element: HTMLFormElement, submitter: HTMLElement | null) => boolean | Promise<boolean>;
     /**
      * Controls how submitters are disabled during form submission.
      * Can be "disabled" (default), "aria-disabled", or a custom SubmitterConfig.
@@ -326,7 +459,7 @@ export interface VisitOptions {
     action?: Action;
     frame?: string;
 }
-export function visit(location: string, options?: VisitOptions): void;
+export function visit(location: string | URL, options?: VisitOptions): void;
 
 /**
  * Starts the main Turbo session.
@@ -348,6 +481,33 @@ export function registerAdapter(adapter: Adapter): void;
  * @deprecated Use `Turbo.config.forms.mode = mode` instead.
  */
 export function setFormMode(mode: "on" | "off" | "optin"): void;
+
+/**
+ * Sets the delay after which the progress bar will appear during navigation,
+ * in milliseconds. The progress bar appears after 500ms by default.
+ *
+ * @param delayInMilliseconds
+ * @deprecated Use `Turbo.config.drive.progressBarDelay = delayInMilliseconds` instead.
+ */
+export function setProgressBarDelay(delayInMilliseconds: number): void;
+
+/**
+ * Sets the method that is called by links decorated with `data-turbo-confirm`
+ * and forms decorated with `data-turbo-confirm`.
+ *
+ * The default is the browser's built in confirm. The method should return
+ * (or resolve with) `true` if the visit or submission can proceed.
+ *
+ * @param confirmMethod
+ * @deprecated Use `Turbo.config.forms.confirm = confirmMethod` instead.
+ */
+export function setConfirmMethod(
+    confirmMethod: (
+        message: string,
+        element: HTMLFormElement,
+        submitter: HTMLElement | null,
+    ) => boolean | Promise<boolean>,
+): void;
 
 /**
  * Options for morphing elements.
@@ -432,12 +592,18 @@ export interface TurboGlobal {
      **
      * The default is the browser's built in confirm.
      *
-     * The method should return true if the visit can proceed.
+     * The method should return (or resolve with) true if the visit can proceed.
      *
      * @param confirmMethod
      * @deprecated Use `Turbo.config.forms.confirm = confirmMethod` instead.
      */
-    setConfirmMethod(confirmMethod: () => boolean): void;
+    setConfirmMethod(
+        confirmMethod: (
+            message: string,
+            element: HTMLFormElement,
+            submitter: HTMLElement | null,
+        ) => boolean | Promise<boolean>,
+    ): void;
 
     /**
      * Sets the form mode for Turbo Drive.
@@ -452,9 +618,9 @@ export interface TurboGlobal {
      *
      * @param adapter Adapter to register
      */
-    registerAdapter(adapter: unknown): void;
+    registerAdapter(adapter: Adapter): void;
 
-    visit(location: string, options?: { action?: Action; frame?: string }): void;
+    visit(location: string | URL, options?: VisitOptions): void;
 
     /**
      * Starts the main Turbo session.
@@ -484,14 +650,13 @@ declare global {
 
 export type Render = (currentElement: StreamElement) => Promise<void>;
 export type TimingData = unknown;
-export type VisitFallback = (location: string | Response, options: VisitOptions) => Promise<void>;
+export type VisitFallback = (location: string | Response, options?: VisitOptions) => Promise<void>;
 
 export type TurboBeforeCacheEvent = CustomEvent;
 export type TurboBeforePrefetchEvent = CustomEvent;
 export type TurboBeforeRenderEvent = CustomEvent<{
     newBody: HTMLBodyElement;
     renderMethod: "replace" | "morph";
-    isPreview: boolean;
     resume: (value?: unknown) => void;
     render: (currentBody: HTMLBodyElement, newBody: HTMLBodyElement) => void;
 }>;
@@ -503,6 +668,7 @@ export type TurboClickEvent = CustomEvent<{
 export type TurboFrameLoadEvent = CustomEvent;
 export type TurboBeforeFrameRenderEvent = CustomEvent<{
     newFrame: FrameElement;
+    renderMethod: "replace" | "morph";
     resume: (value?: unknown) => void;
     render: (currentFrame: FrameElement, newFrame: FrameElement) => void;
 }>;
@@ -510,8 +676,11 @@ export type TurboFrameRenderEvent = CustomEvent<{
     fetchResponse: FetchResponse;
 }>;
 export type TurboLoadEvent = CustomEvent<{ url: string; timing: TimingData }>;
-export type TurboRenderEvent = CustomEvent;
-export type TurboReloadEvent = CustomEvent;
+export type TurboRenderEvent = CustomEvent<{ renderMethod: "replace" | "morph" }>;
+export type TurboReloadEvent = CustomEvent<{
+    reason: string;
+    context?: { statusCode: number };
+}>;
 export type TurboVisitEvent = CustomEvent<{ url: string; action: Action }>;
 
 export type TurboBeforeStreamRenderEvent = CustomEvent<{
@@ -552,7 +721,11 @@ export interface FormSubmission {
     formElement: HTMLFormElement;
     isSafe: boolean;
     location: URL;
-    method: "get" | "post" | "put" | "patch" | "delete";
+    /**
+     * The HTTP method verb in UPPERCASE (e.g. "GET"), as read back from the
+     * underlying fetch request.
+     */
+    method: string;
     stop(): void;
     submitter?: HTMLButtonElement | HTMLInputElement;
 }

--- a/types/hotwired__turbo/index.d.ts
+++ b/types/hotwired__turbo/index.d.ts
@@ -1,3 +1,7 @@
+export {};
+
+type RequestMethod = "get" | "post" | "put" | "patch" | "delete";
+
 export const FrameLoadingStyle: {
     readonly eager: "eager";
     readonly lazy: "lazy";
@@ -120,7 +124,7 @@ export const FetchEnctype: {
  * @param method Method string to parse (case-insensitive)
  * @returns The matching method, or `undefined` for unknown methods
  */
-export function fetchMethodFromString(method: string): "get" | "post" | "put" | "patch" | "delete" | undefined;
+export function fetchMethodFromString(method: string): RequestMethod | undefined;
 
 /**
  * Parses a string into a form enctype, falling back to
@@ -168,7 +172,7 @@ export interface FetchRequestDelegate {
 export class FetchRequest {
     constructor(
         delegate: FetchRequestDelegate,
-        method: "get" | "post" | "put" | "patch" | "delete",
+        method: RequestMethod,
         location: URL | string,
         requestBody?: FormData | URLSearchParams,
         target?: HTMLFormElement | HTMLAnchorElement | FrameElement | null,
@@ -181,7 +185,7 @@ export class FetchRequest {
     delegate: FetchRequestDelegate;
     enctype: "application/x-www-form-urlencoded" | "multipart/form-data" | "text/plain";
     readonly entries: Array<[string, FormDataEntryValue]>;
-    fetchOptions: RequestInit;
+    fetchOptions: RequestInit & { method: Uppercase<RequestMethod> };
     headers: FetchRequestHeaders;
     readonly isSafe: boolean;
     readonly location: URL;
@@ -190,8 +194,8 @@ export class FetchRequest {
      * on the underlying fetch options; assignments accept Turbo's lowercase
      * method names.
      */
-    get method(): string;
-    set method(value: "get" | "post" | "put" | "patch" | "delete");
+    get method(): Uppercase<RequestMethod>;
+    set method(value: RequestMethod);
     readonly params: URLSearchParams;
     target: HTMLFormElement | HTMLAnchorElement | FrameElement | null;
     url: URL;
@@ -722,10 +726,11 @@ export interface FormSubmission {
     isSafe: boolean;
     location: URL;
     /**
-     * The HTTP method verb in UPPERCASE (e.g. "GET"), as read back from the
-     * underlying fetch request.
+     * Reads back the HTTP method verb in UPPERCASE (e.g. "GET"); assignments
+     * accept Turbo's lowercase method names.
      */
-    method: string;
+    get method(): Uppercase<RequestMethod>;
+    set method(value: RequestMethod);
     stop(): void;
     submitter?: HTMLButtonElement | HTMLInputElement;
 }


### PR DESCRIPTION
🤖 _Drafted with agent assistance._

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hotwired/turbo/tree/v8.0.23/src

---

Result of auditing these declarations against the hotwired/turbo v8.0.23 source and the built `dist/turbo.es2017-esm.js` export surface.

Fixes #75207: `StreamMessage` and `BrowserAdapter` were declared as exported classes, but `@hotwired/turbo` exports neither at runtime, so value imports compiled and then resolved to `undefined` (introduced in #74439). Both are now interfaces; tests assert the names are unusable as values. Technically breaking for anyone value-importing them, but that code was already broken at runtime.

### Event details

- `turbo:before-render`: removed `isPreview` — not part of the dispatched detail ([view.js:72](https://github.com/hotwired/turbo/blob/v8.0.23/src/core/view.js)); `turbo:render` and `turbo:before-frame-render`: added `renderMethod`; `turbo:reload`: typed the `{ reason, context? }` detail.
- `VisitFallback`: `options` is now optional — the `turbo:frame-missing` fallback can be called as `detail.visit(url)`.

### Fetch layer

- `FetchRequest`: declared the real constructor (introducing `FetchRequestDelegate`) so zero-arg `new FetchRequest()` no longer compiles; added `abortController`, `abortSignal`, `entries`, `isSafe`, `location`, `defaultHeaders`, `cancel()`, `perform()`, `acceptResponseType()`.
- `FetchRequest#method` and `FormSubmission#method` use split accessors: the getters return the UPPERCASE verbs the implementation stores (`method.toUpperCase()`), the setters keep accepting Turbo's lowercase verbs, and `FetchRequest#fetchOptions.method` is narrowed to the uppercase verbs so the getter is sound. The lowercase union is an internal `RequestMethod` helper — not exported, matching Turbo, with a test asserting that.
- `FetchResponse`: declared the constructor; `header()` and `contentType` are `string | null` (delegating to `Headers#get`); `responseHTML` resolves `string | undefined`; getter-backed members are now `readonly`.

### Previously missing runtime exports

Now declared: `fetch` (Turbo's `X-Turbo-Request-Id`-appending wrapper), `FetchMethod`, `FetchEnctype`, `fetchMethodFromString`, `fetchEnctypeFromString`, `isSafe`, `FrameLoadingStyle`, `PageRenderer`, `FrameRenderer`, `PageSnapshot` (minimal statics + getters), and the deprecated `setProgressBarDelay` / `setConfirmMethod`.

### `session.view`

Adds `TurboSession#view`, typed via new `PageView` and `SnapshotCache` interfaces (`lastRenderedLocation`, `snapshot`, `snapshotCache`, `cacheSnapshot()`, …), verified against [page_view.js](https://github.com/hotwired/turbo/blob/v8.0.23/src/core/drive/page_view.js) / [snapshot_cache.js](https://github.com/hotwired/turbo/blob/v8.0.23/src/core/drive/snapshot_cache.js). Both are type-only, per the same non-runtime-export convention. Motivated by downstream code that must correct `view.lastRenderedLocation` (it keys the snapshot cache and page-refresh detection) after rewriting the URL through `session.history`: [opf/openproject#23818 (comment)](https://github.com/opf/openproject/pull/23818#discussion_r3516448661).

### Cleanups / judgment calls

- `StreamElement` attribute getters (`action`, `target`, `targets`, `requestId`) are `string | null` — readonly reflections of attributes genuinely absent in common cases (`request-id` in particular), so unlike the write-side `refresh` discussion in #75196 the `null` is observable. Happy to revert if we'd rather idealize here too.
- `visit()` / `Turbo.visit()` accept `URL` as well as `string`; `Turbo.registerAdapter` takes `Adapter` (was `unknown`); `Turbo.setConfirmMethod` matches `config.forms.confirm`, which may return `boolean | Promise<boolean>` (the implementation `await`s it, so `config.forms.confirm = window.confirm` type-checks).

Not included (deliberate non-alignments, per #75196): `FrameElement.refresh` stays `"morph" | null`; `VisitOptions` stays the documented `{ action?, frame? }`; `FetchResponse.isHTML` stays `boolean` even though the implementation returns a truthy match result (upstream fix candidate); `TurboSubmitEndEvent.success` stays required even though an aborted submission dispatches without a result.
