### PR TITLE
[mapbox__mapbox-gl-geocoder] Add MarkerOptions to marker option type

### DIFF
--- a/types/mapbox__mapbox-gl-geocoder/index.d.ts
+++ b/types/mapbox__mapbox-gl-geocoder/index.d.ts
@@ -154,7 +154,7 @@ declare namespace MapboxGeocoder {
          * Requires that `options.mapboxgl` also be set.
          * @default true
          */
-        marker?: boolean | mapboxgl.Marker | undefined;
+        marker?: boolean | mapboxgl.Marker | mapboxgl.MarkerOptions | undefined;
         /**
          * A function that specifies how the results should be rendered in the dropdown menu.
          * This function should accepts a single [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md)

--- a/types/mapbox__mapbox-gl-geocoder/mapbox__mapbox-gl-geocoder-tests.ts
+++ b/types/mapbox__mapbox-gl-geocoder/mapbox__mapbox-gl-geocoder-tests.ts
@@ -158,3 +158,9 @@ geocoder.addTo(mapDiv);
 
 // $ExpectType MapboxGeocoder
 geocoder.addTo("#map");
+
+// marker as MarkerOptions
+const geocoderWithMarkerOpts = new MapboxGeocoder({
+    accessToken: "token",
+    marker: { color: "#ff0000" },
+});


### PR DESCRIPTION
The `marker` option accepts a `MarkerOptions` object at runtime (passed directly to `new mapboxgl.Marker(options)`), but the typedef only allows `boolean | Marker`. Adding `MarkerOptions` removes the need for `@ts-ignore` at call sites.