### PR TITLE
[hotwired__turbo] Demote phantom exports to types

### DIFF
--- a/types/hotwired__turbo/hotwired__turbo-tests.ts
+++ b/types/hotwired__turbo/hotwired__turbo-tests.ts
@@ -223,7 +223,12 @@ navigator.delegate;
 navigator.delegate.adapter;
 
 // Test ProgressBar via BrowserAdapter cast
+// BrowserAdapter is not a runtime export of @hotwired/turbo, only a type
+// @ts-expect-error
+new BrowserAdapter();
 const browserAdapter = navigator.delegate.adapter as BrowserAdapter;
+const browserAdapterAsAdapter: Adapter = browserAdapter;
+browserAdapterAsAdapter.visitStarted;
 // $ExpectType ProgressBar
 browserAdapter.progressBar;
 browserAdapter.progressBar.setValue(0);
@@ -317,16 +322,16 @@ disconnectStreamSource(webSocket);
 // @ts-expect-error
 connectStreamSource({});
 
-const streamMessage = new StreamMessage(document.createDocumentFragment());
+const streamMessage: StreamMessage = { fragment: document.createDocumentFragment() };
 renderStreamMessage("<turbo-stream></turbo-stream>");
 renderStreamMessage(streamMessage);
 Turbo.renderStreamMessage("<turbo-stream></turbo-stream>");
 Turbo.renderStreamMessage(streamMessage);
 
-// $ExpectType "text/vnd.turbo-stream.html"
-StreamMessage.contentType;
-
-// $ExpectType StreamMessage
+// StreamMessage is not a runtime export of @hotwired/turbo, only a type
+// @ts-expect-error
+new StreamMessage(document.createDocumentFragment());
+// @ts-expect-error
 StreamMessage.wrap("<turbo-stream></turbo-stream>");
 
 // Test TurboHistory via session.history

--- a/types/hotwired__turbo/index.d.ts
+++ b/types/hotwired__turbo/index.d.ts
@@ -79,11 +79,15 @@ export interface StreamSource {
     ): void;
 }
 
-export class StreamMessage {
-    static readonly contentType: "text/vnd.turbo-stream.html";
+/**
+ * A stream message, as accepted by {@link renderStreamMessage}.
+ *
+ * Note that Turbo does not export the `StreamMessage` class at runtime, so
+ * this interface only describes instances (there is no constructor and no
+ * access to the static `wrap` method or `contentType` property).
+ */
+export interface StreamMessage {
     readonly fragment: DocumentFragment;
-    static wrap(message: StreamMessage | string): StreamMessage;
-    constructor(fragment: DocumentFragment);
 }
 
 export interface FetchRequestHeaders {
@@ -141,18 +145,14 @@ export interface Adapter {
     linkPrefetchingIsEnabledForLocation?(location: URL): boolean;
 }
 
-export class BrowserAdapter implements Adapter {
+/**
+ * The default adapter installed on the session.
+ *
+ * Note that Turbo does not export the `BrowserAdapter` class at runtime —
+ * obtain the instance via `session.adapter` or `navigator.delegate.adapter`.
+ */
+export interface BrowserAdapter extends Adapter {
     progressBar: ProgressBar;
-    visitProposedToLocation(location: URL, options?: VisitOptions): void;
-    visitStarted(visit: Visit): void;
-    visitCompleted(visit: Visit): void;
-    visitFailed(visit: Visit): void;
-    visitRequestStarted(visit: Visit): void;
-    visitRequestCompleted(visit: Visit): void;
-    visitRequestFailedWithStatusCode(visit: Visit, statusCode: number): void;
-    visitRequestFinished(visit: Visit): void;
-    visitRendered(visit: Visit): void;
-    pageInvalidated(reason: { reason: string }): void;
     formSubmissionStarted(formSubmission: FormSubmission): void;
     formSubmissionFinished(formSubmission: FormSubmission): void;
     linkPrefetchingIsEnabledForLocation(location: URL): boolean;


### PR DESCRIPTION
`StreamMessage` and `BrowserAdapter` were declared as exported classes, but @hotwired/turbo does not export either at runtime (neither appears in the dist export surface), so value imports compiled but resolved to undefined. Introduced in #74439.

Convert both to interfaces: `StreamMessage` keeps its instance shape (fragment) for renderStreamMessage(); `BrowserAdapter` now extends `Adapter`, keeping `progressBar` and the members it makes non-optional. Tests assert both names are no longer usable as values.

Fixes #75207


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hotwired/turbo/blob/main/src/core/session.js
