### PR TITLE
[three] Refactor Node type extensions into a lookup map

### DIFF
--- a/types/three/src/nodes/core/Node.d.ts
+++ b/types/three/src/nodes/core/Node.d.ts
@@ -556,63 +556,60 @@ export interface Mat4Extensions {
 export interface MatExtensions<TMat extends MatType> {
 }
 
+interface NodeExtras {
+    [x: string]: {};
+    "float": NumOrBoolExtensions<"float"> & FloatExtensions & NumExtensions<"float"> & FloatOrVecExtensions<"float">;
+    "int":
+        & NumOrBoolExtensions<"int">
+        & IntExtensions
+        & NumExtensions<"int">
+        & IntegerExtensions<"int">
+        & IntOrVecExtensions<"int">;
+    "uint":
+        & NumOrBoolExtensions<"uint">
+        & UintExtensions
+        & NumExtensions<"uint">
+        & IntegerExtensions<"uint">
+        & IntOrVecExtensions<"uint">;
+    "bool": NumOrBoolExtensions<"bool"> & BoolExtensions & BoolOrVecExtensions<"bool">;
+    "vec2":
+        & NumOrBoolVec2Extensions<"float">
+        & Vec2Extensions
+        & NumVec2Extensions<"float">
+        & FloatVecExtensions<"vec2">
+        & FloatOrVecExtensions<"vec2">;
+    "ivec2": NumOrBoolVec2Extensions<"int"> & NumVec2Extensions<"int"> & IntOrVecExtensions<"ivec2">;
+    "uvec2": NumOrBoolVec2Extensions<"uint"> & NumVec2Extensions<"uint"> & IntOrVecExtensions<"uvec2">;
+    "bvec2": NumOrBoolVec2Extensions<"bool"> & BoolOrVecExtensions<"bvec2">;
+    "vec3":
+        & NumOrBoolVec3Extensions<"float">
+        & Vec3Extensions
+        & NumVec3Extensions<"float">
+        & FloatVecExtensions<"vec3">
+        & FloatOrVecExtensions<"vec3">;
+    "ivec3": NumOrBoolVec3Extensions<"int"> & NumVec3Extensions<"int"> & IntOrVecExtensions<"ivec3">;
+    "uvec3": NumOrBoolVec3Extensions<"uint"> & NumVec3Extensions<"uint"> & IntOrVecExtensions<"uvec3">;
+    "bvec3": NumOrBoolVec3Extensions<"bool"> & BoolOrVecExtensions<"bvec3">;
+    "vec4":
+        & NumOrBoolVec4Extensions<"float">
+        & Vec4Extensions
+        & NumVec4Extensions<"float">
+        & FloatVecExtensions<"vec4">
+        & FloatOrVecExtensions<"vec4">;
+    "ivec4": NumOrBoolVec4Extensions<"int"> & NumVec4Extensions<"int"> & IntOrVecExtensions<"ivec4">;
+    "uvec4": NumOrBoolVec4Extensions<"uint"> & NumVec4Extensions<"uint"> & IntOrVecExtensions<"uvec4">;
+    "bvec4": NumOrBoolVec4Extensions<"bool"> & BoolOrVecExtensions<"bvec4">;
+    "color": ColorExtensions;
+    "mat2": Mat2Extensions & MatExtensions<"mat2">;
+    "mat3": Mat3Extensions & MatExtensions<"mat3">;
+    "mat4": Mat4Extensions & MatExtensions<"mat4">;
+}
+
 type Node<TNodeType = unknown> =
     & NodeClass
     & NodeElements
     & (unknown extends TNodeType ? {} : NodeExtensions<TNodeType>)
-    & (TNodeType extends "float"
-        ? NumOrBoolExtensions<"float"> & FloatExtensions & NumExtensions<"float"> & FloatOrVecExtensions<"float">
-        : TNodeType extends "int" ?
-                & NumOrBoolExtensions<"int">
-                & IntExtensions
-                & NumExtensions<"int">
-                & IntegerExtensions<"int">
-                & IntOrVecExtensions<"int">
-        : TNodeType extends "uint" ?
-                & NumOrBoolExtensions<"uint">
-                & UintExtensions
-                & NumExtensions<"uint">
-                & IntegerExtensions<"uint">
-                & IntOrVecExtensions<"uint">
-        : TNodeType extends "bool" ? NumOrBoolExtensions<"bool"> & BoolExtensions & BoolOrVecExtensions<"bool">
-        : TNodeType extends "vec2" ?
-                & NumOrBoolVec2Extensions<"float">
-                & Vec2Extensions
-                & NumVec2Extensions<"float">
-                & FloatVecExtensions<"vec2">
-                & FloatOrVecExtensions<"vec2">
-        : TNodeType extends "ivec2"
-            ? NumOrBoolVec2Extensions<"int"> & NumVec2Extensions<"int"> & IntOrVecExtensions<"ivec2">
-        : TNodeType extends "uvec2"
-            ? NumOrBoolVec2Extensions<"uint"> & NumVec2Extensions<"uint"> & IntOrVecExtensions<"uvec2">
-        : TNodeType extends "bvec2" ? NumOrBoolVec2Extensions<"bool"> & BoolOrVecExtensions<"bvec2">
-        : TNodeType extends "vec3" ?
-                & NumOrBoolVec3Extensions<"float">
-                & Vec3Extensions
-                & NumVec3Extensions<"float">
-                & FloatVecExtensions<"vec3">
-                & FloatOrVecExtensions<"vec3">
-        : TNodeType extends "ivec3"
-            ? NumOrBoolVec3Extensions<"int"> & NumVec3Extensions<"int"> & IntOrVecExtensions<"ivec3">
-        : TNodeType extends "uvec3"
-            ? NumOrBoolVec3Extensions<"uint"> & NumVec3Extensions<"uint"> & IntOrVecExtensions<"uvec3">
-        : TNodeType extends "bvec3" ? NumOrBoolVec3Extensions<"bool"> & BoolOrVecExtensions<"bvec3">
-        : TNodeType extends "vec4" ?
-                & NumOrBoolVec4Extensions<"float">
-                & Vec4Extensions
-                & NumVec4Extensions<"float">
-                & FloatVecExtensions<"vec4">
-                & FloatOrVecExtensions<"vec4">
-        : TNodeType extends "ivec4"
-            ? NumOrBoolVec4Extensions<"int"> & NumVec4Extensions<"int"> & IntOrVecExtensions<"ivec4">
-        : TNodeType extends "uvec4"
-            ? NumOrBoolVec4Extensions<"uint"> & NumVec4Extensions<"uint"> & IntOrVecExtensions<"uvec4">
-        : TNodeType extends "bvec4" ? NumOrBoolVec4Extensions<"bool"> & BoolOrVecExtensions<"bvec4">
-        : TNodeType extends "color" ? ColorExtensions
-        : TNodeType extends "mat2" ? Mat2Extensions & MatExtensions<"mat2">
-        : TNodeType extends "mat3" ? Mat3Extensions & MatExtensions<"mat3">
-        : TNodeType extends "mat4" ? Mat4Extensions & MatExtensions<"mat4">
-        : {})
+    & NodeExtras[TNodeType & string]
     & {
         __TypeScript_NODE_TYPE__: TNodeType;
     };


### PR DESCRIPTION
The newly released TypeScript 7 fails with OOM when processing the TSL module.

This PR refactors the `Node<TNodeType>` type in `types/three/src/nodes/core/Node.d.ts`, replacing the deeply nested `TNodeType extends ... ? ... : ...` conditional chain with a `NodeExtras` lookup map keyed by node type string.

This should be behaviorally equivalent (the `[x: string]: {}` index signature reproduces the previous `: {}` fallback branch), but avoids the long conditional chain that causes `tsgo` to loop and is substantially cheaper for the type checker.

Refactoring as suggested by Anders Hejlsberg in https://github.com/microsoft/typescript-go/issues/4528#issuecomment-4879046574

## Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
  - Observation: TSC completed within a few seconds. Before: TSC ran indefinitely and used 80GB of memory.
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid common mistakes described in the [handbook](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run test-all` to check for regressions in other packages that depend on this one.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/microsoft/typescript-go/issues/4528
- [ ] ~~Increase the version number in the header if appropriate.~~
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "@definitelytyped/dtslint/dt.json" }`.~~
