### PR TITLE
[node] crypto: accept KeyObject to createPublicKey()

### DIFF
--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -1185,7 +1185,7 @@ declare module "node:crypto" {
      * and it will be impossible to extract the private key from the returned object.
      * @since v11.6.0
      */
-    function createPublicKey(key: PublicKeyInput | RawPublicKeyInput | JsonWebKeyInput | BinaryLike): KeyObject;
+    function createPublicKey(key: PublicKeyInput | RawPublicKeyInput | JsonWebKeyInput | KeyLike): KeyObject;
     /**
      * Creates and returns a new key object containing a secret key for symmetric
      * encryption or `Hmac`.

--- a/types/node/node-tests/crypto.ts
+++ b/types/node/node-tests/crypto.ts
@@ -1190,6 +1190,11 @@ import { promisify } from "node:util";
 }
 
 {
+    let privateKey!: crypto.KeyObject;
+    crypto.createPublicKey(privateKey);
+}
+
+{
     crypto.createSecretKey(Buffer.from("asdf"));
     crypto.createSecretKey(new Uint8Array(128));
     crypto.createSecretKey("ascii", "ascii");


### PR DESCRIPTION
Corrigendum to 9bec7894975dcca6a5303548bc053a2129b842a4.

It's not typed correctly in the upstream documentation, but `createPublicKey` specifically (and not `createPrivateKey` or `createSecretKey`) accepts a `KeyObject` as the source parameter, for the case of deriving a public key from existing private key material.

https://github.com/nodejs/node/blob/4140d4c2c8edf6c773603663a3684efac486ce63/lib/internal/crypto/keys.js#L543-L548