### PR TITLE
[three] Fix barrelMask typo in CRT declarations

### DIFF
--- a/types/three/examples/jsm/tsl/display/CRT.d.ts
+++ b/types/three/examples/jsm/tsl/display/CRT.d.ts
@@ -2,7 +2,7 @@ import { Node } from "three/webgpu";
 
 export const barrelUV: (curvature?: Node<"float">, coord?: Node<"vec2">) => Node<"vec2">;
 
-export const barrelMast: (coord: Node<"vec2">) => Node<"float">;
+export const barrelMask: (coord: Node<"vec2">) => Node<"float">;
 
 export const colorBleeding: (color: Node, amount?: Node<"float">) => Node<"vec3">;
 

--- a/types/three/test/unit/examples/jsm/tsl/display/CRT.ts
+++ b/types/three/test/unit/examples/jsm/tsl/display/CRT.ts
@@ -1,0 +1,4 @@
+import { barrelMask } from "three/addons/tsl/display/CRT.js";
+import { uv } from "three/tsl";
+
+barrelMask(uv());

--- a/types/three/tsconfig.json
+++ b/types/three/tsconfig.json
@@ -36,6 +36,7 @@
         "test/unit/examples/jsm/postprocessing/EffectComposer.ts",
         "test/unit/examples/jsm/postprocessing/SavePass.ts",
         "test/unit/examples/jsm/shaders/ACESFilmicToneMappingShader.ts",
+        "test/unit/examples/jsm/tsl/display/CRT.ts",
         "test/unit/src/audio/AudioContext.ts",
         "test/unit/src/core/EventDispatcher.ts",
         "test/unit/src/core/Uniform.ts",


### PR DESCRIPTION
The Three.js r185 CRT module exports `barrelMask`, but the corresponding
declaration currently exposes `barrelMast`.

This causes valid named imports of `barrelMask` to fail type checking even
though the export exists at runtime.

This change:

- Renames the declaration from `barrelMast` to `barrelMask`.
- Adds a regression test that imports and calls `barrelMask` through the
  public `three/addons/tsl/display/CRT.js` path.

### Runtime source

https://github.com/mrdoob/three.js/blob/r185/examples/jsm/tsl/display/CRT.js#L45

### Validation

- Confirmed against a local Three.js WebGPU/TSL project using the API.
- Ran `pnpm test three` successfully.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mrdoob/three.js/blob/r185/examples/jsm/tsl/display/CRT.js#L45
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`. Not applicable; this corrects a typo in the existing r185 declarations.