### PR TITLE
[express-serve-static-core] Split Send into overloads so a typed ResBody doesn't implicitly accept undefined

### DIFF
--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -199,7 +199,14 @@ app.get<never, { foo: string }>("/", (req, res) => {
     // @ts-expect-error
     req.params.baz;
 
+    res.send(); // $ExpectType Response<{ foo: string; }, Record<string, any>, number>
     res.send({ foo: "ok" }); // $ExpectType Response<{ foo: string; }, Record<string, any>, number>
+    res.send(undefined); // $ExpectType Response<{ foo: string; }, Record<string, any>, number>
+    // @ts-expect-error
+    res.send({ bar: "fail" });
+    res.json(); // $ExpectType Response<{ foo: string; }, Record<string, any>, number>
+    res.json({ foo: "ok" }); // $ExpectType Response<{ foo: string; }, Record<string, any>, number>
+    res.json(undefined); // $ExpectType Response<{ foo: string; }, Record<string, any>, number>
     req.body; // $ExpectType any
 });
 

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -680,7 +680,11 @@ export interface MediaType {
     subtype: string;
 }
 
-export type Send<ResBody = any, T = Response<ResBody>> = (body?: ResBody) => T;
+export interface Send<ResBody = any, T = Response<ResBody>> {
+    (): T;
+    (body: undefined): T;
+    (body: ResBody): T;
+}
 
 export interface SendFileOptions extends SendOptions {
     /** Object containing HTTP headers to serve with the file. */

--- a/types/express-serve-static-core/v4/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/v4/express-serve-static-core-tests.ts
@@ -169,7 +169,14 @@ app.get<never, { foo: string }>("/", (req, res) => {
     // @ts-expect-error
     req.params.baz;
 
+    res.send(); // $ExpectType Response<{ foo: string; }, Record<string, any>, number>
     res.send({ foo: "ok" }); // $ExpectType Response<{ foo: string; }, Record<string, any>, number>
+    res.send(undefined); // $ExpectType Response<{ foo: string; }, Record<string, any>, number>
+    // @ts-expect-error
+    res.send({ bar: "fail" });
+    res.json(); // $ExpectType Response<{ foo: string; }, Record<string, any>, number>
+    res.json({ foo: "ok" }); // $ExpectType Response<{ foo: string; }, Record<string, any>, number>
+    res.json(undefined); // $ExpectType Response<{ foo: string; }, Record<string, any>, number>
     req.body; // $ExpectType any
 });
 

--- a/types/express-serve-static-core/v4/index.d.ts
+++ b/types/express-serve-static-core/v4/index.d.ts
@@ -677,7 +677,11 @@ export interface MediaType {
     subtype: string;
 }
 
-export type Send<ResBody = any, T = Response<ResBody>> = (body?: ResBody) => T;
+export interface Send<ResBody = any, T = Response<ResBody>> {
+    (): T;
+    (body: undefined): T;
+    (body: ResBody): T;
+}
 
 export interface SendFileOptions extends SendOptions {
     /** Object containing HTTP headers to serve with the file. */


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test `](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/expressjs/express/blob/master/lib/response.js (see also the runtime tests for `res.send(undefined)` in [test/res.send.js](https://github.com/expressjs/express/blob/master/test/res.send.js) and `res.json(undefined)` in [test/res.json.js](https://github.com/expressjs/express/blob/master/test/res.json.js))
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---

### What this changes

`Send` was previously declared as `(body?: ResBody) => T`, which silently widens the body parameter to `ResBody | undefined`. This PR splits it into dedicated overloads:

```ts
export interface Send<ResBody = any, T = Response<ResBody>> {
    (): T;
    (body: undefined): T;
    (body: ResBody): T;
}
```

This keeps a concrete `ResBody` (e.g. `{ foo: string }`) clean. The body parameter is no longer implicitly `{ foo: string } | undefined`, while still accepting `res.send()` and an explicit `res.send(undefined)`, which Express supports at runtime (responds with an empty body; covered by Express's own tests linked above).
