### PR TITLE
Added `null` to `google.visualization.ChartWrapper.setDataTable()`

### DIFF
--- a/types/google.visualization/google.visualization-tests.ts
+++ b/types/google.visualization/google.visualization-tests.ts
@@ -17,6 +17,14 @@ function test_arrayToDataTable() {
     var dataTable = google.visualization.arrayToDataTable(array);
 }
 
+function test_setChartWrapperDataTable() {
+    const chartWrapper = new google.visualization.ChartWrapper();
+    const dataTable = test_ctorDataTable();
+
+    chartWrapper.setDataTable(dataTable);
+    chartWrapper.setDataTable(null);
+}
+
 function test_ctorDataTable() {
     var dataTable = new google.visualization.DataTable();
     return dataTable;

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -73,7 +73,7 @@ declare namespace google {
             getOptions(): Object;
             getView(): any;
             setDataSourceUrl(url: string): void;
-            setDataTable(table: DataTable): void;
+            setDataTable(table: DataTable | null): void;
             setChartType(type: string): void;
             setChartName(name: string): void;
             setContainerId(id: string): void;


### PR DESCRIPTION
Added `null` to `google.visualization`'s `ChartWrapper`'s `setDataTable()` method.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/chart/interactive/docs/reference#methods_2
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.


As stated in the documentation provided above:
> setDataTable(table) | None | Sets the DataTable for the chart. Pass in one of the following: null; a DataTable object; a JSON representation of a DataTable; or an array following the syntax of arrayToDataTable().

~There are no relevant tests written for this package, and I do not know how to write good tests for it.~
I have written a test for the `setDataTable()` method based on the rest of the tests written for `google.visualization`. I'm a bit uncertain on how good of a test it is.