### PR TITLE
[react] Add commandFor and command attributes to ButtonHTMLAttributes

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3050,6 +3050,8 @@ declare namespace React {
     }
 
     interface ButtonHTMLAttributes<T> extends HTMLAttributes<T> {
+        commandFor?: string | undefined;
+        command?: string | undefined;
         disabled?: boolean | undefined;
         form?: string | undefined;
         formAction?:

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -3049,6 +3049,8 @@ declare namespace React {
     }
 
     interface ButtonHTMLAttributes<T> extends HTMLAttributes<T> {
+        commandFor?: string | undefined;
+        command?: string | undefined;
         disabled?: boolean | undefined;
         form?: string | undefined;
         formAction?:


### PR DESCRIPTION
﻿Adds the \commandFor\ and \command\ attributes to \ButtonHTMLAttributes\ as specified by the [Invoker Commands API](https://open-ui.org/components/invokers.explainer/) (whatwg/html#9841).

These attributes are already supported in Chrome/Edge 135+ and Safari TP.

Fixes #74664
