### PR TITLE
pg: Add missing 'verify' option to PoolConfig

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -53,8 +53,9 @@ export interface PoolConfig extends ClientConfig {
     allowExitOnIdle?: boolean | undefined;
     maxUses?: number | undefined;
     maxLifetimeSeconds?: number | undefined;
-    Client?: (new() => ClientBase) | undefined;
+    Client?: (new () => ClientBase) | undefined;
     onConnect?: ((client: ClientBase) => void) | undefined;
+    verify?: ((client: PoolClient, done: (err?: Error) => void) => void) | undefined;
 }
 
 export interface QueryConfig<I = any[]> {
@@ -313,8 +314,7 @@ export interface PoolClient extends ClientBase {
 }
 
 export class Query<R extends QueryResultRow = any, I extends any[] = any> extends events.EventEmitter
-    implements Submittable
-{
+    implements Submittable {
     constructor(
         queryTextOrConfig?: string | QueryConfig<I>,
         callback?: (error: Error | undefined, result: ResultBuilder<R>) => void,


### PR DESCRIPTION
Fixes #74971

Add the missing `verify` option to `PoolConfig`. This is a documented feature of the underlying `pg-pool` package (see `pg-pool/index.js`, lines 347–361), but it was absent from the types.

- Tested with `pnpm test pg` — passes.

Ref: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/74971
