### PR TITLE
[@types/mithril] improve hyperscript diagnostics

### DIFF
--- a/types/mithril/index.d.ts
+++ b/types/mithril/index.d.ts
@@ -44,17 +44,17 @@ declare namespace Mithril {
 
     interface Hyperscript {
         /** Creates a virtual element (Vnode). */
+        (selector: string, attributes: Attributes, ...children: Children[]): Vnode<any, any>;
+        /** Creates a virtual element (Vnode). */
+        (selector: string, ...children: Children[]): Vnode<any, any>;
+        /** Creates a virtual element (Vnode). */
+        <Attrs, State>(component: ComponentTypes<Attrs, State>, ...args: Children[]): Vnode<Attrs, State>;
+        /** Creates a virtual element (Vnode). */
         <Attrs, State>(
             component: ComponentTypes<Attrs, State>,
             attributes: Attrs & CommonAttributes<Attrs, State>,
             ...args: Children[]
         ): Vnode<Attrs, State>;
-        /** Creates a virtual element (Vnode). */
-        (selector: string, attributes: Attributes, ...children: Children[]): Vnode<any, any>;
-        /** Creates a virtual element (Vnode). */
-        <Attrs, State>(component: ComponentTypes<Attrs, State>, ...args: Children[]): Vnode<Attrs, State>;
-        /** Creates a virtual element (Vnode). */
-        (selector: string, ...children: Children[]): Vnode<any, any>;
         /** Creates a fragment virtual element (Vnode). */
         fragment(
             attrs: CommonAttributes<any, any> & { [key: string]: any },

--- a/types/mithril/test/test-component.ts
+++ b/types/mithril/test/test-component.ts
@@ -51,6 +51,21 @@ m(comp2, { title: "", description: "" });
 // Correct use with lifecycle method
 m(comp2, { title: "", description: "", oncreate: v => `${v.attrs.title}\n${v.attrs.description}` });
 
+// Component attribute diagnostics
+interface NumberComponentAttrs {
+    min: number;
+}
+
+const numberComponent: Component<NumberComponentAttrs> = {
+    view() {
+        return null;
+    },
+};
+
+// Type 'string' is not assignable to type 'number'.
+// @ts-expect-error
+m(numberComponent, { min: "x" });
+
 // Properties missing
 // @ts-expect-error
 m(comp2, {});


### PR DESCRIPTION
Reorders Hyperscript overloads so TypeScript reports the component-attribute overload when a direct component invocation has invalid attributes.

This preserves the accepted calls while improving diagnostics such as a property type mismatch or an unknown component attribute. Existing negative component-attribute tests cover these invalid calls; this change affects diagnostic selection rather than assignability.