### PR TITLE
[parse-torrent] Lock @types/magnet-uri dependency to ^5

### DIFF
--- a/types/parse-torrent/package.json
+++ b/types/parse-torrent/package.json
@@ -6,7 +6,7 @@
         "https://github.com/webtorrent/parse-torrent"
     ],
     "dependencies": {
-        "@types/magnet-uri": "*",
+        "@types/magnet-uri": "^5",
         "@types/node": "*",
         "@types/parse-torrent-file": "*"
     },


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/75274
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

This PR pins the `@types/magnet-uri` dependency to `^5` to prevent automatic upgrade to a future incompatible major version (v7 ESM migration). This is part of a series of PRs to smoothly upgrade magnet-uri to v7 and parse-torrent to v11.