### PR TITLE
feat(csp-html-webpack-plugin): upgrade to v5.1

### DIFF
--- a/types/csp-html-webpack-plugin/csp-html-webpack-plugin-tests.ts
+++ b/types/csp-html-webpack-plugin/csp-html-webpack-plugin-tests.ts
@@ -1,7 +1,7 @@
-import HtmlWebpackPlugin = require("html-webpack-plugin");
-import CspHtmlWebpackPlugin = require("csp-html-webpack-plugin");
+import CspHtmlWebpackPlugin from "csp-html-webpack-plugin";
+import HtmlWebpackPlugin from "html-webpack-plugin";
 
-import { Configuration as WebpackConfiguration } from "webpack";
+import { Compiler, Configuration as WebpackConfiguration } from "webpack";
 
 // Should accept various CSP directive types.
 const policy: CspHtmlWebpackPlugin.Policy = {
@@ -31,6 +31,25 @@ new CspHtmlWebpackPlugin(policy, {
         "script-src": true,
         "style-src": true,
     },
+    processFn(builtPolicy, htmlPluginData, $, compilation) {
+        // $ExpectType string
+        builtPolicy;
+        // $ExpectType string
+        htmlPluginData.html;
+        // $ExpectType string
+        htmlPluginData.outputName;
+        htmlPluginData.plugin satisfies HtmlWebpackPlugin;
+        // $ExpectType CheerioAPI
+        $;
+        // $ExpectType { (this: CheerioAPI, options?: CheerioOptions | undefined): string; (this: CheerioAPI, dom?: BasicAcceptedElems<AnyNode> | undefined, options?: CheerioOptions | undefined): string; }
+        $.html;
+        // $ExpectType (this: CheerioAPI, dom?: BasicAcceptedElems<AnyNode> | undefined) => string
+        $.xml;
+        // $ExpectType Compilation
+        compilation;
+        // $ExpectType any[]
+        compilation.errors;
+    },
 });
 
 const optsWithEnableFunc: CspHtmlWebpackPlugin.AdditionalOptions = {
@@ -40,8 +59,8 @@ const optsWithEnableFunc: CspHtmlWebpackPlugin.AdditionalOptions = {
         // $ExpectType string
         htmlPluginData.html;
 
-        if (htmlPluginData.plugin.apply as any) {
-        }
+        // $ExpectType (compiler: Compiler) => void
+        htmlPluginData.plugin.apply;
 
         return true;
     },
@@ -52,6 +71,25 @@ const optsWithEnableFunc: CspHtmlWebpackPlugin.AdditionalOptions = {
     nonceEnabled: {
         "script-src": true,
         "style-src": true,
+    },
+    processFn(builtPolicy, htmlPluginData, $, compilation) {
+        // $ExpectType string
+        builtPolicy;
+        // $ExpectType string
+        htmlPluginData.html;
+        // $ExpectType string
+        htmlPluginData.outputName;
+        htmlPluginData.plugin satisfies HtmlWebpackPlugin;
+        // $ExpectType CheerioAPI
+        $;
+        // $ExpectType { (this: CheerioAPI, options?: CheerioOptions | undefined): string; (this: CheerioAPI, dom?: BasicAcceptedElems<AnyNode> | undefined, options?: CheerioOptions | undefined): string; }
+        $.html;
+        // $ExpectType (this: CheerioAPI, dom?: BasicAcceptedElems<AnyNode> | undefined) => string
+        $.xml;
+        // $ExpectType Compilation
+        compilation;
+        // $ExpectType any[]
+        compilation.errors;
     },
 };
 
@@ -83,5 +121,25 @@ new HtmlWebpackPlugin({
             "script-src": true,
             "style-src": true,
         },
+        processFn(builtPolicy, htmlPluginData, $, compilation) {
+            // $ExpectType string
+            builtPolicy;
+            // $ExpectType string
+            htmlPluginData.html;
+            // $ExpectType string
+            htmlPluginData.outputName;
+            htmlPluginData.plugin satisfies HtmlWebpackPlugin;
+            // $ExpectType CheerioAPI
+            $;
+            // $ExpectType { (this: CheerioAPI, options?: CheerioOptions | undefined): string; (this: CheerioAPI, dom?: BasicAcceptedElems<AnyNode> | undefined, options?: CheerioOptions | undefined): string; }
+            $.html;
+            // $ExpectType (this: CheerioAPI, dom?: BasicAcceptedElems<AnyNode> | undefined) => string
+            $.xml;
+            // $ExpectType Compilation
+            compilation;
+            // $ExpectType any[]
+            compilation.errors;
+        },
     },
+    xhtml: false,
 });

--- a/types/csp-html-webpack-plugin/index.d.ts
+++ b/types/csp-html-webpack-plugin/index.d.ts
@@ -1,5 +1,6 @@
+import { CheerioAPI } from "cheerio";
 import { AsyncSeriesWaterfallHook } from "tapable";
-import { Compiler as WebpackCompiler } from "webpack";
+import { compilation, Compiler as WebpackCompiler } from "webpack";
 import HtmlWebpackPlugin = require("html-webpack-plugin");
 
 export = CspHtmlWebpackPlugin;
@@ -7,8 +8,8 @@ export = CspHtmlWebpackPlugin;
 declare class CspHtmlWebpackPlugin {
     /**
      * Setup for our plugin
-     * @param policy - the policy object
-     * @param additionalOpts - additional config options
+     * @param policy a flat object which defines your CSP policy. Valid keys and values can be found on the [MDN CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy) page. Values can either be a string, or an array of strings.
+     * @param additionalOpts a flat object with the optional configuration options
      */
     constructor(
         policy?: CspHtmlWebpackPlugin.Policy,
@@ -38,10 +39,7 @@ declare namespace CspHtmlWebpackPlugin {
         [directive: string]: string | string[];
     }
 
-    // HtmlWebpackPlugin v3 and v4 use different hook interfaces. Figure out
-    // which we're using and infer the generic type variable inside.
-    type HtmlPluginData = HtmlWebpackPlugin.Hooks extends HtmlPluginDataHookV3<infer T> ? T
-        : HtmlWebpackPlugin.Hooks extends HtmlPluginDataHookV4<infer U> ? U
+    type HtmlPluginData = HtmlWebpackPlugin.Hooks extends HtmlPluginDataHookV4<infer U> ? U
         : any; // Fallback when nothing works.
 
     /**
@@ -88,6 +86,20 @@ declare namespace CspHtmlWebpackPlugin {
          * include nonces.
          */
         nonceEnabled?: { [directive: string]: boolean } | undefined;
+        /**
+         * Allows the developer to overwrite the default method of what happens to the CSP after it has been created.
+         *
+         * @param builtPolicy A string containing the completed policy
+         * @param htmlPluginData The `HtmlWebpackPlugin` object
+         * @param $ The `cheerio` object of the html file currently being processed
+         * @param compilation Internal webpack object to manipulate the build
+         */
+        processFn?(
+            builtPolicy: string,
+            htmlPluginData: HtmlPluginData,
+            $: CheerioAPI,
+            compilation: compilation.Compilation,
+        ): void;
     }
 }
 
@@ -99,12 +111,6 @@ declare module "html-webpack-plugin" {
             }
             | undefined;
     }
-}
-
-// Helpers for extracting the relevant generic types from
-// HtmlWebpackPlugin.Hooks.
-interface HtmlPluginDataHookV3<T> {
-    htmlWebpackPluginAfterHtmlProcessing: AsyncSeriesWaterfallHook<T>;
 }
 
 interface HtmlPluginDataHookV4<T> {

--- a/types/csp-html-webpack-plugin/package.json
+++ b/types/csp-html-webpack-plugin/package.json
@@ -1,13 +1,14 @@
 {
     "private": true,
     "name": "@types/csp-html-webpack-plugin",
-    "version": "3.0.9999",
+    "version": "5.1.9999",
     "projects": [
         "https://github.com/slackhq/csp-html-webpack-plugin"
     ],
     "dependencies": {
-        "@types/html-webpack-plugin": "*",
-        "@types/tapable": "^1",
+        "cheerio": ">=1",
+        "html-webpack-plugin": ">=4",
+        "tapable": "^2.2.1",
         "@types/webpack": "^4"
     },
     "devDependencies": {


### PR DESCRIPTION
From https://www.npmjs.com/package/csp-html-webpack-plugin?activeTab=versions, v3 & v4 got way fewer weekly downloads than v5 does. It should make sense to directly migrate without maintaining any legacy versions.

There are a few breaking / significant changes.

- `HtmlPluginDataHookV3` is removed, since v5 no longer works with v3 of `html-webpack-plugin`.
- `.processFn()` is added, by me digging into the release note.
- `.xhtml` is added; It is an undocumented options, but since the other undocumented option `cspPlugin` is already there, it make sense to keep maintaining the interface.

For more details, see https://app.unpkg.com/csp-html-webpack-plugin@5.1.0/files/plugin.js & https://github.com/slackhq/csp-html-webpack-plugin/releases.

Note: `html-webpack-plugin` depends on `tapable` but not `@types/tapable`. Consequently `dependencies` has to be further updated.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
