### PR TITLE
better-sqlite3: Bump to 9.6.9999

### DIFF
--- a/types/better-sqlite3/package.json
+++ b/types/better-sqlite3/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/better-sqlite3",
-    "version": "7.6.9999",
+    "version": "9.6.9999",
     "projects": [
         "https://github.com/JoshuaWise/better-sqlite3"
     ],


### PR DESCRIPTION
Bump `@types/better-sqlite3` from 7.6.9999 to 9.6.9999 to match better-sqlite3 9.6.x.

- Tested with `pnpm test better-sqlite3` — passes.
- No API changes; only the version field is updated.

Source: https://github.com/WiseLibs/better-sqlite3 (v9.6.x)
