### PR TITLE
[plotly.js] Add d2p to LayoutAxis

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -1135,6 +1135,7 @@ export interface LayoutAxis extends Axis {
     angle: any;
     griddash: Dash;
     l2p: (v: Datum) => number;
+    d2p: (v: Datum) => number;
 
     autotickangles: number[];
     insiderange: any[];

--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -1134,8 +1134,8 @@ export interface LayoutAxis extends Axis {
     automargin: boolean;
     angle: any;
     griddash: Dash;
-    l2p: (v: Datum) => number;
-    d2p: (v: Datum) => number;
+    l2p: (v: number) => number;
+    d2p: (v: Datum, clip?: any, calendar?: any) => number;
 
     autotickangles: number[];
     insiderange: any[];

--- a/types/plotly.js/test/index-tests.ts
+++ b/types/plotly.js/test/index-tests.ts
@@ -1658,3 +1658,9 @@ function rand() {
 
     Plotly.newPlot("myDiv", data, layout);
 })();
+
+(() => {
+    const axis = {} as Plotly.LayoutAxis;
+    const dataPixel: number = axis.d2p(2.5);
+    const linearizedPixel: number = axis.l2p(2.5);
+})();

--- a/types/plotly.js/test/index-tests.ts
+++ b/types/plotly.js/test/index-tests.ts
@@ -1662,5 +1662,7 @@ function rand() {
 (() => {
     const axis = {} as Plotly.LayoutAxis;
     const dataPixel: number = axis.d2p(2.5);
+    const logPixel: number = axis.d2p(2.5, true);
+    const datePixel: number = axis.d2p("2024-01-01", undefined, "gregorian");
     const linearizedPixel: number = axis.l2p(2.5);
 })();


### PR DESCRIPTION
Fixes #71932

Adds the `d2p` (data-to-pixel) axis conversion method to the `LayoutAxis` interface, alongside the existing `l2p`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `pnpm test plotly.js`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/plotly/plotly.js/blob/master/src/plots/cartesian/set_convert.js — `ax.d2p` is defined for all axis types (linear: `ax.d2p = ax.r2p = function(v) { return ax.l2p(cleanNumber(v)); }`, plus log, date, and category variants), matching the `(v: Datum) => number` shape of the already-declared `l2p`.