### PR TITLE
[chrome] fix chrome.declarativeWebRequest, bad enum + deprecated functions

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -1060,7 +1060,10 @@ declare namespace chrome {
 
         /** A set of data types. Missing data types are interpreted as `false`. */
         interface DataTypeSet {
-            /** Websites' WebSQL data. */
+            /**
+             * Websites' WebSQL data.
+             * @deprecated since Chrome 139. Support for WebSQL has been removed. This data type will be ignored.
+             */
             webSQL?: boolean | undefined;
             /** Websites' IndexedDB data. */
             indexedDB?: boolean | undefined;
@@ -1082,7 +1085,10 @@ declare namespace chrome {
             cache?: boolean | undefined;
             /** Cache storage. */
             cacheStorage?: boolean | undefined;
-            /** Websites' appcaches. */
+            /**
+             * Websites' appcaches.
+             * @deprecated since Chrome 98. Support for appcache has been removed. This data type will be ignored.
+             */
             appcache?: boolean | undefined;
             /** Websites' file systems. */
             fileSystems?: boolean | undefined;
@@ -1181,6 +1187,7 @@ declare namespace chrome {
          * Clears websites' WebSQL data.
          *
          * Can return its result via Promise in Manifest V3 or later since Chrome 96.
+         * @deprecated since Chrome 139. Support for WebSQL has been removed. This function has no effect.
          */
         function removeWebSQL(options: RemovalOptions): Promise<void>;
         function removeWebSQL(options: RemovalOptions, callback: () => void): void;
@@ -1189,6 +1196,7 @@ declare namespace chrome {
          * Clears websites' appcache data.
          *
          * Can return its result via Promise in Manifest V3 or later since Chrome 96.
+         * @deprecated since Chrome 98. Support for appcache has been removed. This function has no effect.
          */
         function removeAppcache(options: RemovalOptions): Promise<void>;
         function removeAppcache(options: RemovalOptions, callback: () => void): void;

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -2493,7 +2493,7 @@ declare namespace chrome {
      *
      * Permissions: "declarativeWebRequest"
      *
-     * MV2 only
+     * Beta and MV2 only
      * @deprecated Check out the {@link declarativeNetRequest} API instead
      */
     export namespace declarativeWebRequest {
@@ -2548,9 +2548,9 @@ declare namespace chrome {
             /** Matches if the MIME media type of a response (from the HTTP Content-Type header) is not contained in the list. */
             excludeContentType?: string[] | undefined;
             /** Matches if none of the request headers is matched by any of the HeaderFilters. */
-            excludeResponseHeaders?: HeaderFilter[] | undefined;
+            excludeRequestHeaders?: HeaderFilter[] | undefined;
             /** Matches if none of the response headers is matched by any of the HeaderFilters. */
-            excludeResponseHeader?: HeaderFilter[] | undefined;
+            excludeResponseHeaders?: HeaderFilter[] | undefined;
             /**
              * Matches if the conditions of the UrlFilter are fulfilled for the 'first party' URL of the request. The 'first party' URL of a request, when present, can be different from the request's target URL, and describes what is considered 'first party' for the sake of third-party checks for cookies.
              * @deprecated since Chrome 82
@@ -2617,7 +2617,7 @@ declare namespace chrome {
         /** Edits one or more cookies of response. Note that it is preferred to use the Cookies API because this is computationally less expensive. */
         interface EditResponseCookie {
             /** Filter for cookies that will be modified. All empty entries are ignored. */
-            filter: ResponseCookie;
+            filter: FilterResponseCookie;
             /** Attributes that shall be overridden in cookies that matched the filter. Attributes that are set to an empty string are removed. */
             modification: ResponseCookie;
         }
@@ -2661,7 +2661,7 @@ declare namespace chrome {
             /** Existence of the Secure cookie attribute. */
             secure?: string | undefined;
             /** Filters session cookies. Session cookies have no lifetime specified in any of 'max-age' or 'expires' attributes. */
-            session?: boolean | undefined;
+            sessionCookie?: boolean | undefined;
             /** Value of a cookie, may be padded in double-quotes. */
             value?: string | undefined;
         }

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -7230,7 +7230,7 @@ declare namespace chrome {
         enum ExtensionType {
             EXTENSION = "extension",
             HOSTED_APP = "hosted_app",
-            PACKAGE_APP = "package_app",
+            PACKAGED_APP = "packaged_app",
             LEGACY_PACKAGED_APP = "legacy_packaged_app",
             THEME = "theme",
             LOGIN_SCREEN_EXTENSION = "login_screen_extension",

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -2841,7 +2841,7 @@ async function testManagement() {
     chrome.management.ExtensionType.HOSTED_APP === "hosted_app";
     chrome.management.ExtensionType.LEGACY_PACKAGED_APP === "legacy_packaged_app";
     chrome.management.ExtensionType.LOGIN_SCREEN_EXTENSION === "login_screen_extension";
-    chrome.management.ExtensionType.PACKAGE_APP === "package_app";
+    chrome.management.ExtensionType.PACKAGED_APP === "packaged_app";
     chrome.management.ExtensionType.THEME === "theme";
 
     chrome.management.LaunchType.OPEN_AS_PINNED_TAB === "OPEN_AS_PINNED_TAB";
@@ -2881,7 +2881,7 @@ async function testManagement() {
         result.optionsUrl; // $ExpectType string
         result.permissions; // $ExpectType string[]
         result.shortName; // $ExpectType string
-        result.type; // $ExpectType "extension" | "hosted_app" | "legacy_packaged_app" | "login_screen_extension" | "package_app" | "theme"
+        result.type; // $ExpectType "extension" | "hosted_app" | "legacy_packaged_app" | "login_screen_extension" | "packaged_app" | "theme"
         result.updateUrl; // $ExpectType string | undefined
         result.version; // $ExpectType string
         result.versionName; // $ExpectType string | undefined

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -4329,6 +4329,11 @@ async function testDeclarativeNetRequest() {
 
 // https://developer.chrome.com/docs/extensions/mv2/reference/declarativeWebRequest
 function testDeclarativeWebRequest() {
+    chrome.declarativeWebRequest.Stage.ON_AUTH_REQUIRED === "onAuthRequired";
+    chrome.declarativeWebRequest.Stage.ON_BEFORE_REQUEST === "onBeforeRequest";
+    chrome.declarativeWebRequest.Stage.ON_BEFORE_SEND_HEADERS === "onBeforeSendHeaders";
+    chrome.declarativeWebRequest.Stage.ON_HEADERS_RECEIVED === "onHeadersReceived";
+
     chrome.declarativeWebRequest.onRequest.addRules([]); // $ExpectType void
     chrome.declarativeWebRequest.onRequest.removeRules([]); // $ExpectType void
     chrome.declarativeWebRequest.onRequest.getRules((rules) => { // $ExpectType void


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://developer.chrome.com/docs/extensions/mv2/reference/declarativeWebRequest
  - https://developer.chrome.com/docs/extensions/reference/api/management#type-ExtensionType
  - https://developer.chrome.com/docs/extensions/reference/api/browsingData
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Notes:
- fix `chrome.declarativeWebRequest.RequestMatcher`: 
  - add `excludeRequestHeaders` key
  - remove `excludeResponseHeader` key  
  
  <img width="952" height="155" alt="image" src="https://github.com/user-attachments/assets/83eb626b-fb66-406b-a591-9375984013f9" />
  
- fix `chrome.declarativeWebRequest.EditResponseCookie`: replace type of `filter` param (`ResponseCookie` -> `FilterResponseCookie`)
  
  <img width="941" height="147" alt="image" src="https://github.com/user-attachments/assets/221d323f-357a-4967-ae12-3cb695f33995" />


- fix `chrome.declarativeWebRequest.FilterResponseCookie`: rename key `session` to `sessionCookie`
  
  <img width="955" height="275" alt="image" src="https://github.com/user-attachments/assets/a4fd4bb8-1bf0-4e50-8011-8ae7ee60befb" />
  
- fix `chrome.management.ExtensionType`: rename `package_app` to `packaged_app`  
  
  <img width="812" height="117" alt="image" src="https://github.com/user-attachments/assets/6cbaf337-c061-4274-b612-65b830bf418a" />

- fix `chrome.tabs.Tab`: `lastAccessed` is not optional

  <img width="952" height="342" alt="image" src="https://github.com/user-attachments/assets/1f4a382c-1016-42ea-98dd-21f058c463ca" />
  
 - deprecate `chrome.browsingData.removeWebSQL` and `webSQL` key
 
 - deprecate `chrome.browsingData.removeAppcache` and `appcache` key

  