### PR TITLE
[hotwired__turbo] Add session.view types

### DIFF
--- a/types/hotwired__turbo/hotwired__turbo-tests.ts
+++ b/types/hotwired__turbo/hotwired__turbo-tests.ts
@@ -7,10 +7,13 @@ import {
     disconnectStreamSource,
     navigator,
     NavigatorDelegate,
+    PageSnapshot,
+    PageView,
     ProgressBar,
     registerAdapter,
     renderStreamMessage,
     session,
+    SnapshotCache,
     start,
     StreamActions,
     StreamMessage,
@@ -354,3 +357,45 @@ session.restorationIdentifier;
 session.started;
 // $ExpectType boolean
 session.enabled;
+
+// Test PageView via session.view
+// PageView and SnapshotCache are not runtime exports of @hotwired/turbo, only types
+// @ts-expect-error
+new PageView(session, document.documentElement);
+// @ts-expect-error
+new SnapshotCache(10);
+// $ExpectType PageView
+session.view;
+// $ExpectType PageView
+Turbo.session.view;
+// @ts-expect-error - view cannot be reassigned
+session.view = session.view;
+// $ExpectType URL
+session.view.lastRenderedLocation;
+session.view.lastRenderedLocation = new URL("https://example.com");
+// $ExpectType HTMLElement
+session.view.element;
+// $ExpectType boolean
+session.view.forceReloaded;
+// $ExpectType PageSnapshot
+session.view.snapshot;
+// $ExpectType Promise<PageSnapshot | undefined>
+session.view.cacheSnapshot();
+session.view.cacheSnapshot(PageSnapshot.fromHTMLString("<html><body></body></html>"));
+// $ExpectType PageSnapshot | undefined
+session.view.getCachedSnapshotForLocation(new URL("https://example.com"));
+session.view.clearSnapshotCache();
+
+// Test SnapshotCache via session.view.snapshotCache
+// $ExpectType SnapshotCache
+session.view.snapshotCache;
+// $ExpectType boolean
+session.view.snapshotCache.has(new URL("https://example.com"));
+// $ExpectType PageSnapshot | undefined
+session.view.snapshotCache.get(new URL("https://example.com"));
+// $ExpectType PageSnapshot
+session.view.snapshotCache.put(
+    new URL("https://example.com"),
+    PageSnapshot.fromHTMLString("<html><body></body></html>"),
+);
+session.view.snapshotCache.clear();

--- a/types/hotwired__turbo/index.d.ts
+++ b/types/hotwired__turbo/index.d.ts
@@ -292,8 +292,57 @@ export interface TurboHistory {
     replace(location: URL, restorationIdentifier?: string): void;
 }
 
+export class PageSnapshot {
+    static fromHTMLString(html?: string): PageSnapshot;
+    static fromElement(element: Element): PageSnapshot;
+    static fromDocument(document: Pick<Document, "documentElement" | "body" | "head">): PageSnapshot;
+
+    readonly headElement: HTMLHeadElement;
+    readonly isCacheable: boolean;
+    readonly isPreviewable: boolean;
+    readonly isVisitable: boolean;
+    readonly lang: string | null;
+    readonly rootLocation: URL;
+    clone(): PageSnapshot;
+}
+
+/**
+ * An LRU cache of page snapshots, keyed by location.
+ *
+ * Note that Turbo does not export the `SnapshotCache` class at runtime —
+ * obtain the instance via `session.view.snapshotCache`.
+ */
+export interface SnapshotCache {
+    has(location: URL): boolean;
+    get(location: URL): PageSnapshot | undefined;
+    put(location: URL, snapshot: PageSnapshot): PageSnapshot;
+    clear(): void;
+}
+
+/**
+ * The session's view of the current page.
+ *
+ * Note that Turbo does not export the `PageView` class at runtime —
+ * obtain the instance via `session.view`.
+ */
+export interface PageView {
+    element: HTMLElement;
+    snapshotCache: SnapshotCache;
+    /**
+     * The location of the last rendered page. Keys the snapshot cache and
+     * page-refresh detection.
+     */
+    lastRenderedLocation: URL;
+    forceReloaded: boolean;
+    readonly snapshot: PageSnapshot;
+    cacheSnapshot(snapshot?: PageSnapshot): Promise<PageSnapshot | undefined>;
+    getCachedSnapshotForLocation(location: URL): PageSnapshot | undefined;
+    clearSnapshotCache(): void;
+}
+
 export interface TurboSession {
     readonly history: TurboHistory;
+    readonly view: PageView;
     adapter: Adapter;
     readonly enabled: boolean;
     readonly started: boolean;


### PR DESCRIPTION
Adds `TurboSession#view`, typed via new `PageView` and `SnapshotCache` interfaces plus the `PageSnapshot` class it returns. Verified against [page_view.js](https://github.com/hotwired/turbo/blob/v8.0.23/src/core/drive/page_view.js) and [snapshot_cache.js](https://github.com/hotwired/turbo/blob/v8.0.23/src/core/drive/snapshot_cache.js) in hotwired/turbo v8.0.23.

Motivated by downstream code that must correct `view.lastRenderedLocation` (it keys the snapshot cache and page-refresh detection) after rewriting the URL through `session.history`: [opf/openproject#23818 (comment)](https://github.com/opf/openproject/pull/23818#discussion_r3516448661).

`PageView` and `SnapshotCache` are type-only — Turbo does not export them at runtime, and the tests assert the names are unusable as values. `PageSnapshot` is a real runtime export.

- [x] Use a meaningful title for the pull request.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change.
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hotwired/turbo/tree/v8.0.23/src/core/drive
