### PR TITLE
Deprecated React.forwardRef

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1377,6 +1377,7 @@ declare namespace React {
      * Lets your component expose a DOM node to a parent component
      * using a ref.
      *
+     * @deprecated In React 19, `forwardRef` is no longer necessary. Pass `ref` as a prop instead.
      * @see {@link https://react.dev/reference/react/forwardRef React Docs}
      * @see {@link https://react-typescript-cheatsheet.netlify.app/docs/basic/getting-started/forward_and_create_ref/ React TypeScript Cheatsheet}
      *


### PR DESCRIPTION
According to the documentation, `forwardRef` is deprecated.

The documentation is a bit unclear, because there _**is**_ a deprecation notice, but it states the function _**will be**_ deprecated later. Regardless, it’s probably good to tell users not to use it in their editor.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://react.dev/reference/react/forwardRef
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
