### PR TITLE
[pg] Make PoolClient extend Client

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -308,7 +308,7 @@ export class Client extends ClientBase {
     end(callback: (err: Error) => void): void;
 }
 
-export interface PoolClient extends ClientBase {
+export interface PoolClient extends Client {
     release(err?: Error | boolean): void;
 }
 

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -303,6 +303,15 @@ pool.connect().then(client => {
         );
 });
 
+pool.connect().then(client => {
+    // PoolClient must contain the complete Client API.
+    const pgClient: Client = client;
+    void pgClient;
+
+    // Pool-specific clients must also be releasable.
+    client.release();
+});
+
 pool.on("error", (err, client) => {
     // $ExpectType PoolClient
     client;


### PR DESCRIPTION
## Summary

`PoolClient` currently extends `ClientBase`, which omits members declared on `Client`.

At runtime, `PoolClient` instances returned by `pool.connect()` are regular `Client` instances with an additional `release()` method. Making `PoolClient` extend `Client` more accurately reflects the runtime API.

This also fixes missing `Client` members on `PoolClient` in TypeScript (for example `user`, `database`, `host`, `port`, etc.).

## Tests

- Added a regression test verifying that `PoolClient` is assignable to `Client`.
- Verified that the new test fails before this change and passes after it.
- Ran the dependent package tests successfully. The test run reports the existing npm version warnings for `db-migrate-pg` and `promise-pg`, which are unrelated to this change.