### PR TITLE
[luxon] Fix DateTime#isDateTime type-guard to narrow types correctly

### DIFF
--- a/types/luxon/src/datetime.d.ts
+++ b/types/luxon/src/datetime.d.ts
@@ -903,7 +903,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
      *
      * @param o
      */
-    static isDateTime(o: unknown): o is DateTimeMaybeValid;
+    static isDateTime(o: unknown): o is DateTime;
 
     /**
      * Produce the format string for a set of options

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -281,9 +281,25 @@ DateTime.min(now, now); // $ExpectType DateTime<true>
 DateTime.min(...[dt, now].filter(date => date)); // $ExpectType DateTime<true> | DateTime<false> | undefined
 DateTime.min(); // $ExpectType undefined
 
-const anything: unknown = 0;
-if (DateTime.isDateTime(anything)) {
-    anything; // $ExpectType DateTime<true> | DateTime<false>
+// DateTime.isDateTime guard check
+function isDateTimeCheck(case1: DateTime | string, case2: DateTime<true> | number, case3: DateTime<false> | boolean) {
+    if (DateTime.isDateTime(case1)) {
+        case1; // $ExpectType DateTime<boolean>
+    } else {
+        case1; // $ExpectType string
+    }
+
+    if (DateTime.isDateTime(case2)) {
+        case2; // $ExpectType DateTime<true>
+    } else {
+        case2; // $ExpectType number
+    }
+
+    if (DateTime.isDateTime(case3)) {
+        case3; // $ExpectType DateTime<false>
+    } else {
+        case3; // $ExpectType boolean
+    }
 }
 
 const { input, result, zone } = DateTime.fromFormatExplain("Aug 6 1982", "MMMM d yyyy");
@@ -349,7 +365,7 @@ dur.toFormat("", {
     floor: true,
     signMode: "negativeLargestOnly",
 });
-
+const anything: unknown = 0;
 if (Duration.isDuration(anything)) {
     anything; // $ExpectType Duration<true> | Duration<false>
 }
@@ -644,3 +660,4 @@ function typeGuardCheck(dt: DateTime): void {
 
     dt; // $ExpectType DateTime<boolean>
 }
+

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -660,4 +660,3 @@ function typeGuardCheck(dt: DateTime): void {
 
     dt; // $ExpectType DateTime<boolean>
 }
-


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [URL](https://moment.github.io/luxon/api-docs/index.html#datetimeisdatetime)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

## Summary

Change `DateTime#isDateTime` to use `is DateTime` and not `is DateTimeMaybeValid`

This enables TypeScript type guards and assertion functions to correctly narrow `unknown` to `DateTime`.

Apparently TypeScript's CFA has fundamental problems narrowing types when the target of a type guard is a conditional type.

## Motivation

Due to a bug report under my previous PR #75132 [(Comment)](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/75132#issuecomment-4870042169). The `DateTime.isDateTime` method does not narrow the type correctly.

## Tests

Added test cases to check that `DateTime.isDateTime` narrows correctly.

## Notes

During my dive into the tests and writing the fix I got caught by some false-positive tests.
The tests are written by defining variables and then checking against their types in certain situations. But TypeScript differs between a declared type and a currently narrowed type.

For example:

```typescript
let testCase: string | DateTime = "";
if (DateTime.isDateTime(testCase)) {
   testCase; // $ExpectType DateTime
}
```
fails, not because the logic is wrong, but because TypeScript already knows at the `if` that `testCase` can currently only be string (from its initializer), so the check can never actually be a `DateTime` at this point. TypeScript narrows this to `string & DateTime`, since logically it has to satisfy both.

Why TypeScript doesn't reduce this down to `never` or `unknown` is out of my league. That's a question for a TypeScript dev.

To avoid this, I moved the test cases into a function so the values come through parameters, where TypeScript can't make assumptions about it.

This "bug" made me think it might be worth writing all tests in function blocks going forward.
