### PR TITLE
[plotly.js] Add missing default modebar buttons of plotly 3.7.0

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -1270,7 +1270,7 @@ export type ModeBarDefaultButtons =
     | "zoomOutGeo"
     | "resetGeo"
     | "hoverClosestGeo"
-    | "hoverClosestGl2d"
+    | "hoverClosestGl2d" // was dropped in poltly.js v3.0.0 (see https://github.com/plotly/plotly.js/commit/3a064e7d32911560d659daf4732990587774b916)
     | "hoverClosestPie"
     | "toggleHover"
     | "toImage"
@@ -1286,7 +1286,27 @@ export type ModeBarDefaultButtons =
     | "togglehover"
     | "hovercompare"
     | "hoverclosest"
-    | "v1hovermode";
+    | "v1hovermode"
+    | "sendChartToCloud"
+    | "drawclosedpath"
+    | "drawopenpath"
+    | "drawline"
+    | "drawrect"
+    | "drawcircle"
+    | "eraseshape"
+    | "resetViewSankey"
+    | "zoom"
+    | "pan"
+    | "select"
+    | "lasso"
+    | "zoomin"
+    | "zoomout"
+    | "autoscale"
+    | "resetscale"
+    | "resetCameraDefault"
+    | "resetCameraLastSave"
+    | "reset"
+    | "resetView";
 
 export type ButtonClickEvent = (gd: PlotlyHTMLElement, ev: MouseEvent) => void;
 

--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -1270,7 +1270,6 @@ export type ModeBarDefaultButtons =
     | "zoomOutGeo"
     | "resetGeo"
     | "hoverClosestGeo"
-    | "hoverClosestGl2d" // was dropped in poltly.js v3.0.0 (see https://github.com/plotly/plotly.js/commit/3a064e7d32911560d659daf4732990587774b916)
     | "hoverClosestPie"
     | "toggleHover"
     | "toImage"

--- a/types/plotly.js/test/index-tests.ts
+++ b/types/plotly.js/test/index-tests.ts
@@ -61,6 +61,8 @@ const config: Partial<Config> = {
     modeBarButtonsToAdd: [
         "togglespikelines",
         "togglehover",
+        "drawrect",
+        "zoom",
         {
             name: "customButton",
             title: "Custom Action",

--- a/types/plotly.js/v2/index.d.ts
+++ b/types/plotly.js/v2/index.d.ts
@@ -1289,7 +1289,27 @@ export type ModeBarDefaultButtons =
     | "togglehover"
     | "hovercompare"
     | "hoverclosest"
-    | "v1hovermode";
+    | "v1hovermode"
+    | "drawclosedpath"
+    | "drawopenpath"
+    | "drawline"
+    | "drawrect"
+    | "drawcircle"
+    | "eraseshape"
+    | "resetViewSankey"
+    | "zoom"
+    | "pan"
+    | "select"
+    | "lasso"
+    | "zoomin"
+    | "zoomout"
+    | "autoscale"
+    | "resetscale"
+    | "resetCameraDefault"
+    | "resetCameraLastSave"
+    | "reset"
+    | "resetView";
+
 
 export type ButtonClickEvent = (gd: PlotlyHTMLElement, ev: MouseEvent) => void;
 

--- a/types/plotly.js/v2/index.d.ts
+++ b/types/plotly.js/v2/index.d.ts
@@ -1310,7 +1310,6 @@ export type ModeBarDefaultButtons =
     | "reset"
     | "resetView";
 
-
 export type ButtonClickEvent = (gd: PlotlyHTMLElement, ev: MouseEvent) => void;
 
 export interface Icon {

--- a/types/plotly.js/v2/test/index-tests.ts
+++ b/types/plotly.js/v2/test/index-tests.ts
@@ -61,6 +61,8 @@ const config: Partial<Config> = {
     modeBarButtonsToAdd: [
         "togglespikelines",
         "togglehover",
+        "drawrect",
+        "zoom",
         {
             name: "customButton",
             title: "Custom Action",


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/plotly/plotly.js/blob/v3.7.0/src/components/modebar/buttons.js
  - https://github.com/plotly/plotly.js/pull/5660
  - https://github.com/plotly/plotly.js/commit/3a064e7d32911560d659daf4732990587774b916

