### PR TITLE
[three] Fix type of Interpolant.valueSize

### DIFF
--- a/types/three/src/math/Interpolant.d.ts
+++ b/types/three/src/math/Interpolant.d.ts
@@ -57,7 +57,7 @@ export abstract class Interpolant<TSettings = {}> {
      *
      * @type {TypedArray}
      */
-    valueSize: TypedArray;
+    valueSize: number;
     /**
      * The interpolation settings.
      *


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/three-types/three-ts-types/issues/2245
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
