### PR TITLE
fix(pg): add verify option to PoolConfig

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -55,6 +55,7 @@ export interface PoolConfig extends ClientConfig {
     maxLifetimeSeconds?: number | undefined;
     Client?: (new() => ClientBase) | undefined;
     onConnect?: ((client: ClientBase) => void) | undefined;
+    verify?: ((client: PoolClient, done: (err?: Error) => void) => void) | undefined;
 }
 
 export interface QueryConfig<I = any[]> {

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -445,3 +445,15 @@ const poolWithOnConnect = new Pool({
 poolWithOnConnect.connect().then(client => {
     console.log("client connected");
 });
+
+const poolWithVerify = new Pool({
+    verify: (client, done) => {
+        client.query("SELECT 1", (err) => {
+            done(err ?? undefined);
+        });
+    },
+});
+
+poolWithVerify.connect().then(client => {
+    console.log("client connected");
+});


### PR DESCRIPTION
Closes #74971

Adds the `verify` option to `PoolConfig` in `@types/pg`. The underlying `pg-pool` package supports this option for connection verification. The type follows the signature from pg-pool source (lines 347-361).

Also adds a test case using the `verify` callback.