### PR TITLE
[express-serve-static-core]: Changed Errback type err parameter to be optional

### DIFF
--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -300,13 +300,16 @@ app.get<{}, any, any, {}, { foo: boolean }>("/locals", (req, res, next) => {
 
 app.get("/file.txt", (req, res) => {
     res.download("/some/path/to/file.txt", "file.txt", { maxAge: 3_600_000 }, error => {
-        // $ExpectType Error
+        // $ExpectType Error | undefined
         error;
     });
 });
 
 app.get("/file2.txt", (req, res) => {
-    res.sendFile("/some/path/to/file2.txt", { maxAge: 3_600_000 });
+    res.sendFile("/some/path/to/file2.txt", { maxAge: 3_600_000 }, error => {
+        // $ExpectType Error | undefined
+        error;
+    });
     // @ts-expect-error
     res.sendFile("/some/path/to/file2.txt", { "max-age": 3_600_000 });
 });

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -391,7 +391,7 @@ export interface ByteRange {
 
 export interface RequestRanges extends RangeParserRanges {}
 
-export type Errback = (err: Error) => void;
+export type Errback = (err?: Error) => void;
 
 /**
  * @param P  For most requests, this should be `ParamsDictionary`, but if you're


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/expressjs/express/blob/ae6dd37680e3a00618d6c8a3e522f0ee4eeba1a4/lib/response.js#L981
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---

**Independent test to validate the behavior during runtime:**

```js
import assert from 'node:assert/strict';
import { randomUUID } from 'node:crypto';
import { unlinkSync, writeFileSync } from 'node:fs';
import { createServer } from 'node:http';
import { join } from 'node:path';
import { cwd } from 'node:process';
import { Readable } from 'node:stream';

import express from 'express';

const app = express();
const server = createServer(app);

app
  .get('/valid-download', (request, response) => {
    const path = join(cwd(), randomUUID());

    writeFileSync(path, 'PH', { encoding: 'utf8' });

    response.download(path, (error) => {
      assert.ok(!(error instanceof Error));
      assert.strictEqual(error, undefined);

      unlinkSync(path);
    });
  })
  .get('/invalid-download', (request, response) => {
    response.download('?:#!.', (error) => {
      assert.ok(error instanceof Error);

      response.status(500).end();
    });
  })
  .get('/valid-send-file', (request, response) => {
    const path = join(cwd(), randomUUID());

    writeFileSync(path, 'PH', { encoding: 'utf8' });

    response.sendFile(path, (error) => {
      assert.ok(!(error instanceof Error));
      assert.strictEqual(error, undefined);

      unlinkSync(path);
    });
  })
  .get('/invalid-send-file', (request, response) => {
    response.sendFile('/?:#!.', (error) => {
      assert.ok(error instanceof Error);

      response.status(500).end();
    });
  });

server.listen(() => {
  const port = server.address().port;

  Promise.allSettled([
    fetch(`http://localhost:${port}/valid-download`, { method: 'GET' }).then((response) => {
      assert.strictEqual(response.status, 200);

      return response.arrayBuffer();
    }),
    fetch(`http://localhost:${port}/invalid-download`, { method: 'GET' }).then((response) => {
      assert.strictEqual(response.status, 500);

      return response.arrayBuffer();
    }),
    fetch(`http://localhost:${port}/valid-send-file`, { method: 'GET' }).then((response) => {
      assert.strictEqual(response.status, 200);

      return response.arrayBuffer();
    }),
    fetch(`http://localhost:${port}/invalid-send-file`, { method: 'GET' }).then((response) => {
      assert.strictEqual(response.status, 500);

      return response.arrayBuffer();
    }),
  ]).then(() => {
    server.close();
  });
});
```
