### PR TITLE
[selectize] Add missing IApi members: addItems, removeOptionGroup, clearOptionGroups, $input, settings

### DIFF
--- a/types/selectize/index.d.ts
+++ b/types/selectize/index.d.ts
@@ -407,6 +407,16 @@ declare namespace Selectize {
     // see https://github.com/brianreavis/selectize.js/blob/master/docs/api.md
     interface IApi<T, U> {
         /**
+         * The original input element the control was created from.
+         */
+        $input: JQuery;
+
+        /**
+         * The settings the control was initialized with, merged with the defaults.
+         */
+        settings: IOptions<T, U>;
+
+        /**
          * An array of selected values.
          */
         items: T[];
@@ -476,6 +486,11 @@ declare namespace Selectize {
         addItem(value: T, silent?: boolean): void;
 
         /**
+         * "Selects" multiple items at once. Adds them to the list at the current caret position.
+         */
+        addItems(values: T | T[], silent?: boolean): void;
+
+        /**
          * Removes the selected item matching the provided value.
          */
         removeItem(value: T, silent?: boolean): void;
@@ -499,6 +514,16 @@ declare namespace Selectize {
          * The "id" argument refers to a value of the property in option identified by the "optgroupField" setting.
          */
         addOptionGroup(id: string, data: U): void;
+
+        /**
+         * Removes the existing optgroup identified by the given id.
+         */
+        removeOptionGroup(id: string): void;
+
+        /**
+         * Removes all existing optgroups from the control.
+         */
+        clearOptionGroups(): void;
 
         // Events
         // ------------------------------------------------------------------------------------------------------------

--- a/types/selectize/selectize-tests.ts
+++ b/types/selectize/selectize-tests.ts
@@ -50,6 +50,22 @@ $("#button-additem").on("click", function() {
 $("#button-setvalue").on("click", function() {
     control.setValue([2, 3]);
 });
+$("#button-additems").on("click", function() {
+    control.addItems(2);
+    control.addItems([2, 3]);
+    control.addItems([2, 3], true);
+});
+$("#button-removeoptiongroup").on("click", function() {
+    control.removeOptionGroup("dodge");
+});
+$("#button-clearoptiongroups").on("click", function() {
+    control.clearOptionGroups();
+});
+
+// The original input element and the resolved settings are exposed on the control.
+var $original: JQuery = control.$input;
+var maxItems: number | undefined = control.settings.maxItems;
+var valueField: string | undefined = control.settings.valueField;
 
 // Cities example
 // --------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #69377
Fixes #69530

## Problem

Several members that exist on the Selectize control are missing from `Selectize.IApi<T, U>`, so consumers have to cast to `any` to reach documented, shipping API:

- `addItems(values, silent)` — [documented](https://selectize.dev/docs/API/selectize#additemsvalues-silent)
- `removeOptionGroup(id)` — [documented](https://selectize.dev/docs/API/selectize#removeoptiongroupid)
- `clearOptionGroups()` — [documented](https://selectize.dev/docs/API/selectize#clearoptiongroups)
- `$input` — the original jQuery object the control was built from
- `settings` — the resolved settings of the control

`addOptionGroup` was already declared, but its two siblings were not, which made the optgroup portion of the API only partially usable.

## Which upstream version was checked, and why

A previous attempt at this (#69378) was closed with the reviewer question:

> DT is at 0.12, and this package upstream is at 0.15; can you verify which versions things were added?

Answering that directly:

| npm package | latest version | what `@types/selectize` targets |
| --- | --- | --- |
| `selectize` | **0.12.6** | ✅ this package (`0.12.9999`) |
| `@selectize/selectize` | 0.15.2 | ❌ separate package, separate name |

The 0.13–0.15 line was republished under the **new scoped name `@selectize/selectize`**. The unscoped `selectize` package on npm — the one `@types/selectize` provides types for — has `latest` at `0.12.6`. So the 0.12 version here is correct, and everything added in this PR was verified against the **0.12.6** implementation, not 0.15:

```js
// selectize@0.12.6 dist/js/standalone/selectize.js
addOptionGroup: function(id, data) { ... }      // L2377 (already typed)
removeOptionGroup: function(id) { ... }         // L2389
clearOptionGroups: function() { ... }           // L2400
addItems: function(values, silent) { ... }      // L2578
```

```js
// constructor, L1141-1142 — both assigned onto the instance
$.extend(self, {
    order            : 0,
    settings         : settings,
    $input           : $input,
    ...
```

`addItems` is typed as `values: T | T[]` because the implementation normalises either form:

```js
var items = $.isArray(values) ? values : [values];
```

## Deliberately *not* included

Issue #69495 asks for a `silent` parameter on `clearOptions()` and `refreshItems()`. That parameter **does not exist in 0.12.6** — both take no arguments there:

```js
clearOptions: function() { ... }    // L2495
refreshItems: function() { ... }    // L2766
```

It was added later, in the `@selectize/selectize` line. Adding it here would type an argument that is silently ignored at runtime for every consumer of `selectize@0.12.6`, so #69495 is intentionally left open rather than fixed incorrectly. That issue is only actionable if/when DT adds types for `@selectize/selectize`.

## Tests

Added coverage in `selectize-tests.ts` for each new member — both `addItems` overload shapes, the two optgroup methods, and reading `$input` / `settings`.

`pnpm dtslint types/selectize` passes (exit code 0) against TypeScript 5.6, 5.7, 5.8, 5.9 and 6.0.

## Checklist

- [x] Use a meaningful title for the pull request.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid common mistakes.
- [x] Run `pnpm test <package to test>`.

No version bump: these are purely additive members to an existing interface, and the package version continues to track `selectize@0.12.x`.
