### PR TITLE
[pg] Add missing "connect" event to ClientBase.on typings

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -281,9 +281,9 @@ export class ClientBase extends events.EventEmitter {
     setTypeParser: typeof pgTypes.setTypeParser;
     getTypeParser: typeof pgTypes.getTypeParser;
 
-    on<E extends "drain" | "error" | "notice" | "notification" | "end">(
+    on<E extends "connect" | "drain" | "error" | "notice" | "notification" | "end">(
         event: E,
-        listener: E extends "drain" | "end" ? () => void
+        listener: E extends "connect" | "drain" | "end" ? () => void
             : E extends "error" ? (err: Error) => void
             : E extends "notice" ? (notice: NoticeMessage) => void
             : (message: Notification) => void,

--- a/types/pg/pg-tests.mts
+++ b/types/pg/pg-tests.mts
@@ -76,6 +76,10 @@ const myFunc2 = (c: pg.Client) => {
     c.on("drain", () => {});
 };
 
+const myFunc3 = (c: pg.Client) => {
+    c.on("connect", () => {});
+};
+
 // $ExpectType ClientBase
 new pg.ClientBase();
 // $ExpectType ClientBase


### PR DESCRIPTION
Add the missing `connect` event to the `ClientBase.on` overload in `@types/pg`.

The `connect` event is emitted without arguments, so its listener should be typed as `() => void`.

The event is emitted by `Client` here:
https://github.com/brianc/node-postgres/blob/e35aed91cb8f04116b3557e09adf33e2677af1ed/packages/pg/lib/client.js

A regression test was added to `pg-tests.mts`. The test fails without the declaration change and passes with it.