### PR TITLE
[chrome] update manifest type

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -9165,9 +9165,11 @@ declare namespace chrome {
         }
 
         interface ManifestAction {
-            default_icon?: ManifestIcons | undefined;
+            default_icon?: ManifestIcons | string | undefined;
             default_title?: string | undefined;
             default_popup?: string | undefined;
+            /** @default 'enabled' */
+            default_state?: "enabled" | "disabled";
         }
 
         /** Source: https://developer.chrome.com/docs/extensions/reference/permissions-list */
@@ -9273,22 +9275,37 @@ declare namespace chrome {
             | "webAuthenticationProxy"
         >;
 
+        /** A search engine. */
         interface SearchProvider {
+            /** Name of the search engine displayed to user. This is required if you don't set `prepopulated_id`. */
             name?: string | undefined;
+            /** An omnibox keyword for the search engine. This is required if you don't set `prepopulated_id`. */
             keyword?: string | undefined;
+            /** An icon URL for the search engine. This is required if you don't set `prepopulated_id`. */
             favicon_url?: string | undefined;
+            /** The search URL the search engine uses. */
             search_url: string;
+            /** The encoding used for search terms. This is required if you don't set `prepopulated_id`. */
             encoding?: string | undefined;
+            /** The URL the search engine uses for suggestions. If this isn't used, the engine doesn't support suggestions. */
             suggest_url?: string | undefined;
             instant_url?: string | undefined;
+            /** The URL the search engine uses for image search. If this isn't used, the engine doesn't support image search. */
             image_url?: string | undefined;
+            /** The post parameters for `search_url`. */
             search_url_post_params?: string | undefined;
+            /** The post parameters for `suggest_url`. */
             suggest_url_post_params?: string | undefined;
+            /** The post parameters for `instant_url`. */
             instant_url_post_params?: string | undefined;
+            /** The post parameters for `image_url`. */
             image_url_post_params?: string | undefined;
+            /** A list of URL patterns that can be used in addition to `search_url`. */
             alternate_urls?: string[] | undefined;
+            /** An ID for Chrome's built-in search engine. */
             prepopulated_id?: number | undefined;
-            is_default?: boolean | undefined;
+            /** Specifies whether the search provider should be default. */
+            is_default: boolean;
         }
 
         interface ManifestBase {
@@ -9313,8 +9330,10 @@ declare namespace chrome {
             author?: { email: string } | undefined;
             /** Defines overrides for selected Chrome settings.  */
             chrome_settings_overrides?: {
+                /** The new value for the homepage. */
                 homepage?: string | undefined;
                 search_provider?: SearchProvider | undefined;
+                /** An array of length one containing a URL to be used as the startup page. */
                 startup_pages?: string[] | undefined;
             } | undefined;
             /** Defines overrides for default Chrome pages. */
@@ -9326,13 +9345,16 @@ declare namespace chrome {
             /** Defines keyboard shortcuts within the extension. */
             commands?: {
                 [name: string]: {
-                    suggested_key?: {
-                        default?: string | undefined;
-                        windows?: string | undefined;
-                        mac?: string | undefined;
-                        chromeos?: string | undefined;
-                        linux?: string | undefined;
-                    } | undefined;
+                    suggested_key?:
+                        | {
+                            default?: string | undefined;
+                            windows?: string | undefined;
+                            mac?: string | undefined;
+                            chromeos?: string | undefined;
+                            linux?: string | undefined;
+                        }
+                        | string
+                        | undefined;
                     description?: string | undefined;
                     global?: boolean | undefined;
                 };
@@ -9348,7 +9370,7 @@ declare namespace chrome {
             cross_origin_opener_policy?: { value: string } | undefined;
             current_locale?: string | undefined;
             /** Defines static rules for the declarativeNetRequest API, which allows blocking and modifying of network requests. */
-            declarative_net_request?: { rule_resources?: declarativeNetRequest.Ruleset[] } | undefined;
+            declarative_net_request?: { rule_resources: declarativeNetRequest.Ruleset[] } | undefined;
             /** Defines pages that use the DevTools APIs. */
             devtools_page?: string | undefined;
             event_rules?:
@@ -9420,20 +9442,13 @@ declare namespace chrome {
             /** Allows the use of an OAuth 2.0 security ID. The value of this key must be an object with "client_id" and "scopes" properties. */
             oauth2?: {
                 client_id: string;
-                scopes?: string[] | undefined;
+                scopes: string[];
             } | undefined;
             offline_enabled?: boolean | undefined;
             /** Allows the extension to register a keyword in Chrome's address bar. */
             omnibox?: { keyword: string } | undefined;
             /** Specifies a path to an options.html file for the extension to use as an options page. */
             options_page?: string | undefined;
-            /** Specifies a path to an HTML file that lets a user change extension options from the Chrome Extensions page. */
-            options_ui?: {
-                /** Path to the options page, relative to the extension's root. */
-                page: string;
-                /** Specify as `false` to declare an embedded options page. If `true`, the extension's options page will be opened in a new tab rather than embedded in `chrome://extensions`. */
-                open_in_tab: boolean;
-            } | undefined;
             /** Lists technologies required to use the extension. */
             requirements?: {
                 "3D"?: { features?: string[] | undefined } | undefined;
@@ -9469,8 +9484,8 @@ declare namespace chrome {
             manifest_version: 2;
 
             // Pick one (or none)
-            browser_action?: ManifestAction | undefined;
-            page_action?: ManifestAction | undefined;
+            browser_action?: Omit<ManifestAction, "default_state"> | undefined;
+            page_action?: Omit<ManifestAction, "default_state"> | undefined;
 
             // Optional
             background?:
@@ -9496,6 +9511,15 @@ declare namespace chrome {
                 | undefined;
             /** Defines restrictions on the scripts, styles, and other resources an extension can use. */
             content_security_policy?: string | undefined;
+            /** Specifies a path to an HTML file that lets a user change extension options from the Chrome Extensions page. */
+            options_ui?: {
+                /** Path to the options page, relative to the extension's root. */
+                page: string;
+                /** If `true`, a Chrome user agent stylesheet will be applied to your options page. Defaults to `false`. */
+                chrome_style?: boolean | undefined;
+                /** Specify as `false` to declare an embedded options page. If `true`, the extension's options page will be opened in a new tab rather than embedded in `chrome://extensions`. */
+                open_in_tab?: boolean | undefined;
+            } | undefined;
             /** Declares optional permissions for your extension. */
             optional_permissions?: (ManifestOptionalPermission | string)[] | undefined;
             /** Enables use of particular extension APIs. */
@@ -9559,6 +9583,13 @@ declare namespace chrome {
                 | undefined;
             /** Lists the web pages your extension is allowed to interact with, defined using URL match patterns. User permission for these sites is requested at install time. */
             host_permissions?: string[] | undefined;
+            /** Specifies a path to an HTML file that lets a user change extension options from the Chrome Extensions page. */
+            options_ui?: {
+                /** Specifies the path to the options page, relative to the extension's root. */
+                page: string;
+                /** Indicates whether the extension's options page will be opened in a new tab. If set to `false`, the extension's options page is embedded in `chrome://extensions` rather than opened in a new tab. */
+                open_in_tab?: boolean | undefined;
+            } | undefined;
             /** Declares optional permissions for your extension. */
             optional_permissions?: ManifestOptionalPermission[] | undefined;
             /** Declares optional host permissions for your extension. */

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1033,6 +1033,42 @@ function testGetManifest() {
         manifest.author.email; // $ExpectType string
     }
 
+    if (manifest.chrome_settings_overrides) {
+        manifest.chrome_settings_overrides.homepage; // $ExpectType string | undefined
+        manifest.chrome_settings_overrides.startup_pages; // $ExpectType string[] | undefined
+        if (manifest.chrome_settings_overrides.search_provider) {
+            manifest.chrome_settings_overrides.search_provider.name; // $ExpectType string | undefined
+            manifest.chrome_settings_overrides.search_provider.keyword; // $ExpectType string | undefined
+            manifest.chrome_settings_overrides.search_provider.favicon_url; // $ExpectType string | undefined
+            manifest.chrome_settings_overrides.search_provider.search_url; // $ExpectType string
+            manifest.chrome_settings_overrides.search_provider.encoding; // $ExpectType string | undefined
+            manifest.chrome_settings_overrides.search_provider.suggest_url; // $ExpectType string | undefined
+            manifest.chrome_settings_overrides.search_provider.instant_url; // $ExpectType string | undefined
+            manifest.chrome_settings_overrides.search_provider.image_url; // $ExpectType string | undefined
+            manifest.chrome_settings_overrides.search_provider.search_url_post_params; // $ExpectType string | undefined
+            manifest.chrome_settings_overrides.search_provider.suggest_url_post_params; // $ExpectType string | undefined
+            manifest.chrome_settings_overrides.search_provider.instant_url_post_params; // $ExpectType string | undefined
+            manifest.chrome_settings_overrides.search_provider.image_url_post_params; // $ExpectType string | undefined
+            manifest.chrome_settings_overrides.search_provider.alternate_urls; // $ExpectType string[] | undefined
+            manifest.chrome_settings_overrides.search_provider.prepopulated_id; // $ExpectType number | undefined
+            manifest.chrome_settings_overrides.search_provider.is_default; // $ExpectType boolean
+        }
+    }
+
+    if (manifest.commands?.foobar) {
+        if (typeof manifest.commands.foobar.suggested_key === "object") {
+            manifest.commands.foobar.suggested_key.default; // $ExpectType string | undefined
+            manifest.commands.foobar.suggested_key.windows; // $ExpectType string | undefined
+            manifest.commands.foobar.suggested_key.mac; // $ExpectType string | undefined
+            manifest.commands.foobar.suggested_key.chromeos; // $ExpectType string | undefined
+            manifest.commands.foobar.suggested_key.linux; // $ExpectType string | undefined
+        } else {
+            manifest.commands.foobar.suggested_key; // $ExpectType string | undefined
+        }
+        manifest.commands.foobar.global; // $ExpectType boolean | undefined
+        manifest.commands.foobar.description; // $ExpectType string | undefined
+    }
+
     if (manifest.cross_origin_embedder_policy) {
         manifest.cross_origin_embedder_policy.value; // $ExpectType string
     }
@@ -1080,9 +1116,9 @@ function testGetManifest() {
         manifest.input_components[0].options_page; // $ExpectType string | undefined
     }
 
-    if (manifest.options_ui) {
-        manifest.options_ui.page; // $ExpectType string
-        manifest.options_ui.open_in_tab; // $ExpectType boolean
+    if (manifest.oauth2) {
+        manifest.oauth2.client_id; // $ExpectType string
+        manifest.oauth2.scopes; // $ExpectType string[]
     }
 
     if (manifest.sandbox) {
@@ -1091,8 +1127,27 @@ function testGetManifest() {
     }
 
     if (manifest.manifest_version === 2) {
-        manifest.browser_action; // $ExpectType ManifestAction | undefined
-        manifest.page_action; // $ExpectType ManifestAction | undefined
+        if (manifest.page_action) {
+            manifest.page_action.default_icon; // $ExpectType ManifestIcons | string | undefined
+            manifest.page_action.default_title; // $ExpectType string | undefined
+            manifest.page_action.default_popup; // $ExpectType string | undefined
+            // @ts-expect-error The default_state key cannot be set for browser_action or page_action keys.
+            manifest.page_action.default_state;
+        }
+
+        if (manifest.browser_action) {
+            manifest.browser_action.default_icon; // $ExpectType ManifestIcons | string | undefined
+            manifest.browser_action.default_title; // $ExpectType string | undefined
+            manifest.browser_action.default_popup; // $ExpectType string | undefined
+            // @ts-expect-error The default_state key cannot be set for browser_action or page_action keys.
+            manifest.browser_action.default_state;
+        }
+
+        if (manifest.options_ui) {
+            manifest.options_ui.page; // $ExpectType string
+            manifest.options_ui.open_in_tab; // $ExpectType boolean | undefined
+            manifest.options_ui.chrome_style; // $ExpectType boolean | undefined
+        }
 
         manifest.content_security_policy; // $ExpectType string | undefined
 
@@ -1107,7 +1162,19 @@ function testGetManifest() {
 
         manifest.web_accessible_resources; // $ExpectType string[] | undefined
     } else if (manifest.manifest_version === 3) {
-        manifest.action; // $ExpectType ManifestAction | undefined
+        if (manifest.action) {
+            manifest.action.default_icon; // $ExpectType ManifestIcons | string | undefined
+            manifest.action.default_title; // $ExpectType string | undefined
+            manifest.action.default_popup; // $ExpectType string | undefined
+            manifest.action.default_state; // $ExpectType 'enabled' | 'disabled' | undefined
+        }
+
+        if (manifest.options_ui) {
+            manifest.options_ui.page; // $ExpectType string
+            manifest.options_ui.open_in_tab; // $ExpectType boolean | undefined
+            // @ts-expect-error The chrome_style option cannot be used with manifest version 3.
+            manifest.options_ui.chrome_style;
+        }
 
         // @ts-expect-error
         manifest.content_security_policy = "default-src 'self'";
@@ -1202,6 +1269,11 @@ function testGetManifest() {
             },
         ],
         content_security_policy: "default-src 'self'",
+        options_ui: {
+            page: "options.html",
+            open_in_tab: true,
+            chrome_style: true,
+        },
         optional_permissions: ["https://*/*"],
         permissions: ["https://*/*"],
         web_accessible_resources: ["some-page.html"],
@@ -1230,6 +1302,10 @@ function testGetManifest() {
         content_security_policy: {
             extension_pages: "default-src 'self'",
             sandbox: "default-src 'self'",
+        },
+        options_ui: {
+            page: "options.html",
+            open_in_tab: true,
         },
         host_permissions: ["http://*/*"],
         optional_permissions: ["cookies"],


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (see "Notes")
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Notes:
- update `page_action`: `default_icon` key can be a `string` ([mv2 doc](https://developer.chrome.com/docs/extensions/mv2/reference/pageAction?hl=en#:~:text=The%20old%20syntax%20for%20registering%20the%20default%20icon%20is%20still%20supported%3A)) 
- update `browser_action`: `default_icon` key can be a `string` ([mv2 doc](https://developer.chrome.com/docs/extensions/mv2/reference/browserAction#:~:text=The%20old%20syntax%20for%20registering%20the%20default%20icon%20is%20still%20supported)) 
- update `action` : 
  - `default_icon` key can be a `string` ([mv3 doc](https://developer.chrome.com/docs/extensions/reference/api/action?hl=en#:~:text=the%20%22default_icon%22%20key%20can%20also%20be%20set%20to%20a%20string%20with%20the%20path%20to%20a%20single%20icon%20instead%20of%20a%20dictionary.))
  - add `default_state` key  ([mv3 doc](https://developer.chrome.com/docs/extensions/reference/api/action?hl=en#enabled_state)) 
  
    <img width="472" height="60" alt="action default_state" src="https://github.com/user-attachments/assets/d1926c1a-3e1a-4eb4-9172-77eb7a384eb8" />
- update `chrome_settings_overrides.search_provider`:
  - add JSDoc
  - `is_default` key is required ([mv3 doc](https://developer.chrome.com/docs/extensions/reference/manifest/chrome-settings-override#reference), [mv2 doc](https://developer.chrome.com/docs/extensions/mv2/settings-override))
  
    <img width="397" height="30" alt="chrome_settings_overrides search_provider is_default" src="https://github.com/user-attachments/assets/d174e52e-092b-4fac-9d34-53069fa9a865" />

- update `commands.[string].suggested_key` key can be a `string` ([mv3 doc](https://developer.chrome.com/docs/extensions/reference/api/commands#concepts_and_usage), [mv2 doc](https://developer.chrome.com/docs/extensions/mv2/reference/commands#usage))
   
- update `declarative_net_request`: `rule_resources` key is required

   <img width="611" height="47" alt="declarative_net_request rule_resources" src="https://github.com/user-attachments/assets/5e8de9f7-ff01-4d5b-bf39-c416de307806" />

- update `oauth2`: `scopes` key is required

     <img width="557" height="36" alt="image" src="https://github.com/user-attachments/assets/436cff3c-9b02-4981-897d-aca5b77f2f36" />

- update `options_ui`: 

  - `open_in_tab` key is optional ([source](https://chromium.googlesource.com/chromium/src/+/heads/main/extensions/common/api/extensions_manifest_types.json#89))
  - add `chrome_style` key for mv2 only ([mv2 doc](https://developer.chrome.com/docs/extensions/mv2/manifest))
    
    <img width="636" height="52" alt="options_ui chrome_style" src="https://github.com/user-attachments/assets/7f17b881-f9a5-466e-8a11-cc7313915d97" />
