### PR TITLE
[semaphore] Pass leave callback to Task

### DIFF
--- a/types/semaphore/index.d.ts
+++ b/types/semaphore/index.d.ts
@@ -1,8 +1,17 @@
 declare function semaphore(capacity?: number): semaphore.Semaphore;
 
 declare namespace semaphore {
+    /**
+     * Releases `n` (default `1`) units of capacity back to the semaphore.
+     */
+    type Leave = (n?: number) => void;
+
     interface Task {
-        (): void;
+        /**
+         * @param leave Releases the capacity held by this task. `take` passes it to every
+         * task it runs, so a task can release the semaphore without closing over it.
+         */
+        (leave: Leave): void;
     }
 
     interface Semaphore {

--- a/types/semaphore/semaphore-tests.ts
+++ b/types/semaphore/semaphore-tests.ts
@@ -13,3 +13,16 @@ sem.leave(2);
 sem.current;
 
 const available: boolean = sem.available(2);
+
+// `take` passes `leave` to every task, so a task can release the semaphore
+// without closing over it. Tasks that ignore it still type-check.
+sem.take((leave: semaphore.Leave) => {
+    console.log("My task");
+    leave();
+});
+
+sem.take(2, (leave) => {
+    // $ExpectType Leave
+    leave;
+    leave(2);
+});


### PR DESCRIPTION
Fixes #68377

## Problem

`semaphore.Task` declares a call signature with no parameters:

```ts
interface Task {
    (): void;
}
```

But the implementation always invokes the task with the semaphore's `leave` function as its first argument. In [`lib/semaphore.js`](https://github.com/abrkn/semaphore.js/blob/master/lib/semaphore.js), `take` wraps the user's task before queuing or running it:

```js
var task = item.task;
item.task = function() { task(semaphore.leave); };
```

Both code paths that eventually run the task go through that wrapper — the immediate path (`item.task(semaphore.leave)`) and the queued path (`nextTick(item.task)` from `leave`) — so a task is *always* called with `leave`.

This is the documented usage pattern, per [abrkn/semaphore.js#2](https://github.com/abrkn/semaphore.js/issues/2#issuecomment-18669896):

```js
var sem = require('semaphore')()
sem.take(function (leave) {
    console.log('about to leave')
    leave()
})
```

With the current types that callback fails to compile — the parameter is implicitly `any` under `noImplicitAny`, and `leave` is untyped. Users have to fall back to closing over the semaphore or casting.

## Change

Declare the parameter, and add a `Leave` alias so the callback parameter has a meaningful, referenceable type:

```ts
type Leave = (n?: number) => void;

interface Task {
    (leave: Leave): void;
}
```

`Leave` mirrors the existing `Semaphore.leave(n?: number): void` signature — the same function is what gets passed in, and its `n = n || 1` default makes the argument optional.

## Not a breaking change

TypeScript allows a function with fewer parameters to be assignable to a function type with more, so tasks that ignore `leave` still type-check unchanged:

```ts
sem.take(function task() { sem.leave(); }); // still fine
```

The pre-existing test case that passes a zero-argument `task` is left untouched and still compiles, which covers this.

I declared the parameter as required rather than optional (`leave?: Leave`) on purpose. The runtime always supplies it, so making it optional would type it as `Leave | undefined` and force consumers into `leave!()` or `leave?.()` for a value that is never actually absent. Declaring it required matches how callback parameters are typed elsewhere (e.g. `Array.prototype.forEach`) and keeps zero-argument tasks assignable either way.

## Testing

- Added test coverage for both `take` overloads with a `leave`-consuming task, including an `$ExpectType Leave` assertion on the inferred parameter.
- `pnpm test semaphore` passes (TypeScript 5.6 through 6.0).
- Verified the new assertion is genuinely enforced by temporarily asserting a wrong type and confirming dtslint failed, then restoring it.

## Checklist

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid common mistakes.
- [x] Run `pnpm test <package to test>`.

No version bump: this is a non-breaking addition to an existing type.
