### PR TITLE
node: v26.2

### DIFF
--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -227,7 +227,6 @@ declare module "node:child_process" {
          * new process in a shell or with the use of the `shell` option of `ChildProcess`:
          *
          * ```js
-         * 'use strict';
          * import { spawn } from 'node:child_process';
          *
          * const subprocess = spawn(

--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -2698,12 +2698,12 @@ declare module "node:crypto" {
      */
     function sign(
         algorithm: string | null | undefined,
-        data: ArrayBufferLike | NodeJS.ArrayBufferView,
+        data: BinaryLike,
         key: KeyLike | SignKeyObjectInput | SignPrivateKeyInput | SignJsonWebKeyInput,
     ): NonSharedBuffer;
     function sign(
         algorithm: string | null | undefined,
-        data: ArrayBufferLike | NodeJS.ArrayBufferView,
+        data: BinaryLike,
         key: KeyLike | SignKeyObjectInput | SignPrivateKeyInput | SignJsonWebKeyInput,
         callback: (error: Error | null, data: NonSharedBuffer) => void,
     ): void;
@@ -2729,15 +2729,15 @@ declare module "node:crypto" {
      */
     function verify(
         algorithm: string | null | undefined,
-        data: ArrayBufferLike | NodeJS.ArrayBufferView,
+        data: BinaryLike,
         key: KeyLike | VerifyKeyObjectInput | VerifyPublicKeyInput | VerifyJsonWebKeyInput,
-        signature: ArrayBufferLike | NodeJS.ArrayBufferView,
+        signature: BinaryLike,
     ): boolean;
     function verify(
         algorithm: string | null | undefined,
-        data: ArrayBufferLike | NodeJS.ArrayBufferView,
+        data: BinaryLike,
         key: KeyLike | VerifyKeyObjectInput | VerifyPublicKeyInput | VerifyJsonWebKeyInput,
-        signature: ArrayBufferLike | NodeJS.ArrayBufferView,
+        signature: BinaryLike,
         callback: (error: Error | null, result: boolean) => void,
     ): void;
     /**

--- a/types/node/dns.d.ts
+++ b/types/node/dns.d.ts
@@ -490,7 +490,7 @@ declare module "node:dns" {
      *   regexp: '',
      *   replacement: '_sip._udp.example.com',
      *   order: 30,
-     *   preference: 100
+     *   preference: 100,
      * }
      * ```
      * @since v0.9.12
@@ -547,7 +547,7 @@ declare module "node:dns" {
      *   refresh: 10000,
      *   retry: 2400,
      *   expire: 604800,
-     *   minttl: 3600
+     *   minttl: 3600,
      * }
      * ```
      * @since v0.11.10
@@ -573,7 +573,7 @@ declare module "node:dns" {
      *   priority: 10,
      *   weight: 5,
      *   port: 21223,
-     *   name: 'service.example.com'
+     *   name: 'service.example.com',
      * }
      * ```
      * @since v0.1.27
@@ -600,7 +600,7 @@ declare module "node:dns" {
      *   certUsage: 3,
      *   selector: 1,
      *   match: 1,
-     *   data: [ArrayBuffer]
+     *   data: [ArrayBuffer],
      * }
      * ```
      * @since v23.9.0, v22.15.0
@@ -650,7 +650,7 @@ declare module "node:dns" {
      *     refresh: 900,
      *     retry: 900,
      *     expire: 1800,
-     *     minttl: 60 } ]
+     *     minttl: 60 } ];
      * ```
      *
      * DNS server operators may choose not to respond to `ANY` queries. It may be better to call individual methods like {@link resolve4}, {@link resolveMx}, and so on. For more details, see

--- a/types/node/dns/promises.d.ts
+++ b/types/node/dns/promises.d.ts
@@ -183,7 +183,7 @@ declare module "node:dns/promises" {
      *     refresh: 900,
      *     retry: 900,
      *     expire: 1800,
-     *     minttl: 60 } ]
+     *     minttl: 60 } ];
      * ```
      * @since v10.6.0
      */
@@ -226,7 +226,7 @@ declare module "node:dns/promises" {
      *   regexp: '',
      *   replacement: '_sip._udp.example.com',
      *   order: 30,
-     *   preference: 100
+     *   preference: 100,
      * }
      * ```
      * @since v10.6.0
@@ -265,7 +265,7 @@ declare module "node:dns/promises" {
      *   refresh: 10000,
      *   retry: 2400,
      *   expire: 604800,
-     *   minttl: 3600
+     *   minttl: 3600,
      * }
      * ```
      * @since v10.6.0
@@ -285,7 +285,7 @@ declare module "node:dns/promises" {
      *   priority: 10,
      *   weight: 5,
      *   port: 21223,
-     *   name: 'service.example.com'
+     *   name: 'service.example.com',
      * }
      * ```
      * @since v10.6.0
@@ -306,7 +306,7 @@ declare module "node:dns/promises" {
      *   certUsage: 3,
      *   selector: 1,
      *   match: 1,
-     *   data: [ArrayBuffer]
+     *   data: [ArrayBuffer],
      * }
      * ```
      * @since v23.9.0, v22.15.0

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -48,6 +48,13 @@ declare module "node:fs" {
         mtime: Date;
         ctime: Date;
         birthtime: Date;
+        // Deliberately not defining a type alias here... it'd be exported, and something in the ecosystem would inevitably start using it.
+        // TODO: replace with Temporal builtins once @types/node no longer supports TS <6.0.
+        atimeInstant: typeof globalThis extends { Temporal: { Instant: new(...args: any[]) => infer T } } ? T : unknown;
+        mtimeInstant: typeof globalThis extends { Temporal: { Instant: new(...args: any[]) => infer T } } ? T : unknown;
+        ctimeInstant: typeof globalThis extends { Temporal: { Instant: new(...args: any[]) => infer T } } ? T : unknown;
+        birthtimeInstant: typeof globalThis extends { Temporal: { Instant: new(...args: any[]) => infer T } } ? T
+            : unknown;
     }
     interface Stats extends StatsBase<number> {}
     /**

--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -923,6 +923,36 @@ declare module "node:http" {
         ): this;
         writeHead(statusCode: number, headers?: OutgoingHttpHeaders | OutgoingHttpHeader[]): this;
         /**
+         * Sends an arbitrary HTTP/1.1 1xx informational response to the client. This
+         * is a generic equivalent of `response.writeContinue()`,
+         * `response.writeProcessing()` and `response.writeEarlyHints()`, and
+         * can be called multiple times before the final response. After the final
+         * response headers have been sent (via `response.writeHead()` or an
+         * implicit header), calling this method throws `ERR_HTTP_HEADERS_SENT`.
+         *
+         * Clients receive these responses via the [`'information'`](https://nodejs.org/docs/latest-v26.x/api/http.html#event-information)
+         * event on `http.ClientRequest`.
+         *
+         * ```js
+         * response.writeInformation(110, { 'X-Progress': '50%' });
+         * ```
+         * @since v26.2.0
+         * @param statusCode An HTTP 1xx informational status code, between `100`
+         * and `199` inclusive, excluding `101` (Switching Protocols) which is only
+         * available through the [`'upgrade'`](https://nodejs.org/docs/latest-v26.x/api/http.html#event-upgrade) event.
+         * @param headers An optional set of headers to send with the
+         * informational response. Accepts the same shapes as
+         * `response.writeHead()`.
+         * @param callback Optional, called once the message has been written
+         * to the socket.
+         */
+        writeInformation(
+            statusCode: number,
+            headers?: OutgoingHttpHeaders | readonly string[],
+            callback?: () => void,
+        ): void;
+        writeInformation(statusCode: number, callback: () => void): void;
+        /**
          * Sends a HTTP/1.1 102 Processing message to the client, indicating that
          * the request body should be sent.
          * @since v10.0.0

--- a/types/node/http2.d.ts
+++ b/types/node/http2.d.ts
@@ -59,7 +59,7 @@ declare module "node:http2" {
         "ready": [];
         "streamClosed": [code: number];
         "timeout": [];
-        "trailers": [trailers: IncomingHttpHeaders, flags: number];
+        "trailers": [headers: IncomingHttpHeaders, flags: number, rawHeaders: string[]];
         "wantTrailers": [];
     }
     interface Http2Stream extends stream.Duplex {
@@ -245,7 +245,7 @@ declare module "node:http2" {
     interface ClientHttp2StreamEventMap extends Http2StreamEventMap {
         "continue": [];
         "headers": [headers: IncomingHttpHeaders & IncomingHttpStatusHeader, flags: number, rawHeaders: string[]];
-        "push": [headers: IncomingHttpHeaders, flags: number];
+        "push": [headers: IncomingHttpHeaders, flags: number, rawHeaders: string[]];
         "response": [headers: IncomingHttpHeaders & IncomingHttpStatusHeader, flags: number, rawHeaders: string[]];
     }
     interface ClientHttp2Stream extends Http2Stream {

--- a/types/node/http2.d.ts
+++ b/types/node/http2.d.ts
@@ -1644,8 +1644,8 @@ declare module "node:http2" {
          *
          * Then `request.url` will be:
          *
-         * ```js
-         * '/status?name=ryan'
+         * ```json
+         * "/status?name=ryan"
          * ```
          *
          * To parse the url into its parts, `new URL()` can be used:

--- a/types/node/node-tests/fs.ts
+++ b/types/node/node-tests/fs.ts
@@ -980,6 +980,14 @@ async function testStat(
     fh.stat(opts); // $ExpectType Promise<Stats | BigIntStats>
 }
 
+{
+    let stats!: fs.Stats | fs.BigIntStats;
+    stats.atimeInstant; // $ExpectType Instant || unknown
+    stats.mtimeInstant; // $ExpectType Instant || unknown
+    stats.ctimeInstant; // $ExpectType Instant || unknown
+    stats.birthtimeInstant; // $ExpectType Instant || unknown
+}
+
 const bigStats: fs.BigIntStats = fs.statSync(".", { bigint: true });
 const bigIntStat: bigint = bigStats.atimeNs;
 const anyStats: fs.Stats | fs.BigIntStats = fs.statSync(".", { bigint: Math.random() > 0.5 });

--- a/types/node/node-tests/http.ts
+++ b/types/node/node-tests/http.ts
@@ -277,6 +277,12 @@ import * as url from "node:url";
     res.writeHead(200, ["Transfer-Encoding", "chunked"]);
     res.writeHead(200);
 
+    // writeInformation
+    res.writeInformation(110);
+    res.writeInformation(110, () => {});
+    res.writeInformation(110, { "X-Progress": "50%" });
+    res.writeInformation(110, { "X-Progress": "50%" }, () => {});
+
     // writeProcessing
     res.writeProcessing();
     res.writeProcessing(() => {});

--- a/types/node/node-tests/quic.ts
+++ b/types/node/node-tests/quic.ts
@@ -1,3 +1,4 @@
+import { KeyObject } from "node:crypto";
 import { connect, listen, QuicEndpoint } from "node:quic";
 
 void async function() {
@@ -28,4 +29,102 @@ void async function() {
     // will be destroyed. The call returns a promise that is resolved once
     // the endpoint is destroyed.
     await endpoint.close();
+};
+
+void async function() {
+    const session = await connect("localhost");
+    const stream = await session.createUnidirectionalStream();
+    for await (const chunks of stream) {
+        for (const chunk of chunks) {
+            chunk; // $ExpectType Uint8Array || NonSharedUint8Array
+        }
+    }
+};
+
+void async function() {
+    const { listen } = await import("node:quic");
+
+    await listen((session) => {/* ... */}, {
+        application: {
+            maxHeaderPairs: 64,
+            qpackMaxDTableCapacity: 8192,
+            enableDatagrams: true,
+        },
+        // ... other session options
+    });
+};
+
+void async function(
+    defaultKey: KeyObject,
+    defaultCert: Buffer,
+    apiKey: KeyObject,
+    apiCert: Buffer,
+    wwwKey: KeyObject,
+    wwwCert: Buffer,
+    intKey: KeyObject,
+    intCert: Buffer,
+) {
+    const endpoint = await listen((session) => {/* ... */}, {
+        sni: {
+            "*": { keys: [defaultKey], certs: [defaultCert] },
+            "api.example.com": { keys: [apiKey], certs: [apiCert], port: 8443 },
+            "www.example.com": { keys: [wwwKey], certs: [wwwCert] },
+            "internal.example.com": { keys: [intKey], certs: [intCert], authoritative: false },
+        },
+    });
+};
+
+void async function() {
+    const session = await connect("example.com:443", {
+        // ALPN defaults to 'h3'.
+        servername: "example.com",
+    });
+    await session.opened;
+
+    const stream = await session.createBidirectionalStream({
+        headers: {
+            ":method": "GET",
+            ":path": "/",
+            ":scheme": "https",
+            ":authority": "example.com",
+        },
+        onheaders(headers) {
+            console.log("status:", headers[":status"]);
+        },
+    });
+
+    const decoder = new TextDecoder();
+    for await (const chunks of stream) {
+        for (const chunk of chunks) {
+            process.stdout.write(decoder.decode(chunk, { stream: true }));
+        }
+    }
+
+    await session.close();
+};
+
+void async function(defaultKey: KeyObject, defaultCert: Buffer) {
+    const encoder = new TextEncoder();
+
+    const endpoint = await listen((session) => {
+        // The session.onstream callback fires for each new client-initiated stream.
+    }, {
+        sni: { "*": { keys: [defaultKey], certs: [defaultCert] } },
+        // ALPN defaults to 'h3'.
+        onheaders(headers) {
+            // `this` is the QuicStream. Pseudo-headers are available on the
+            // request header block (`:method`, `:path`, `:scheme`,
+            // `:authority`).
+            if (headers[":path"] === "/health") {
+                this.sendHeaders({ ":status": "200", "content-type": "text/plain" });
+                const w = this.writer;
+                w.writeSync(encoder.encode("ok\n"));
+                w.endSync();
+            } else {
+                this.sendHeaders({ ":status": "404" }, { terminal: true });
+            }
+        },
+    });
+
+    console.log("listening on", endpoint.address);
 };

--- a/types/node/node-tests/sqlite.ts
+++ b/types/node/node-tests/sqlite.ts
@@ -97,7 +97,8 @@ import { TextEncoder } from "node:util";
 
 {
     const database = new DatabaseSync(":memory:", { allowExtension: true });
-    database.loadExtension("/path/to/extension.so");
+    database.loadExtension("./decimal.dylib");
+    database.loadExtension("./base64.dylib", "sqlite3_base64_init");
     database.enableLoadExtension(false);
 }
 

--- a/types/node/node-tests/test.ts
+++ b/types/node/node-tests/test.ts
@@ -51,6 +51,7 @@ run({
     isolation: "process",
     testNamePatterns: ["executed", /^core-/],
     testSkipPatterns: ["excluded", /^lib-/],
+    testTagFilters: ["tag1", "tag2"],
     only: true,
     setup: (reporter) => {
         // $ExpectType TestsStream
@@ -178,6 +179,8 @@ test(undefined, undefined, t => {
     t.error;
     // $ExpectType number
     t.attempt;
+    // $ExpectType readonly string[]
+    t.tags;
     // $ExpectType number | undefined
     t.workerId;
 });
@@ -527,6 +530,14 @@ suite("foo", (context) => {
     context.attempt;
 
     context.diagnostic("diagnostic");
+});
+
+suite("test tags", () => {
+    describe("database", { tags: ["db"] }, () => {
+        it("reads a row"); // tags: ['db']
+        it("writes a row", { tags: ["integration"] }); // tags: ['db', 'integration']
+        it("reconnects after disconnect", { tags: ["flaky"] }); // tags: ['db', 'flaky']
+    });
 });
 
 // Hooks

--- a/types/node/os.d.ts
+++ b/types/node/os.d.ts
@@ -122,7 +122,7 @@ declare module "node:os" {
      *       irq: 20,
      *     },
      *   },
-     * ]
+     * ];
      * ```
      *
      * `nice` values are POSIX-only. On Windows, the `nice` values of all processors
@@ -167,44 +167,44 @@ declare module "node:os" {
      *
      * The properties available on the assigned network address object include:
      *
-     * ```js
+     * ```json
      * {
-     *   lo: [
+     *   "lo": [
      *     {
-     *       address: '127.0.0.1',
-     *       netmask: '255.0.0.0',
-     *       family: 'IPv4',
-     *       mac: '00:00:00:00:00:00',
-     *       internal: true,
-     *       cidr: '127.0.0.1/8'
+     *       "address:": "127.0.0.1",
+     *       "netmask:": "255.0.0.0",
+     *       "family:": "IPv4",
+     *       "mac:": "00:00:00:00:00:00",
+     *       "internal:": true,
+     *       "cidr:": "127.0.0.1/8"
      *     },
      *     {
-     *       address: '::1',
-     *       netmask: 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
-     *       family: 'IPv6',
-     *       mac: '00:00:00:00:00:00',
-     *       scopeid: 0,
-     *       internal: true,
-     *       cidr: '::1/128'
+     *       "address:": "::1",
+     *       "netmask:": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+     *       "family:": "IPv6",
+     *       "mac:": "00:00:00:00:00:00",
+     *       "scopeid:": 0,
+     *       "internal:": true,
+     *       "cidr:": "::1/128"
      *     }
      *   ],
-     *   eth0: [
+     *   "eth0": [
      *     {
-     *       address: '192.168.1.108',
-     *       netmask: '255.255.255.0',
-     *       family: 'IPv4',
-     *       mac: '01:02:03:0a:0b:0c',
-     *       internal: false,
-     *       cidr: '192.168.1.108/24'
+     *       "address:": "192.168.1.108",
+     *       "netmask:": "255.255.255.0",
+     *       "family:": "IPv4",
+     *       "mac:": "01:02:03:0a:0b:0c",
+     *       "internal:": false,
+     *       "cidr:": "192.168.1.108/24"
      *     },
      *     {
-     *       address: 'fe80::a00:27ff:fe4e:66a1',
-     *       netmask: 'ffff:ffff:ffff:ffff::',
-     *       family: 'IPv6',
-     *       mac: '01:02:03:0a:0b:0c',
-     *       scopeid: 1,
-     *       internal: false,
-     *       cidr: 'fe80::a00:27ff:fe4e:66a1/64'
+     *       "address:": "fe80::a00:27ff:fe4e:66a1",
+     *       "netmask:": "ffff:ffff:ffff:ffff::",
+     *       "family:": "IPv6",
+     *       "mac:": "01:02:03:0a:0b:0c",
+     *       "scopeid:": 1,
+     *       "internal:": false,
+     *       "cidr:": "fe80::a00:27ff:fe4e:66a1/64"
      *     }
      *   ]
      * }

--- a/types/node/package.json
+++ b/types/node/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/node",
-    "version": "26.1.9999",
+    "version": "26.2.9999",
     "nonNpm": "conflict",
     "nonNpmDescription": "Node.js",
     "projects": [

--- a/types/node/perf_hooks.d.ts
+++ b/types/node/perf_hooks.d.ts
@@ -11,6 +11,7 @@ declare module "node:perf_hooks" {
         | "measure" // available on the Web
         | "net" // Node.js only
         | "node" // Node.js only
+        | "quic" // Node.js only
         | "resource"; // available on the Web
     interface ConnectionTimingInfo {
         domainLookupStartTime: number;
@@ -214,7 +215,7 @@ declare module "node:perf_hooks" {
          * @since v16.0.0
          */
         readonly detail: any;
-        readonly entryType: "dns" | "function" | "gc" | "http2" | "http" | "net" | "node";
+        readonly entryType: "dns" | "function" | "gc" | "http2" | "http" | "net" | "node" | "quic";
     }
     interface UVMetrics {
         /**

--- a/types/node/process.d.ts
+++ b/types/node/process.d.ts
@@ -791,14 +791,14 @@ declare module "node:process" {
                  *
                  * Results in `process.execArgv`:
                  *
-                 * ```js
+                 * ```json
                  * ["--icu-data-dir=./foo", "--require", "./bar.js"]
                  * ```
                  *
                  * And `process.argv`:
                  *
-                 * ```js
-                 * ['/usr/local/bin/node', 'script.js', '--version']
+                 * ```json
+                 * ["/usr/local/bin/node", "script.js", "--version"]
                  * ```
                  *
                  * Refer to `Worker constructor` for the detailed behavior of worker
@@ -810,8 +810,8 @@ declare module "node:process" {
                  * The `process.execPath` property returns the absolute pathname of the executable
                  * that started the Node.js process. Symbolic links, if any, are resolved.
                  *
-                 * ```js
-                 * '/usr/local/bin/node'
+                 * ```json
+                 * "/usr/local/bin/node"
                  * ```
                  * @since v0.1.100
                  */
@@ -994,18 +994,18 @@ declare module "node:process" {
                  *
                  * An example of this object looks like:
                  *
-                 * ```js
+                 * ```json
                  * {
-                 *   TERM: 'xterm-256color',
-                 *   SHELL: '/usr/local/bin/bash',
-                 *   USER: 'maciej',
-                 *   PATH: '~/.bin/:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin',
-                 *   PWD: '/Users/maciej',
-                 *   EDITOR: 'vim',
-                 *   SHLVL: '1',
-                 *   HOME: '/Users/maciej',
-                 *   LOGNAME: 'maciej',
-                 *   _: '/usr/local/bin/node'
+                 *   "TERM": "xterm-256color",
+                 *   "SHELL": "/usr/local/bin/bash",
+                 *   "USER": "maciej",
+                 *   "PATH": "~/.bin/:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin",
+                 *   "PWD": "/Users/maciej",
+                 *   "EDITOR": "vim",
+                 *   "SHLVL": "1",
+                 *   "HOME": "/Users/maciej",
+                 *   "LOGNAME": "maciej",
+                 *   "_": "/usr/local/bin/node"
                  * }
                  * ```
                  *
@@ -1540,29 +1540,28 @@ declare module "node:process" {
                  *
                  * An example of the possible output looks like:
                  *
-                 * ```js
+                 * ```json
                  * {
-                 *   target_defaults:
-                 *    { cflags: [],
-                 *      default_configuration: 'Release',
-                 *      defines: [],
-                 *      include_dirs: [],
-                 *      libraries: [] },
-                 *   variables:
+                 *   "target_defaults":
+                 *    { "cflags": [],
+                 *      "default_configuration": "Release",
+                 *      "defines": [],
+                 *      "include_dirs": [],
+                 *      "libraries": [] },
+                 *   "variables":
                  *    {
-                 *      host_arch: 'x64',
-                 *      napi_build_version: 5,
-                 *      node_install_npm: 'true',
-                 *      node_prefix: '',
-                 *      node_shared_cares: 'false',
-                 *      node_shared_http_parser: 'false',
-                 *      node_shared_libuv: 'false',
-                 *      node_shared_zlib: 'false',
-                 *      node_use_openssl: 'true',
-                 *      node_shared_openssl: 'false',
-                 *      strict_aliasing: 'true',
-                 *      target_arch: 'x64',
-                 *      v8_use_snapshot: 1
+                 *      "host_arch": "x64",
+                 *      "napi_build_version": 5,
+                 *      "node_install_npm": "true",
+                 *      "node_prefix": "",
+                 *      "node_shared_cares": "false",
+                 *      "node_shared_http_parser": "false",
+                 *      "node_shared_libuv": "false",
+                 *      "node_shared_zlib": "false",
+                 *      "node_use_openssl": "true",
+                 *      "node_shared_openssl": "false",
+                 *      "target_arch": "x64",
+                 *      "v8_use_snapshot": 1
                  *    }
                  * }
                  * ```
@@ -1876,13 +1875,13 @@ declare module "node:process" {
                  *
                  * `process.release` contains the following properties:
                  *
-                 * ```js
+                 * ```json
                  * {
-                 *   name: 'node',
-                 *   lts: 'Hydrogen',
-                 *   sourceUrl: 'https://nodejs.org/download/release/v18.12.0/node-v18.12.0.tar.gz',
-                 *   headersUrl: 'https://nodejs.org/download/release/v18.12.0/node-v18.12.0-headers.tar.gz',
-                 *   libUrl: 'https://nodejs.org/download/release/v18.12.0/win-x64/node.lib'
+                 *   "name": "node",
+                 *   "lts": "Hydrogen",
+                 *   "sourceUrl": "https://nodejs.org/download/release/v18.12.0/node-v18.12.0.tar.gz",
+                 *   "headersUrl": "https://nodejs.org/download/release/v18.12.0/node-v18.12.0-headers.tar.gz",
+                 *   "libUrl": "https://nodejs.org/download/release/v18.12.0/win-x64/node.lib"
                  * }
                  * ```
                  *

--- a/types/node/quic.d.ts
+++ b/types/node/quic.d.ts
@@ -53,17 +53,7 @@ declare module "node:quic" {
     /**
      * @since v23.8.0
      */
-    type OnHandshakeCallback = (
-        this: QuicSession,
-        sni: string,
-        alpn: string,
-        cipher: string,
-        cipherVersion: string,
-        validationErrorReason: string,
-        validationErrorCode: number,
-        earlyDataAttempted: boolean,
-        earlyDataAccepted: boolean,
-    ) => void;
+    type OnHandshakeCallback = (this: QuicSession, info: SessionHandshakeInfo) => void;
     /**
      * @since v26.2.0
      */
@@ -311,7 +301,7 @@ declare module "node:quic" {
          */
         enableEarlyData?: boolean | undefined;
         /**
-         * The list of support TLS 1.3 cipher groups.
+         * The list of supported TLS 1.3 cipher groups.
          * @since v23.8.0
          */
         groups?: string | undefined;
@@ -582,7 +572,7 @@ declare module "node:quic" {
         /**
          * The endpoint maintains an internal cache of validated socket addresses as a
          * performance optimization. This option sets the maximum number of addresses
-         * that are cache. This is an advanced option that users typically won't have
+         * that are cached. This is an advanced option that users typically won't have
          * need to specify.
          * @since v23.8.0
          */
@@ -750,7 +740,7 @@ declare module "node:quic" {
         readonly destroyed: boolean;
         /**
          * True if the endpoint is actively listening for incoming connections. Read only.
-         * @since v26.1.0
+         * @since v26.2.0
          */
         readonly listening: boolean;
         /**
@@ -791,7 +781,7 @@ declare module "node:quic" {
          */
         setSNIContexts(entries: Record<string, SNIEntry>, options?: SetSNIContextsOptions): void;
         /**
-         * The statistics collected for an active session. Read only.
+         * The statistics collected for an active endpoint. Read only.
          * @since v23.8.0
          */
         readonly stats: QuicEndpoint.Stats;
@@ -861,7 +851,7 @@ declare module "node:quic" {
              */
             readonly retryCount: bigint;
             /**
-             * The total number sessions rejected due to QUIC version mismatch. Read only.
+             * The total number of sessions rejected due to QUIC version mismatch. Read only.
              * @since v23.8.0
              */
             readonly versionNegotiationCount: bigint;
@@ -877,7 +867,7 @@ declare module "node:quic" {
             readonly immediateCloseCount: bigint;
         }
     }
-    interface CreateUnidirectionalStreamOptions {
+    interface CreateStreamOptions {
         /**
          * The outbound body source. See `stream.setBody()` for details on
          * supported types. When omitted, the stream starts half-closed (writable
@@ -904,6 +894,13 @@ declare module "node:quic" {
          */
         incremental?: boolean | undefined;
         /**
+         * The maximum number of bytes that the writer
+         * will buffer before `writeSync()` returns `false`. When the buffered
+         * data exceeds this limit, the caller should wait for drain before
+         * writing more. **Default:** `65536` (64 KB).
+         */
+        highWaterMark?: number | undefined;
+        /**
          * Callback for received initial response headers.
          * Called with `(headers)`.
          */
@@ -923,19 +920,10 @@ declare module "node:quic" {
          */
         onwanttrailers?: QuicStream["onwanttrailers"] | undefined;
     }
-    interface CreateBidirectionalStreamOptions extends CreateUnidirectionalStreamOptions {
-        /**
-         * The maximum number of bytes that the writer
-         * will buffer before `writeSync()` returns `false`. When the buffered
-         * data exceeds this limit, the caller should wait for drain before
-         * writing more. **Default:** `65536` (64 KB).
-         */
-        highWaterMark?: number | undefined;
-    }
     interface SessionDestroyOptions {
         /**
          * The error code to include in the `CONNECTION_CLOSE`
-         * frame sent to the peer. Defaults to `0` (no error). **Default:** `0`.
+         * frame sent to the peer. **Default:** `0` (no error).
          */
         code?: bigint | number | undefined;
         /**
@@ -1036,6 +1024,12 @@ declare module "node:quic" {
          */
         readonly closed: Promise<void>;
         /**
+         * True if `session.close()` has been called and the session has not yet
+         * been destroyed. Read only.
+         * @since v26.2.0
+         */
+        readonly closing: boolean;
+        /**
          * Immediately destroy the session. All streams will be destroyed and the
          * session will be closed. If `error` is provided and [`session.onerror`][] is
          * set, the `onerror` callback is invoked before destruction. The
@@ -1051,10 +1045,11 @@ declare module "node:quic" {
          */
         readonly destroyed: boolean;
         /**
-         * The endpoint that created this session. Read only.
+         * The endpoint that created this session. Returns `null` if the session
+         * has been destroyed. Read only.
          * @since v23.8.0
          */
-        readonly endpoint: QuicEndpoint;
+        readonly endpoint: QuicEndpoint | null;
         /**
          * An optional callback invoked when the session is destroyed with an error.
          * This includes errors caused by user callbacks that throw or reject (see
@@ -1065,6 +1060,7 @@ declare module "node:quic" {
          *
          * Can also be set via the `onerror` option in `quic.connect()` or
          * `quic.listen()`.
+         * @since v26.2.0
          */
         onerror: ((this: QuicSession, error: any) => void) | undefined;
         /**
@@ -1184,14 +1180,14 @@ declare module "node:quic" {
          * options are only used when the session supports headers (e.g. HTTP/3).
          * @since v23.8.0
          */
-        createBidirectionalStream(options?: CreateBidirectionalStreamOptions): Promise<QuicStream>;
+        createBidirectionalStream(options?: CreateStreamOptions): Promise<QuicStream>;
         /**
          * Open a new unidirectional stream. If the `body` option is not specified,
          * the outgoing stream will be closed. The `priority` and `incremental`
          * options are only used when the session supports priority (e.g. HTTP/3).
          * @since v23.8.0
          */
-        createUnidirectionalStream(options?: CreateUnidirectionalStreamOptions): Promise<QuicStream>;
+        createUnidirectionalStream(options?: CreateStreamOptions): Promise<QuicStream>;
         /**
          * The local and remote socket addresses associated with the session. Read only.
          * @since v23.8.0
@@ -1592,15 +1588,15 @@ declare module "node:quic" {
          */
         readonly early: boolean;
         /**
-         * The directionality of the stream. Read only.
+         * The directionality of the stream, or `null` if the stream has been destroyed
+         * or is still pending. Read only.
          * @since v23.8.0
          */
-        readonly direction: "bidi" | "uni";
+        readonly direction: "bidi" | "uni" | null;
         /**
          * The maximum number of bytes that the writer will buffer before
          * `writeSync()` returns `false`. When the buffered data exceeds this limit,
-         * the caller should wait for the `drainableProtocol` promise to resolve
-         * before writing more.
+         * the caller should wait for drain before writing more.
          *
          * The value can be changed dynamically at any time. This is particularly
          * useful for streams received via the `onstream` callback, where the
@@ -1610,10 +1606,11 @@ declare module "node:quic" {
          */
         highWaterMark: number;
         /**
-         * The stream ID. Read only.
+         * The stream ID, or `null` if the stream has been destroyed or is still
+         * pending. Read only.
          * @since v23.8.0
          */
-        readonly id: bigint;
+        readonly id: bigint | null;
         /**
          * An optional callback invoked when the stream is destroyed with an error.
          * This includes errors caused by user callbacks that throw or reject (see
@@ -1847,10 +1844,11 @@ declare module "node:quic" {
          */
         setBody(body: StreamBody): void;
         /**
-         * The session that created this stream. Read only.
+         * The session that created this stream, or `null` if the stream has been
+         * destroyed. Read only.
          * @since v23.8.0
          */
-        readonly session: QuicSession;
+        readonly session: QuicSession | null;
         /**
          * The current statistics for the stream. Read only.
          * @since v23.8.0
@@ -1913,13 +1911,33 @@ declare module "node:quic" {
             readonly receivedAt: bigint;
         }
     }
+    /**
+     * An object containing commonly used constants for QUIC configuration.
+     * @since v26.2.0
+     */
     namespace constants {
+        /**
+         * Congestion control algorithm identifiers, for use with the
+         * `sessionOptions.cc` option:
+         *
+         * * `quic.constants.cc.RENO` — Reno congestion control.
+         * * `quic.constants.cc.CUBIC` — CUBIC congestion control.
+         * * `quic.constants.cc.BBR` — BBR congestion control.
+         */
         enum cc {
             RENO = "reno",
             CUBIC = "cubic",
             BBR = "bbr",
         }
+        /**
+         * The default TLS 1.3 cipher suite list used when `sessionOptions.ciphers`
+         * is not specified.
+         */
         const DEFAULT_CIPHERS: string;
+        /**
+         * The default TLS 1.3 key-exchange group list used when
+         * `sessionOptions.groups` is not specified.
+         */
         const DEFAULT_GROUPS: string;
     }
 }

--- a/types/node/quic.d.ts
+++ b/types/node/quic.d.ts
@@ -1,7 +1,10 @@
 declare module "node:quic" {
-    import { KeyObject, webcrypto } from "node:crypto";
+    import { NonSharedBuffer } from "node:buffer";
+    import { KeyObject } from "node:crypto";
+    import { FileHandle } from "node:fs/promises";
     import { SocketAddress } from "node:net";
-    import { ReadableStream } from "node:stream/web";
+    import { Writer } from "node:stream/iter";
+    import { EphemeralKeyInfo, PeerCertificate } from "node:tls";
     /**
      * @since v23.8.0
      */
@@ -13,11 +16,15 @@ declare module "node:quic" {
     /**
      * @since v23.8.0
      */
-    type OnDatagramCallback = (this: QuicSession, datagram: Uint8Array, early: boolean) => void;
+    type OnDatagramCallback = (this: QuicSession, datagram: NodeJS.NonSharedUint8Array, early: boolean) => void;
     /**
      * @since v23.8.0
      */
-    type OnDatagramStatusCallback = (this: QuicSession, id: bigint, status: "lost" | "acknowledged") => void;
+    type OnDatagramStatusCallback = (
+        this: QuicSession,
+        id: bigint,
+        status: "acknowledged" | "lost" | "abandoned",
+    ) => void;
     /**
      * @since v23.8.0
      */
@@ -26,8 +33,8 @@ declare module "node:quic" {
         result: "success" | "failure" | "aborted",
         newLocalAddress: SocketAddress,
         newRemoteAddress: SocketAddress,
-        oldLocalAddress: SocketAddress,
-        oldRemoteAddress: SocketAddress,
+        oldLocalAddress: SocketAddress | null,
+        oldRemoteAddress: SocketAddress | null,
         preferredAddress: boolean,
     ) => void;
     /**
@@ -54,8 +61,34 @@ declare module "node:quic" {
         cipherVersion: string,
         validationErrorReason: string,
         validationErrorCode: number,
+        earlyDataAttempted: boolean,
         earlyDataAccepted: boolean,
     ) => void;
+    /**
+     * @since v26.2.0
+     */
+    type OnNewTokenCallback = (this: QuicSession, token: NonSharedBuffer, address: SocketAddress) => void;
+    /**
+     * @since v26.2.0
+     */
+    type OnOriginCallback = (this: QuicSession, origins: string[]) => void;
+    /**
+     * Called when TLS key material is available. Only fires when
+     * `sessionOptions.keylog` is `true`. Multiple lines are emitted during the
+     * TLS 1.3 handshake, each containing a secret label, the client random, and
+     * the secret value.
+     * @since v26.2.0
+     */
+    type OnKeylogCallback = (this: QuicSession, line: string) => void;
+    /**
+     * Called when qlog diagnostic data is available. Only fires when
+     * `sessionOptions.qlog` is `true`. The `data` chunks should be
+     * concatenated in order to produce the complete qlog output. When `fin` is
+     * `true`, no more chunks will be emitted and the concatenated result is a
+     * complete JSON-SEQ document.
+     * @since v26.2.0
+     */
+    type OnQlogCallback = (this: QuicSession, data: string, fin: boolean) => void;
     /**
      * @since v23.8.0
      */
@@ -65,16 +98,34 @@ declare module "node:quic" {
      */
     type OnStreamErrorCallback = (this: QuicStream, error: any) => void;
     /**
+     * Called when initial request or response headers are received. For HTTP/3,
+     * this delivers request pseudo-headers on the server and response headers
+     * on the client.
+     * @since v26.2.0
+     */
+    type OnHeadersCallback = (this: QuicStream, headers: NodeJS.Dict<string | string[]>) => void;
+    /**
+     * Called when trailing headers are received from the peer.
+     * @since v26.2.0
+     */
+    type OnTrailersCallback = (this: QuicStream, trailers: NodeJS.Dict<string | string[]>) => void;
+    /**
+     * Called when informational (1xx) headers are received from the server
+     * (e.g., 103 Early Hints).
+     * @since v26.2.0
+     */
+    type OnInfoCallback = (this: QuicStream, headers: NodeJS.Dict<string | string[]>) => void;
+    /**
      * @since v23.8.0
      */
     interface TransportParams {
         /**
-         * The preferred IPv4 address to advertise.
+         * The preferred IPv4 address to advertise (only used by servers).
          * @since v23.8.0
          */
         preferredAddressIpv4?: SocketAddress | undefined;
         /**
-         * The preferred IPv6 address to advertise.
+         * The preferred IPv6 address to advertise (only used by servers)
          * @since v23.8.0
          */
         preferredAddressIpv6?: SocketAddress | undefined;
@@ -119,16 +170,74 @@ declare module "node:quic" {
          */
         maxAckDelay?: bigint | number | undefined;
         /**
+         * The maximum size in bytes of a DATAGRAM frame payload that this endpoint
+         * is willing to receive. Set to `0` to disable datagram support. The peer
+         * will not send datagrams larger than this value. The actual maximum size of
+         * a datagram that can be _sent_ is determined by the peer's
+         * `maxDatagramFrameSize`, not this endpoint's value.
          * @since v23.8.0
          */
         maxDatagramFrameSize?: bigint | number | undefined;
     }
     interface SNIEntry {
+        /**
+         * The TLS private keys. **Required.**
+         */
         keys: KeyObject | readonly KeyObject[];
+        /**
+         * The TLS certificates. **Required.**
+         */
         certs: ArrayBuffer | NodeJS.ArrayBufferView | ReadonlyArray<ArrayBuffer | NodeJS.ArrayBufferView>;
-        ca?: ArrayBuffer | NodeJS.ArrayBufferView | ReadonlyArray<ArrayBuffer | NodeJS.ArrayBufferView> | undefined;
-        crl?: ArrayBuffer | NodeJS.ArrayBufferView | ReadonlyArray<ArrayBuffer | NodeJS.ArrayBufferView> | undefined;
+        /**
+         * Verify the private key. Default: `false`.
+         */
         verifyPrivateKey?: boolean | undefined;
+        /**
+         * The port to advertise in ORIGIN frames (RFC 9412) for this host name. **Default:** `443`. Only used for HTTP/3 sessions.
+         */
+        port?: number | undefined;
+        /**
+         * Whether to include this host name in ORIGIN frames. **Default:** `true`. Set to `false` to exclude a host name
+         * from ORIGIN advertisements. Wildcard (`'*'`) entries are always excluded regardless of this setting.
+         */
+        authoritative?: boolean | undefined;
+    }
+    interface ApplicationOptions {
+        /**
+         * Maximum number of header name-value pairs accepted per header block. Headers beyond this limit are silently
+         * dropped. **Default:** `128`
+         */
+        maxHeaderPairs?: number | undefined;
+        /**
+         * Maximum total byte length of all header names and values combined per header block. Headers that would push
+         * the total over this limit are silently dropped. **Default:** `8192`
+         */
+        maxHeaderLength?: number | undefined;
+        /**
+         * Maximum size of a compressed header field section (QPACK). `0` means unlimited. **Default:** `0`
+         */
+        maxFieldSectionSize?: number | undefined;
+        /**
+         * QPACK dynamic table capacity in bytes. Set to `0` to disable the dynamic table. **Default:** `4096`
+         */
+        qpackMaxDTableCapacity?: number | undefined;
+        /**
+         * QPACK encoder maximum dynamic table capacity. **Default:** `4096`
+         */
+        qpackEncoderMaxDTableCapacity?: number | undefined;
+        /**
+         * Maximum number of streams that can be blocked waiting for QPACK dynamic table updates.
+         * **Default:** `100`
+         */
+        qpackBlockedStreams?: number | undefined;
+        /**
+         * Enable the extended CONNECT protocol (RFC 9220). **Default:** `false`
+         */
+        enableConnectProtocol?: boolean | undefined;
+        /**
+         * Enable HTTP/3 datagrams (RFC 9297). **Default:** `false`
+         */
+        enableDatagrams?: boolean | undefined;
     }
     /**
      * @since v23.8.0
@@ -156,6 +265,12 @@ declare module "node:quic" {
          * @since v26.1.0
          */
         alpn?: string | readonly string[] | undefined;
+        /**
+         * HTTP/3 application-specific options. These only apply when the negotiated
+         * ALPN selects the HTTP/3 application (`'h3'`).
+         * @since v26.2.0
+         */
+        application?: ApplicationOptions | undefined;
         /**
          * The CA certificates to use for client sessions. For server sessions, CA
          * certificates are specified per-identity in the `sessionOptions.sni` map.
@@ -188,12 +303,23 @@ declare module "node:quic" {
          */
         crl?: ArrayBuffer | NodeJS.ArrayBufferView | ReadonlyArray<ArrayBuffer | NodeJS.ArrayBufferView> | undefined;
         /**
+         * When `true`, enables TLS 0-RTT early data for this session. Early data
+         * allows the client to send application data before the TLS handshake
+         * completes, reducing latency on reconnection when a valid session ticket
+         * is available. Set to `false` to disable early data support.
+         * @since v26.2.0
+         */
+        enableEarlyData?: boolean | undefined;
+        /**
          * The list of support TLS 1.3 cipher groups.
          * @since v23.8.0
          */
         groups?: string | undefined;
         /**
-         * True to enable TLS keylogging output.
+         * When `true`, enables TLS key logging for the session. Key material is
+         * delivered to the `session.onkeylog` callback in [NSS Key Log Format](https://udn.realityripple.com/docs/Mozilla/Projects/NSS/Key_Log_Format).
+         * Each callback invocation receives a single line of key material. The output
+         * can be used with tools such as Wireshark to decrypt captured QUIC traffic.
          * @since v23.8.0
          */
         keylog?: boolean | undefined;
@@ -231,7 +357,10 @@ declare module "node:quic" {
          */
         preferredAddressPolicy?: "use" | "ignore" | "default" | undefined;
         /**
-         * True if qlog output should be enabled.
+         * When `true`, enables [qlog](https://datatracker.ietf.org/doc/draft-ietf-quic-qlog-main-schema/) diagnostic output for the session. Qlog data
+         * is delivered to the `session.onqlog` callback as chunks of [JSON-SEQ](https://www.rfc-editor.org/rfc/rfc7464)
+         * formatted text. The output can be analyzed with qlog visualization tools
+         * such as [qvis](https://qvis.quictools.info/).
          * @since v23.8.0
          */
         qlog?: boolean | undefined;
@@ -241,8 +370,40 @@ declare module "node:quic" {
          */
         sessionTicket?: NodeJS.ArrayBufferView | undefined;
         /**
-         * Specifies the maximum number of milliseconds a TLS handshake is permitted to take
-         * to complete before timing out.
+         * Controls which datagram to drop when the pending datagram queue
+         * (sized by `session.maxPendingDatagrams`) is full. Must be one of
+         * `'drop-oldest'` (discard the oldest queued datagram to make room) or
+         * `'drop-newest'` (reject the incoming datagram). Dropped datagrams are
+         * reported as lost via the `ondatagramstatus` callback.
+         *
+         * This option is immutable after session creation.
+         * @since v26.2.0
+         */
+        datagramDropPolicy?: "drop-oldest" | "drop-newest" | undefined;
+        /**
+         * The maximum number of `SendPendingData` cycles a datagram can survive
+         * without being sent before it is abandoned. When a datagram cannot be
+         * sent due to congestion control or packet size constraints, it remains
+         * in the queue and the attempt counter increments. Once the limit is
+         * reached, the datagram is dropped and reported as `'abandoned'` via the
+         * `ondatagramstatus` callback. Valid range: `1` to `255`.
+         * @since v26.2.0
+         */
+        maxDatagramSendAttempts?: number | undefined;
+        /**
+         * A multiplier applied to the Probe Timeout (PTO) to compute the draining
+         * period duration after receiving a `CONNECTION_CLOSE` frame from the peer.
+         * RFC 9000 Section 10.2 requires the draining period to persist for at least
+         * three times the current PTO. The valid range is `3` to `255`. Values below
+         * `3` are clamped to `3`.
+         * @since v26.2.0
+         */
+        drainingPeriodMultiplier?: number | undefined;
+        /**
+         * Specifies the keep-alive timeout in milliseconds. When set to a non-zero
+         * value, PING frames will be sent automatically to keep the connection alive
+         * before the idle timeout fires. The value should be less than the effective
+         * idle timeout (`maxIdleTimeout` transport parameter) to be useful.
          * @since v23.8.0
          */
         handshakeTimeout?: bigint | number | undefined;
@@ -253,28 +414,12 @@ declare module "node:quic" {
         servername?: string | undefined;
         /**
          * An object mapping host names to TLS identity options for Server Name
-         * Indication (SNI) support. This is required for server sessions. The
-         * special key `'*'` specifies the default/fallback identity used when
-         * no other host name matches. Each entry may contain:
-         *
-         * ```js
-         * const endpoint = await listen(callback, {
-         *   sni: {
-         *     '*': { keys: [defaultKey], certs: [defaultCert] },
-         *     'api.example.com': { keys: [apiKey], certs: [apiCert] },
-         *     'www.example.com': { keys: [wwwKey], certs: [wwwCert], ca: [customCA] },
-         *   },
-         * });
-         * ```
-         *
-         * Shared TLS options (such as `ciphers`, `groups`, `keylog`, and `verifyClient`)
-         * are specified at the top level of the session options and apply to all
-         * identities. Each SNI entry overrides only the per-identity certificate
-         * fields.
-         *
-         * The SNI map can be replaced at runtime using `endpoint.setSNIContexts()`,
-         * which atomically swaps the map for new sessions while existing sessions
-         * continue to use their original identity.
+         * Indication (SNI) support. This is required for server sessions and must
+         * contain at least one entry. The special key `'*'` specifies the optional
+         * default/fallback identity used when no other host name matches. If no
+         * wildcard entry is provided, connections with unrecognized server names
+         * will be rejected with a TLS `unrecognized_name` alert. Each entry may
+         * contain:
          * @since v26.1.0
          */
         sni?: Record<string, SNIEntry> | undefined;
@@ -283,6 +428,14 @@ declare module "node:quic" {
          * @since v23.8.0
          */
         tlsTrace?: boolean | undefined;
+        /**
+         * An opaque address validation token previously received from the server
+         * via the `session.onnewtoken` callback. Providing a valid token on
+         * reconnection allows the client to skip the server's address validation,
+         * reducing handshake latency.
+         * @since v26.2.0
+         */
+        token?: NodeJS.ArrayBufferView | undefined;
         /**
          * The QUIC transport parameters to use for the session.
          * @since v23.8.0
@@ -293,6 +446,27 @@ declare module "node:quic" {
          * @since v23.8.0
          */
         unacknowledgedPacketThreshold?: bigint | number | undefined;
+        /**
+         * If `true`, the peer certificate is verified against the list of supplied CAs.
+         * An error is emitted if verification fails; the error can be inspected via
+         * the `validationErrorReason` and `validationErrorCode` fields in the
+         * handshake callback. If `false`, peer certificate verification errors are
+         * ignored.
+         */
+        rejectUnauthorized?: boolean | undefined;
+        /**
+         * When `true` (the default), `connect()` will attempt to reuse an existing
+         * endpoint rather than creating a new one for each session. This provides
+         * connection pooling behavior — multiple sessions can share a single UDP
+         * socket. The reuse logic will not return an endpoint that is listening on
+         * the same address as the connect target (to prevent CID routing conflicts).
+         *
+         * Set to `false` to force creation of a new endpoint for the session. This
+         * is useful when endpoint isolation is required (e.g., testing stateless
+         * reset behavior where source port identity matters).
+         * @since v26.2.0
+         */
+        reuseEndpoint?: boolean | undefined;
         /**
          * True to require verification of TLS client certificate.
          * @since v23.8.0
@@ -311,6 +485,25 @@ declare module "node:quic" {
          * @since v23.8.0
          */
         version?: number | undefined;
+        // Undocumented
+        onerror?: QuicSession["onerror"] | undefined;
+        onstream?: QuicSession["onstream"] | undefined;
+        ondatagram?: QuicSession["ondatagram"] | undefined;
+        ondatagramstatus?: QuicSession["ondatagramstatus"] | undefined;
+        onpathvalidation?: QuicSession["onpathvalidation"] | undefined;
+        onsessionticket?: QuicSession["onsessionticket"] | undefined;
+        onversionnegotiation?: QuicSession["onversionnegotiation"] | undefined;
+        onhandshake?: QuicSession["onhandshake"] | undefined;
+        onnewtoken?: QuicSession["onnewtoken"] | undefined;
+        onearlyrejected?: QuicSession["onearlyrejected"] | undefined;
+        onorigin?: QuicSession["onorigin"] | undefined;
+        ongoaway?: QuicSession["ongoaway"] | undefined;
+        onkeylog?: QuicSession["onkeylog"] | undefined;
+        onqlog?: QuicSession["onqlog"] | undefined;
+        onheaders?: QuicStream["onheaders"] | undefined;
+        ontrailers?: QuicStream["ontrailers"] | undefined;
+        oninfo?: QuicStream["oninfo"] | undefined;
+        onwanttrailers?: QuicStream["onwanttrailers"] | undefined;
     }
     /**
      * Initiate a new client-side session.
@@ -395,20 +588,52 @@ declare module "node:quic" {
          */
         addressLRUSize?: bigint | number | undefined;
         /**
+         * When `true`, the endpoint will not send stateless reset packets in response
+         * to packets from unknown connections. Stateless resets allow a peer to detect
+         * that a connection has been lost even when the server has no state for it.
+         * Disabling them may be useful in testing or when stateless resets are handled
+         * at a different layer.
+         * @since v26.2.0
+         */
+        disableStatelessReset?: boolean | undefined;
+        /**
+         * The number of seconds an endpoint will remain alive after all sessions have
+         * closed and it is no longer listening. A value of `0` (default) means the
+         * endpoint is only destroyed when explicitly closed via `endpoint.close()` or
+         * `endpoint.destroy()`. A positive value starts an idle timer when the endpoint
+         * becomes idle; if no new sessions are created before the timer fires, the
+         * endpoint is automatically destroyed. This is useful for connection pooling
+         * where endpoints should linger briefly for reuse by future `connect()` calls.
+         * @since v26.2.0
+         */
+        idleTimeout?: number | undefined;
+        /**
          * When `true`, indicates that the endpoint should bind only to IPv6 addresses.
          * @since v23.8.0
          */
         ipv6Only?: boolean | undefined;
         /**
-         * Specifies the maximum number of concurrent sessions allowed per remote peer address.
+         * Specifies the maximum number of concurrent sessions allowed per remote IP
+         * address (ignoring port). When the limit is reached, new connections from the
+         * same IP are refused with `CONNECTION_REFUSED`. A value of `0` disables the
+         * limit. The maximum value is `65535`.
+         *
+         * This limit can also be changed dynamically after construction via
+         * `endpoint.maxConnectionsPerHost`.
          * @since v23.8.0
          */
-        maxConnectionsPerHost?: bigint | number | undefined;
+        maxConnectionsPerHost?: number | undefined;
         /**
-         * Specifies the maximum total number of concurrent sessions.
+         * Specifies the maximum total number of concurrent sessions across all remote
+         * addresses. When the limit is reached, new connections are refused with
+         * `CONNECTION_REFUSED`. A value of `0` disables the limit. The maximum value is
+         * `65535`.
+         *
+         * This limit can also be changed dynamically after construction via
+         * `endpoint.maxConnectionsTotal`.
          * @since v23.8.0
          */
-        maxConnectionsTotal?: bigint | number | undefined;
+        maxConnectionsTotal?: number | undefined;
         /**
          * Specifies the maximum number of QUIC retry attempts allowed per remote peer address.
          * @since v23.8.0
@@ -529,6 +754,22 @@ declare module "node:quic" {
          */
         readonly listening: boolean;
         /**
+         * The maximum number of concurrent connections allowed per remote IP address.
+         * `0` means unlimited (default). Can be set at construction time via the
+         * `maxConnectionsPerHost` option and changed dynamically at any time.
+         * The valid range is `0` to `65535`.
+         * @since v26.2.0
+         */
+        maxConnectionsPerHost: number;
+        /**
+         * The maximum total number of concurrent connections across all remote
+         * addresses. `0` means unlimited (default). Can be set at construction time via
+         * the `maxConnectionsTotal` option and changed dynamically at any time.
+         * The valid range is `0` to `65535`.
+         * @since v26.2.0
+         */
+        maxConnectionsTotal: number;
+        /**
          * Replaces or updates the SNI TLS contexts for this endpoint. This allows
          * changing the TLS identity (key/certificate) used for specific host names
          * without restarting the endpoint. Existing sessions are unaffected — only
@@ -636,9 +877,127 @@ declare module "node:quic" {
             readonly immediateCloseCount: bigint;
         }
     }
-    interface CreateStreamOptions {
-        body?: ArrayBuffer | NodeJS.ArrayBufferView | Blob | undefined;
-        sendOrder?: number | undefined;
+    interface CreateUnidirectionalStreamOptions {
+        /**
+         * The outbound body source. See `stream.setBody()` for details on
+         * supported types. When omitted, the stream starts half-closed (writable
+         * side open, no body queued).
+         */
+        body?: StreamBody | undefined;
+        /**
+         * Initial request or response headers to send. Only
+         * used when the session supports headers (e.g. HTTP/3). If `body` is not
+         * specified and `headers` is provided, the stream is treated as
+         * headers-only (terminal).
+         */
+        headers?: NodeJS.Dict<string | readonly string[]> | readonly string[] | undefined;
+        /**
+         * The priority level of the stream. One of `'high'`,
+         * `'default'`, or `'low'`. **Default:** `'default'`.
+         */
+        priority?: "high" | "default" | "low" | undefined;
+        /**
+         * When `true`, data from this stream may be
+         * interleaved with data from other streams of the same priority level.
+         * When `false`, the stream should be completed before same-priority peers.
+         * **Default:** `false`.
+         */
+        incremental?: boolean | undefined;
+        /**
+         * Callback for received initial response headers.
+         * Called with `(headers)`.
+         */
+        onheaders?: QuicStream["onheaders"] | undefined;
+        /**
+         * Callback for received trailing headers.
+         * Called with `(trailers)`.
+         */
+        ontrailers?: QuicStream["ontrailers"] | undefined;
+        /**
+         * Callback for received informational (1xx) headers.
+         * Called with `(headers)`.
+         */
+        oninfo?: QuicStream["oninfo"] | undefined;
+        /**
+         * Callback when trailers should be sent.
+         */
+        onwanttrailers?: QuicStream["onwanttrailers"] | undefined;
+    }
+    interface CreateBidirectionalStreamOptions extends CreateUnidirectionalStreamOptions {
+        /**
+         * The maximum number of bytes that the writer
+         * will buffer before `writeSync()` returns `false`. When the buffered
+         * data exceeds this limit, the caller should wait for drain before
+         * writing more. **Default:** `65536` (64 KB).
+         */
+        highWaterMark?: number | undefined;
+    }
+    interface SessionDestroyOptions {
+        /**
+         * The error code to include in the `CONNECTION_CLOSE`
+         * frame sent to the peer. Defaults to `0` (no error). **Default:** `0`.
+         */
+        code?: bigint | number | undefined;
+        /**
+         * Either `'transport'` or `'application'`. Determines the
+         * error code namespace used in the `CONNECTION_CLOSE` frame. When `'transport'`
+         * (the default), the frame type is `0x1c` and the code is interpreted as a QUIC
+         * transport error. When `'application'`, the frame type is `0x1d` and the code
+         * is application-specific. **Default:** `'transport'`.
+         */
+        type?: "transport" | "application" | undefined;
+        /**
+         * An optional human-readable reason string included in
+         * the `CONNECTION_CLOSE` frame. Per RFC 9000, this is for diagnostic purposes
+         * only and should not be used for machine-readable error descriptions.
+         */
+        reason?: string | undefined;
+    }
+    interface SessionHandshakeInfo {
+        /**
+         * The local socket address.
+         */
+        local: SocketAddress;
+        /**
+         * The remote socket address.
+         */
+        remote: SocketAddress;
+        /**
+         * The SNI server name negotiated during the handshake.
+         */
+        servername: string;
+        /**
+         * The ALPN protocol negotiated during the handshake.
+         */
+        protocol: string;
+        /**
+         * The name of the negotiated TLS cipher suite.
+         */
+        cipher: string;
+        /**
+         * The TLS protocol version of the cipher suite
+         * (e.g., `'TLSv1.3'`).
+         */
+        cipherVersion: string;
+        /**
+         * If certificate validation failed, the
+         * reason string. Empty string if validation succeeded.
+         */
+        validationErrorReason: string;
+        /**
+         * If certificate validation failed, the
+         * error code. `0` if validation succeeded.
+         */
+        validationErrorCode: number;
+        /**
+         * Whether 0-RTT early data was attempted.
+         */
+        earlyDataAttempted: boolean;
+        /**
+         * Whether 0-RTT early data was accepted by
+         * the server.
+         */
+        earlyDataAccepted: boolean;
     }
     interface SessionPath {
         local: SocketAddress;
@@ -654,21 +1013,38 @@ declare module "node:quic" {
          * Initiate a graceful close of the session. Existing streams will be allowed
          * to complete but no new streams will be opened. Once all streams have closed,
          * the session will be destroyed. The returned promise will be fulfilled once
-         * the session has been destroyed.
+         * the session has been destroyed. If a non-zero `code` is specified, the
+         * promise will reject with an `ERR_QUIC_TRANSPORT_ERROR` or
+         * `ERR_QUIC_APPLICATION_ERROR` depending on the `type`.
          * @since v23.8.0
          */
-        close(): Promise<void>;
+        close(options?: SessionDestroyOptions): Promise<void>;
+        /**
+         * A promise that is fulfilled once the TLS handshake completes successfully.
+         * The resolved value contains information about the established session
+         * including the negotiated protocol, cipher suite, certificate validation
+         * status, and 0-RTT early data status.
+         *
+         * If the handshake fails or the session is destroyed before the handshake
+         * completes, the promise will be rejected.
+         * @since v26.2.0
+         */
+        readonly opened: Promise<SessionHandshakeInfo>;
         /**
          * A promise that is fulfilled once the session is destroyed.
          * @since v23.8.0
          */
         readonly closed: Promise<void>;
         /**
-         * Immediately destroy the session. All streams will be destroys and the
-         * session will be closed.
+         * Immediately destroy the session. All streams will be destroyed and the
+         * session will be closed. If `error` is provided and [`session.onerror`][] is
+         * set, the `onerror` callback is invoked before destruction. The
+         * `session.closed` promise will reject with the error. If `options` is
+         * provided, the `CONNECTION_CLOSE` frame sent to the peer will include the
+         * specified error code, type, and reason.
          * @since v23.8.0
          */
-        destroy(error?: any): void;
+        destroy(error?: any, options?: SessionDestroyOptions): void;
         /**
          * True if `session.destroy()` has been called. Read only.
          * @since v23.8.0
@@ -680,10 +1056,34 @@ declare module "node:quic" {
          */
         readonly endpoint: QuicEndpoint;
         /**
+         * An optional callback invoked when the session is destroyed with an error.
+         * This includes errors caused by user callbacks that throw or reject (see
+         * [Callback error handling](https://nodejs.org/docs/latest-v26.x/api/quic.html#callback-error-handling)). The callback receives a single argument: the
+         * error that triggered the destruction. If the `onerror` callback itself throws
+         * or returns a promise that rejects, the error is surfaced as an uncaught
+         * exception. Read/write.
+         *
+         * Can also be set via the `onerror` option in `quic.connect()` or
+         * `quic.listen()`.
+         */
+        onerror: ((this: QuicSession, error: any) => void) | undefined;
+        /**
          * The callback to invoke when a new stream is initiated by a remote peer. Read/write.
          * @since v23.8.0
          */
         onstream: OnStreamCallback | undefined;
+        /**
+         * The callback to invoke when the server rejects 0-RTT early data. When
+         * this fires, all streams that were opened during the 0-RTT phase have
+         * been destroyed. The application should re-open streams if needed.
+         * Read/write.
+         *
+         * This callback only fires on the client side when the server rejects
+         * the client's 0-RTT attempt. The connection falls back to 1-RTT and
+         * continues normally.
+         * @since v26.2.0
+         */
+        onearlyrejected: ((this: QuicSession) => void) | undefined;
         /**
          * The callback to invoke when a new datagram is received from a remote peer. Read/write.
          * @since v23.8.0
@@ -715,29 +1115,175 @@ declare module "node:quic" {
          */
         onhandshake: OnHandshakeCallback | undefined;
         /**
+         * The callback to invoke when a NEW\_TOKEN token is received from the server.
+         * The token can be passed as the `token` option on a future connection to
+         * the same server to skip address validation. Read/write.
+         * @since v26.2.0
+         */
+        onnewtoken: OnNewTokenCallback | undefined;
+        /**
+         * The callback to invoke when an ORIGIN frame (RFC 9412) is received from
+         * the server, indicating which origins the server is authoritative for.
+         * Read/write.
+         * @since v26.2.0
+         */
+        onorigin: OnOriginCallback | undefined;
+        /**
+         * The callback to invoke when the peer sends an HTTP/3 GOAWAY frame,
+         * indicating it is initiating a graceful shutdown. The callback receives
+         * `(lastStreamId)` where `lastStreamId` is a `{bigint}`:
+         *
+         * * When `lastStreamId` is `-1n`, the peer sent a shutdown notice (intent
+         *   to close) without specifying a stream boundary. All existing streams
+         *   may still be processed.
+         * * When `lastStreamId` is `>= 0n`, it is the highest stream ID the peer
+         *   may have processed. Streams with IDs above this value were NOT
+         *   processed and can be safely retried on a new connection.
+         *
+         * After GOAWAY is received, `session.createBidirectionalStream()` will
+         * throw `ERR_INVALID_STATE`. Existing streams continue until they
+         * complete or the session closes.
+         *
+         * This callback is only relevant for HTTP/3 sessions. Read/write.
+         * @since v26.2.0
+         */
+        ongoaway: ((this: QuicSession, lastStreamId: bigint) => void) | undefined;
+        /**
+         * The callback to invoke when TLS key material is available. Requires
+         * `sessionOptions.keylog` to be `true`. Each invocation receives a single
+         * line of [NSS Key Log Format](https://udn.realityripple.com/docs/Mozilla/Projects/NSS/Key_Log_Format) text (including a trailing newline). This is
+         * useful for decrypting packet captures with tools like Wireshark. Read/write.
+         *
+         * Can also be set via the `onkeylog` option in `quic.connect()` or
+         * `quic.listen()`.
+         * @since v26.2.0
+         */
+        onkeylog: OnKeylogCallback | undefined;
+        /**
+         * The callback to invoke when qlog data is available. Requires
+         * `sessionOptions.qlog` to be `true`. The callback receives a string
+         * chunk of [JSON-SEQ](https://www.rfc-editor.org/rfc/rfc7464) formatted qlog data and a boolean `fin` flag. When
+         * `fin` is `true`, the chunk is the final qlog output for this session and
+         * the concatenated chunks form a complete qlog trace. Read/write.
+         *
+         * Qlog data arrives during the connection lifecycle. The first chunk contains
+         * the qlog header with format metadata. Subsequent chunks contain trace
+         * events. The final chunk (with `fin` set to `true`) is emitted during
+         * session destruction and completes the JSON-SEQ output.
+         *
+         * Can also be set via the `onqlog` option in `quic.connect()` or
+         * `quic.listen()`.
+         * @since v26.2.0
+         */
+        onqlog: OnQlogCallback | undefined;
+        /**
          * Open a new bidirectional stream. If the `body` option is not specified,
-         * the outgoing stream will be half-closed.
+         * the outgoing stream will be half-closed. The `priority` and `incremental`
+         * options are only used when the session supports priority (e.g. HTTP/3).
+         * The `headers`, `onheaders`, `ontrailers`, `oninfo`, and `onwanttrailers`
+         * options are only used when the session supports headers (e.g. HTTP/3).
          * @since v23.8.0
          */
-        createBidirectionalStream(options?: CreateStreamOptions): Promise<QuicStream>;
+        createBidirectionalStream(options?: CreateBidirectionalStreamOptions): Promise<QuicStream>;
         /**
          * Open a new unidirectional stream. If the `body` option is not specified,
-         * the outgoing stream will be closed.
+         * the outgoing stream will be closed. The `priority` and `incremental`
+         * options are only used when the session supports priority (e.g. HTTP/3).
          * @since v23.8.0
          */
-        createUnidirectionalStream(options?: CreateStreamOptions): Promise<QuicStream>;
+        createUnidirectionalStream(options?: CreateUnidirectionalStreamOptions): Promise<QuicStream>;
         /**
          * The local and remote socket addresses associated with the session. Read only.
          * @since v23.8.0
          */
         path: SessionPath | undefined;
         /**
-         * Sends an unreliable datagram to the remote peer, returning the datagram ID.
-         * If the datagram payload is specified as an `ArrayBufferView`, then ownership of
-         * that view will be transferred to the underlying stream.
+         * Sends an unreliable datagram to the remote peer, returning a promise for
+         * the datagram ID.
+         *
+         * If `datagram` is a string, it will be encoded using the specified `encoding`.
+         *
+         * If `datagram` is an `ArrayBufferView`, the bytes are copied into an
+         * internal buffer; the caller's source buffer is unchanged and may be reused
+         * or mutated immediately after the call returns. Callers that want to ensure
+         * their source cannot be mutated after the call (for example, when handing
+         * the buffer off to another async consumer) can call
+         * `ArrayBuffer.prototype.transfer()` themselves before passing the buffer.
+         *
+         * If `datagram` is a `Promise`, it will be awaited before sending. If the
+         * session closes while awaiting, `0n` is returned silently (datagrams are
+         * inherently unreliable).
+         *
+         * If the datagram payload is zero-length (empty string after encoding, detached
+         * buffer, or zero-length view), `0n` is returned and no datagram is sent.
+         *
+         * For HTTP/3 sessions, the peer must advertise `SETTINGS_H3_DATAGRAM=1`
+         * (via `application: { enableDatagrams: true }`) for datagrams to be sent.
+         * If the peer's setting is `0`, `sendDatagram()` returns `0n` (per RFC 9297
+         * §3, an endpoint MUST NOT send HTTP Datagrams unless the peer indicated
+         * support).
+         *
+         * Datagrams cannot be fragmented — each must fit within a single QUIC packet.
+         * The maximum datagram size is determined by the peer's
+         * `maxDatagramFrameSize` transport parameter (which the peer advertises during
+         * the handshake). If the peer sets this to `0`, datagrams are not supported
+         * and `0n` will be returned. If the datagram exceeds the peer's limit, it
+         * will be silently dropped and `0n` returned. The local
+         * `maxDatagramFrameSize` transport parameter (default: `1200` bytes) controls
+         * what this endpoint advertises to the peer as its own maximum.
          * @since v23.8.0
+         * @param encoding The encoding to use if `datagram` is a string.
+         * **Default:** `'utf8'`.
          */
-        sendDatagram(datagram: string | NodeJS.ArrayBufferView): bigint;
+        sendDatagram(
+            datagram: string | NodeJS.ArrayBufferView | Promise<string | NodeJS.ArrayBufferView>,
+            encoding?: BufferEncoding,
+        ): Promise<bigint>;
+        /**
+         * The local certificate as an object with properties such as `subject`,
+         * `issuer`, `valid_from`, `valid_to`, `fingerprint`, etc. Returns `undefined`
+         * if the session is destroyed or no certificate is available.
+         * @since v26.2.0
+         */
+        readonly certificate: PeerCertificate | undefined;
+        /**
+         * The peer's certificate as an object with properties such as `subject`,
+         * `issuer`, `valid_from`, `valid_to`, `fingerprint`, etc. Returns `undefined`
+         * if the session is destroyed or the peer did not present a certificate.
+         * @since v26.2.0
+         */
+        readonly peerCertificate: PeerCertificate | undefined;
+        /**
+         * The ephemeral key information for the session, with properties such as
+         * `type`, `name`, and `size`. Only available on client sessions. Returns
+         * `undefined` for server sessions or if the session is destroyed.
+         * @since v26.2.0
+         */
+        readonly ephemeralKeyInfo: EphemeralKeyInfo | undefined;
+        /**
+         * The maximum datagram payload size in bytes that the peer will accept.
+         * This is derived from the peer's `maxDatagramFrameSize` transport
+         * parameter minus the DATAGRAM frame overhead (type byte and variable-length
+         * integer encoding). Returns `0` if the peer does not support datagrams or
+         * if the handshake has not yet completed. Datagrams larger than this value
+         * will not be sent.
+         * @since v26.2.0
+         */
+        readonly maxDatagramSize: number;
+        /**
+         * The maximum number of datagrams that can be queued for sending. Datagrams
+         * are queued when `sendDatagram()` is called and sent opportunistically
+         * alongside stream data by the packet serialization loop. When the queue
+         * is full, the `sessionOptions.datagramDropPolicy` determines whether
+         * the oldest or newest datagram is dropped. Dropped datagrams are reported
+         * as lost via the `ondatagramstatus` callback.
+         *
+         * This property can be changed dynamically to adjust queue capacity
+         * based on application activity or memory pressure. The valid range
+         * is `0` to `65535`.
+         * @since v26.2.0
+         */
+        maxPendingDatagrams: number;
         /**
          * Return the current statistics for the session. Read only.
          * @since v23.8.0
@@ -804,7 +1350,7 @@ declare module "node:quic" {
             /**
              * @since v23.8.0
              */
-            readonly maxBytesInFlights: bigint;
+            readonly maxBytesInFlight: bigint;
             /**
              * @since v23.8.0
              */
@@ -855,50 +1401,451 @@ declare module "node:quic" {
             readonly datagramsLost: bigint;
         }
     }
+    interface QuicErrorOptions {
+        /**
+         * The numeric QUIC error code. Numbers
+         * are coerced to `BigInt`. Must be a non-negative 62-bit unsigned
+         * varint (`0n <= errorCode <= 2n ** 62n - 1n`).
+         */
+        errorCode?: bigint | number | undefined;
+        /**
+         * The Node.js-style error code string assigned to
+         * `error.code`. Defaults to `'ERR_QUIC_STREAM_ABORTED'`.
+         */
+        code?: string | undefined;
+        /**
+         * Either `'application'` (default) or `'transport'`.
+         * Indicates whether the code is defined by the negotiated
+         * application protocol (e.g. RFC 9114 for HTTP/3) or by the QUIC
+         * transport layer (RFC 9000). Stream resets always carry application
+         * codes, so the default is `'application'`.
+         */
+        type?: "application" | "transport" | undefined;
+    }
+    /**
+     * A `QuicError` is an `Error` subclass that carries an explicit numeric
+     * QUIC error code. Use it to abort a QUIC stream or session with a
+     * specific application-protocol-defined error code rather than letting
+     * the implementation pick a generic fallback.
+     *
+     * The class is exported from `node:quic`:
+     *
+     * ```js
+     * import { QuicError } from 'node:quic';
+     * ```
+     *
+     * When a `QuicError` is supplied to APIs that emit a wire frame
+     * (`writer.fail()`, `stream.destroy()`), the QUIC stack uses
+     * `error.errorCode` as the wire code for the resulting frame.
+     * When any other value is supplied (for example a plain `Error`), the
+     * implementation falls back to the negotiated application protocol's
+     * "internal error" code (`H3_INTERNAL_ERROR` (`0x102`) for HTTP/3, or
+     * the QUIC transport-layer `INTERNAL_ERROR` (`0x1`) for raw QUIC).
+     *
+     * The Node.js error code (`error.code`) defaults to
+     * `'ERR_QUIC_STREAM_ABORTED'`. Callers who need a more specific code
+     * string can override it via `options.code` — the numeric QUIC code
+     * is unaffected.
+     *
+     * The Node.js error code is fixed at `'ERR_QUIC_STREAM_ABORTED'` so that
+     * catch blocks can distinguish a `QuicError` from other Node.js errors
+     * without checking the prototype chain. The numeric QUIC code lives on
+     * the separate `error.errorCode` property to avoid colliding with
+     * the Node.js convention that `error.code` is a string.
+     * @since v26.2.0
+     * @experimental
+     */
+    class QuicError extends Error {
+        /**
+         * ```js
+         * import { QuicError } from 'node:quic';
+         *
+         * const err = new QuicError('rejecting stream', { errorCode: 0x10cn });
+         * console.log(err.code);       // 'ERR_QUIC_STREAM_ABORTED'
+         * console.log(err.errorCode);  // 268n
+         * console.log(err.type);       // 'application'
+         *
+         * const custom = new QuicError('custom failure', {
+         *   errorCode: 0x10cn,
+         *   code: 'ERR_MY_QUIC_FAILURE',
+         * });
+         * console.log(custom.code);    // 'ERR_MY_QUIC_FAILURE'
+         * ```
+         * @param message A human-readable description of the error.
+         */
+        constructor(message: string, options?: QuicErrorOptions);
+        /**
+         * The numeric QUIC error code carried by this error.
+         * @since v26.2.0
+         */
+        readonly errorCode: bigint;
+        /**
+         * Either `'application'` or `'transport'`. Indicates the namespace of
+         * `error.errorCode`.
+         * @since v26.2.0
+         */
+        readonly type: "application" | "transport";
+    }
+    type StreamBody =
+        | null
+        | string
+        | ArrayBufferLike
+        | NodeJS.ArrayBufferView
+        | Blob
+        | FileHandle
+        | Iterable<string | Uint8Array>
+        | AsyncIterable<string | Uint8Array>
+        | Promise<StreamBody>;
+    interface StreamPriority {
+        /**
+         * One of `'high'`, `'default'`, or `'low'`.
+         */
+        level: "high" | "default" | "low";
+        /**
+         * Whether the stream data should be interleaved
+         * with other streams of the same priority level.
+         */
+        incremental: boolean;
+    }
+    interface StreamDestroyOptions {
+        /**
+         * The application error code to include in the
+         * `RESET_STREAM` and `STOP_SENDING` frames sent to the peer. Numbers are
+         * coerced to `BigInt`. When omitted, the wire code is derived from `error`
+         * (see below).
+         */
+        code?: bigint | number | undefined;
+        /**
+         * An optional human-readable reason string. Accepted for
+         * symmetry with `session.close()` and `session.destroy()`, but
+         * **not transmitted on the wire** — neither `RESET_STREAM` nor
+         * `STOP_SENDING` carry a reason field. Provided for application logging
+         * and for use by the `stream.onerror` callback.
+         */
+        reason?: string | undefined;
+    }
+    interface StreamSendHeadersOptions {
+        /**
+         * If `true`, the stream is closed for sending
+         * after the headers (no body will follow). **Default:** `false`.
+         */
+        terminal?: boolean | undefined;
+    }
     /**
      * @since v23.8.0
      */
     class QuicStream {
         private constructor();
         /**
-         * A promise that is fulfilled when the stream is fully closed.
+         * A promise that is fulfilled when the stream is fully closed. It resolves
+         * when the stream closes cleanly (including idle timeout). It rejects with
+         * an `ERR_QUIC_APPLICATION_ERROR` or `ERR_QUIC_TRANSPORT_ERROR` when the
+         * stream is closed due to a QUIC error (e.g., stream reset by the peer,
+         * CONNECTION\_CLOSE with a non-zero error code).
          * @since v23.8.0
          */
         readonly closed: Promise<void>;
         /**
-         * Immediately and abruptly destroys the stream.
+         * Immediately and abruptly destroys the stream. If `error` is provided and
+         * `stream.onerror` is set, the `onerror` callback is invoked before
+         * destruction. The `stream.closed` promise rejects with the error.
+         *
+         * When the stream is destroyed with an `error` (or with an explicit
+         * `options.code`), the QUIC stack signals the abort to the peer:
+         *
+         * * If the writable side is still open, a `RESET_STREAM` frame is sent.
+         * * If the readable side is still open (a bidirectional stream, or a
+         *   remote-initiated unidirectional stream), a `STOP_SENDING` frame is sent.
+         *
+         * Both frames carry the same wire code, resolved with the following
+         * precedence:
+         *
+         * 1. `options.code`, when explicitly provided.
+         * 2. [`error.errorCode`][], when `error` is a [`QuicError`][].
+         * 3. The negotiated application protocol's "internal error" code
+         *    (`H3_INTERNAL_ERROR` (`0x102`) for HTTP/3, or the QUIC transport-layer
+         *    `INTERNAL_ERROR` (`0x1`) for raw QUIC).
+         *
+         * A clean destroy — no `error` and no `options.code` — does not emit
+         * `RESET_STREAM` or `STOP_SENDING`; the stream's existing close machinery
+         * handles teardown.
+         *
+         * See [Aborting a stream](https://nodejs.org/docs/latest-v26.x/api/quic.html#aborting-a-stream) for an overview of the available stream-abort
+         * APIs.
          * @since v23.8.0
          */
-        destroy(error?: any): void;
+        destroy(error?: any, options?: StreamDestroyOptions): void;
         /**
          * True if `stream.destroy()` has been called.
          * @since v23.8.0
          */
         readonly destroyed: boolean;
         /**
+         * True if any data on this stream was received as 0-RTT (early data)
+         * before the TLS handshake completed. Early data is less secure and
+         * could potentially be replayed by an attacker. Applications should
+         * treat early data with appropriate caution.
+         *
+         * This property is only meaningful on the server side. On the client
+         * side, it is always `false`.
+         * @since v26.2.0
+         */
+        readonly early: boolean;
+        /**
          * The directionality of the stream. Read only.
          * @since v23.8.0
          */
         readonly direction: "bidi" | "uni";
+        /**
+         * The maximum number of bytes that the writer will buffer before
+         * `writeSync()` returns `false`. When the buffered data exceeds this limit,
+         * the caller should wait for the `drainableProtocol` promise to resolve
+         * before writing more.
+         *
+         * The value can be changed dynamically at any time. This is particularly
+         * useful for streams received via the `onstream` callback, where the
+         * default (65536) may need to be adjusted based on application needs.
+         * The valid range is `0` to `4294967295`.
+         * @since v26.2.0
+         */
+        highWaterMark: number;
         /**
          * The stream ID. Read only.
          * @since v23.8.0
          */
         readonly id: bigint;
         /**
+         * An optional callback invoked when the stream is destroyed with an error.
+         * This includes errors caused by user callbacks that throw or reject (see
+         * [Callback error handling](https://nodejs.org/docs/latest-26.x/api/quic.html#callback-error-handling)). The callback receives a single argument: the
+         * error that triggered the destruction. If the `onerror` callback itself throws
+         * or returns a promise that rejects, the error is surfaced as an uncaught
+         * exception. Read/write.
+         * @since v26.2.0
+         */
+        onerror: ((this: QuicStream, error: any) => void) | undefined;
+        /**
          * The callback to invoke when the stream is blocked. Read/write.
          * @since v23.8.0
          */
         onblocked: OnBlockedCallback | undefined;
         /**
-         * The callback to invoke when the stream is reset. Read/write.
+         * The callback to invoke when the peer aborts a direction of the stream by
+         * sending a `RESET_STREAM` frame (the peer abandons their writable side, so
+         * no further data will arrive on our readable side) or a `STOP_SENDING`
+         * frame (the peer asks us to stop writing on our writable side).
+         *
+         * The callback receives a Node.js error whose `errorCode` (`bigint`)
+         * property carries the application error code from the wire frame.
+         *
+         * The stream is **not** automatically destroyed when this callback fires —
+         * the application chooses how to react. Common patterns are: ignore (and
+         * continue using the still-active direction on a bidirectional stream),
+         * abort the other direction with `writer.fail()`, or tear down the
+         * whole stream with `stream.destroy()`. Read/write.
          * @since v23.8.0
          */
         onreset: OnStreamErrorCallback | undefined;
         /**
-         * @since v23.8.0
+         * The buffered initial headers received on this stream, or `undefined` if the
+         * application does not support headers or no headers have been received yet.
+         * For server-side streams, this contains the request headers (e.g., `:method`,
+         * `:path`, `:scheme`). For client-side streams, this contains the response
+         * headers (e.g., `:status`).
+         *
+         * Header names are lowercase strings. Multi-value headers are represented as
+         * arrays. The object has `__proto__: null`.
+         * @since v26.2.0
          */
-        readonly readable: ReadableStream<Uint8Array>;
+        readonly headers: NodeJS.Dict<string | string[]> | undefined;
+        /**
+         * The callback to invoke when initial headers are received on the stream. The
+         * callback receives `(headers)` where `headers` is an object (same format as
+         * `stream.headers`). For HTTP/3, this delivers request pseudo-headers on the
+         * server side and response headers on the client side. Throws
+         * `ERR_INVALID_STATE` if set on a session that does not support headers.
+         * Read/write.
+         * @since v26.2.0
+         */
+        onheaders: ((this: QuicStream, headers: NodeJS.Dict<string | string[]>) => void) | undefined;
+        /**
+         * The callback to invoke when trailing headers are received from the peer.
+         * The callback receives `(trailers)` where `trailers` is an object in the
+         * same format as `stream.headers`. Throws `ERR_INVALID_STATE` if set on a
+         * session that does not support headers. Read/write.
+         * @since v26.2.0
+         */
+        ontrailers: ((this: QuicStream, trailers: NodeJS.Dict<string | string[]>) => void) | undefined;
+        /**
+         * The callback to invoke when informational (1xx) headers are received from
+         * the server. The callback receives `(headers)` where `headers` is an object
+         * in the same format as `stream.headers`. Informational headers are sent
+         * before the final response (e.g., 103 Early Hints). Throws
+         * `ERR_INVALID_STATE` if set on a session that does not support headers.
+         * Read/write.
+         * @since v26.2.0
+         */
+        oninfo: ((this: QuicStream, headers: NodeJS.Dict<string | string[]>) => void) | undefined;
+        /**
+         * The callback to invoke when the application is ready for trailing headers
+         * to be sent. This is called synchronously — the user must call
+         * `stream.sendTrailers()` within this callback. Throws
+         * `ERR_INVALID_STATE` if set on a session that does not support headers.
+         * Read/write.
+         * @since v26.2.0
+         */
+        onwanttrailers: ((this: QuicStream) => void) | undefined;
+        /**
+         * Set trailing headers to be sent automatically when the application requests
+         * them. This is an alternative to the `stream.onwanttrailers` callback
+         * for cases where the trailers are known before the body completes. Throws
+         * `ERR_INVALID_STATE` if set on a session that does not support headers.
+         * Read/write.
+         * @since v26.2.0
+         */
+        pendingTrailers: NodeJS.Dict<string | string[]> | undefined;
+        /**
+         * Sends initial or response headers on the stream. For client-side streams,
+         * this sends request headers. For server-side streams, this sends response
+         * headers. Throws `ERR_INVALID_STATE` if the session does not support headers.
+         * @since v26.2.0
+         * @param headers Header object with string keys and string or
+         * string-array values. Pseudo-headers (`:method`, `:path`, etc.) must
+         * appear before regular headers.
+         */
+        sendHeaders(headers: NodeJS.Dict<string | string[]>, options?: StreamSendHeadersOptions): boolean;
+        /**
+         * Sends informational (1xx) response headers. Server only. Throws
+         * `ERR_INVALID_STATE` if the session does not support headers.
+         * @since v26.2.0
+         * @param headers Header object. Must include `:status` with a 1xx
+         * value (e.g., `{ ':status': '103', 'link': '</style.css>; rel=preload' }`).
+         */
+        sendInformationalHeaders(headers: NodeJS.Dict<string | string[]>): boolean;
+        /**
+         * Sends trailing headers on the stream. Must be called synchronously during
+         * the `stream.onwanttrailers` callback, or set ahead of time via
+         * `stream.pendingTrailers`. Throws `ERR_INVALID_STATE` if the session
+         * does not support headers.
+         * @since v26.2.0
+         * @param headers Trailing header object. Pseudo-headers must not be
+         * included in trailers.
+         */
+        sendTrailers(headers: NodeJS.Dict<string | string[]>): boolean;
+        /**
+         * The current priority of the stream. Returns `null` if the session does not
+         * support priority (e.g. non-HTTP/3) or if the stream has been destroyed.
+         * Read only. Use `stream.setPriority()` to change the priority.
+         *
+         * On client-side HTTP/3 sessions, the value reflects what was set via
+         * `stream.setPriority()`. On server-side HTTP/3 sessions, the value
+         * reflects the peer's requested priority (e.g., from `PRIORITY_UPDATE` frames).
+         * @since v26.2.0
+         */
+        readonly priority: StreamPriority | null;
+        /**
+         * Sets the priority of the stream. Throws `ERR_INVALID_STATE` if the session
+         * does not support priority (e.g. non-HTTP/3). Has no effect if the stream
+         * has been destroyed.
+         * @since v26.2.0
+         */
+        setPriority(options?: NodeJS.PartialOptions<StreamPriority>): void;
+        /**
+         * The stream implements `Symbol.asyncIterator`, making it directly usable
+         * in `for await...of` loops. Each iteration yields a batch of `Uint8Array`
+         * chunks.
+         *
+         * Only one async iterator can be obtained per stream. A second call throws
+         * `ERR_INVALID_STATE`. Non-readable streams (outbound-only unidirectional
+         * or closed) return an immediately-finished iterator.
+         *
+         * ```js
+         * for await (const chunks of stream) {
+         *   for (const chunk of chunks) {
+         *     // Process each Uint8Array chunk
+         *   }
+         * }
+         * ```
+         *
+         * Compatible with stream/iter utilities:
+         *
+         * ```js
+         * import Stream from 'node:stream/iter';
+         * const body = await Stream.bytes(stream);
+         * const text = await Stream.text(stream);
+         * await Stream.pipeTo(stream, someWriter);
+         * ```
+         * @since v26.2.0
+         */
+        [Symbol.asyncIterator](): NodeJS.AsyncIterator<NodeJS.NonSharedUint8Array[]>;
+        /**
+         * Returns a Writer object for pushing data to the stream incrementally.
+         * The Writer implements the stream/iter Writer interface with the
+         * try-sync-fallback-to-async pattern.
+         *
+         * Only available when no `body` source was provided at creation time or via
+         * `stream.setBody()`. Non-writable streams return an already-closed
+         * Writer. Throws `ERR_INVALID_STATE` if the outbound is already configured.
+         *
+         * The Writer has the following methods:
+         *
+         * * `writeSync(chunk)` — Synchronous write. Returns `true` if accepted,
+         *   `false` if flow-controlled. Data is NOT accepted on `false`.
+         * * `write(chunk[, options])` — Async write with drain wait. `options.signal`
+         *   is checked at entry but not observed during the write.
+         * * `writevSync(chunks)` — Synchronous vectored write. All-or-nothing.
+         * * `writev(chunks[, options])` — Async vectored write.
+         * * `endSync()` — Synchronous close. Returns total bytes or `-1`.
+         * * `end([options])` — Async close.
+         * * `fail(reason)` — Errors the stream (sends `RESET_STREAM` to peer).
+         *   When `reason` is a `QuicError`, its `error.errorCode` is used
+         *   as the wire code on the resulting `RESET_STREAM` frame; otherwise
+         *   the wire code falls back to the negotiated application protocol's
+         *   "internal error" code (`H3_INTERNAL_ERROR` (`0x102`) for HTTP/3, or
+         *   the QUIC transport-layer `INTERNAL_ERROR` (`0x1`) for raw QUIC).
+         *   See `stream.destroy()` for a full-stream abort that also resets
+         *   the readable side via `STOP_SENDING`.
+         * * `desiredSize` — Available capacity in bytes, or `null` if closed/errored.
+         *
+         * The bytes from each `writeSync()` / `writevSync()` / `write()` / `writev()`
+         * input chunk are copied into an internal buffer, so the caller's source
+         * buffer is unchanged and may be reused or mutated immediately after the
+         * call returns. Callers that want to ensure a source buffer cannot be
+         * mutated after handing it off can call `ArrayBuffer.prototype.transfer()`
+         * themselves before passing the buffer.
+         * @since v26.2.0
+         */
+        readonly writer: Writer;
+        /**
+         * Sets the outbound body source for the stream. Can only be called once.
+         * Mutually exclusive with `stream.writer`.
+         *
+         * The following body source types are supported:
+         *
+         * * `null` — The writable side is closed immediately (FIN sent with no data).
+         * * `string` — UTF-8 encoded and sent as a single chunk.
+         * * `ArrayBuffer`, `SharedArrayBuffer`, `ArrayBufferView` — Sent as a single
+         *   chunk. The bytes are copied into an internal buffer, so the caller's
+         *   source buffer is unchanged and may be reused or mutated immediately
+         *   after the call returns. Callers wanting to ensure their source cannot
+         *   be mutated after handing it off can call
+         *   `ArrayBuffer.prototype.transfer()` themselves before passing the buffer.
+         * * `Blob` — Sent from the Blob's underlying data queue.
+         * * {FileHandle} — The file contents are read asynchronously via an
+         *   fd-backed data source. The `FileHandle` must be opened for reading
+         *   (e.g. via [`fs.promises.open(path, 'r')`][]). Once passed as a body, the
+         *   `FileHandle` is locked and cannot be used as a body for another stream.
+         *   The `FileHandle` is automatically closed when the stream finishes.
+         * * `AsyncIterable`, `Iterable` — Each yielded chunk (string or
+         *   `Uint8Array`) is written incrementally in streaming mode.
+         * * `Promise` — Awaited; the resolved value is used as the body (subject
+         *   to the same type rules).
+         *
+         * Throws `ERR_INVALID_STATE` if the outbound is already configured or if
+         * the writer has been accessed.
+         * @since v26.2.0
+         */
+        setBody(body: StreamBody): void;
         /**
          * The session that created this stream. Read only.
          * @since v23.8.0

--- a/types/node/sqlite.d.ts
+++ b/types/node/sqlite.d.ts
@@ -298,10 +298,23 @@ declare module "node:sqlite" {
          * Loads a shared library into the database connection. This method is a wrapper
          * around [`sqlite3_load_extension()`](https://www.sqlite.org/c3ref/load_extension.html). It is required to enable the
          * `allowExtension` option when constructing the `DatabaseSync` instance.
+         *
+         * ```js
+         * import { DatabaseSync } from 'node:sqlite';
+         * const database = new DatabaseSync(':memory:', { allowExtension: true });
+         *
+         * // Load using the entry point derived from the filename.
+         * database.loadExtension('./decimal.dylib');
+         *
+         * // Override the entry point when the derived name does not match.
+         * database.loadExtension('./base64.dylib', 'sqlite3_base64_init');
          * @since v22.13.0
          * @param path The path to the shared library to load.
+         * @param entryPoint The name of the extension's entry-point function. When
+         * omitted, SQLite derives the entry point from the shared library's filename;
+         * pass this argument explicitly when the derived name does not match.
          */
-        loadExtension(path: string): void;
+        loadExtension(path: string, entryPoint?: string): void;
         /**
          * Enables or disables the `loadExtension` SQL function, and the `loadExtension()`
          * method. When `allowExtension` is `false` when constructing, you cannot enable

--- a/types/node/stream/iter.d.ts
+++ b/types/node/stream/iter.d.ts
@@ -311,8 +311,9 @@ declare module "node:stream/iter" {
      * return `false` or `-1`, deferring to the async path. The per-write
      * `options.signal` parameter from the Writer interface is also ignored.
      *
-     * The result is cached per instance -- calling `fromWritable()` twice with the
-     * same stream returns the same Writer.
+     * The result is cached per instance and backpressure policy -- calling
+     * `fromWritable()` twice with the same stream and `backpressure` option returns
+     * the same Writer.
      *
      * For duck-typed streams that do not expose `writableHighWaterMark`,
      * `writableLength`, or similar properties, sensible defaults are used.

--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -265,6 +265,15 @@ declare module "node:test" {
              */
             testSkipPatterns?: string | RegExp | ReadonlyArray<string | RegExp> | undefined;
             /**
+             * A tag name, or an array of tag names,
+             * used to filter tests by their declared tags. Tests must contain every
+             * listed tag to run. Equivalent to passing `--experimental-test-tag-filter`
+             * on the command line. See [Test tags](https://nodejs.org/docs/latest-v26.x/api/test.html#test-tags).
+             * @default undefined
+             * @since v26.2.0
+             */
+            testTagFilters?: string | readonly string[] | undefined;
+            /**
              * The number of milliseconds after which the test execution will fail.
              * If unspecified, subtests inherit this value from their parent.
              * @default Infinity
@@ -669,6 +678,12 @@ declare module "node:test" {
                  */
                 nesting: number;
                 /**
+                 * The flattened lowercased tags declared on the test
+                 * and its ancestor suites, in declaration order. Empty for untagged tests.
+                 * See [Test tags](https://nodejs.org/docs/latest-v26.x/api/test.html#test-tags).
+                 */
+                tags: string[];
+                /**
                  * A numeric identifier for this test instance, unique
                  * within the test file's process. Consistent across all events for the same
                  * test instance, enabling reliable correlation in custom reporters.
@@ -697,6 +712,12 @@ declare module "node:test" {
                  */
                 nesting: number;
                 /**
+                 * The flattened lowercased tags declared on the test
+                 * and its ancestor suites, in declaration order. Empty for untagged tests.
+                 * See [Test tags](https://nodejs.org/docs/latest-v26.x/api/test.html#test-tags).
+                 */
+                tags: string[];
+                /**
                  * A numeric identifier for this test instance, unique
                  * within the test file's process. Consistent across all events for the same
                  * test instance, enabling reliable correlation in custom reporters.
@@ -717,6 +738,12 @@ declare module "node:test" {
                  * The nesting level of the test.
                  */
                 nesting: number;
+                /**
+                 * The flattened lowercased tags declared on the test
+                 * and its ancestor suites, in declaration order. Empty for untagged tests.
+                 * See [Test tags](https://nodejs.org/docs/latest-v26.x/api/test.html#test-tags).
+                 */
+                tags: string[];
                 /**
                  * A numeric identifier for this test instance, unique
                  * within the test file's process. Consistent across all events for the same
@@ -762,6 +789,12 @@ declare module "node:test" {
                  * The nesting level of the test.
                  */
                 nesting: number;
+                /**
+                 * The flattened lowercased tags declared on the test
+                 * and its ancestor suites, in declaration order. Empty for untagged tests.
+                 * See [Test tags](https://nodejs.org/docs/latest-v26.x/api/test.html#test-tags).
+                 */
+                tags: string[];
                 /**
                  * A numeric identifier for this test instance, unique
                  * within the test file's process. Consistent across all events for the same
@@ -824,6 +857,12 @@ declare module "node:test" {
                  */
                 nesting: number;
                 /**
+                 * The flattened lowercased tags declared on the test
+                 * and its ancestor suites, in declaration order. Empty for untagged tests.
+                 * See [Test tags](https://nodejs.org/docs/latest-v26.x/api/test.html#test-tags).
+                 */
+                tags: string[];
+                /**
                  * A numeric identifier for this test instance, unique
                  * within the test file's process. Consistent across all events for the same
                  * test instance, enabling reliable correlation in custom reporters.
@@ -861,6 +900,12 @@ declare module "node:test" {
                  * The nesting level of the test.
                  */
                 nesting: number;
+                /**
+                 * The flattened lowercased tags declared on the test
+                 * and its ancestor suites, in declaration order. Empty for untagged tests.
+                 * See [Test tags](https://nodejs.org/docs/latest-v26.x/api/test.html#test-tags).
+                 */
+                tags: string[];
                 /**
                  * A numeric identifier for this test instance, unique
                  * within the test file's process. Consistent across all events for the same
@@ -1082,6 +1127,13 @@ declare module "node:test" {
              * @since v21.7.0, v20.12.0
              */
             readonly attempt: number;
+            /**
+             * A frozen array of the test's flattened lowercased tags, in declaration
+             * order, including any tags inherited from ancestor suites. Empty when the
+             * test has no tags. See [Test tags](https://nodejs.org/docs/latest-v26.x/api/test.html#test-tags).
+             * @since v26.2.0
+             */
+            readonly tags: readonly string[];
             /**
              * The unique identifier of the worker running the current test file. This value is
              * derived from the `NODE_TEST_WORKER_ID` environment variable. When running tests
@@ -1443,6 +1495,15 @@ declare module "node:test" {
              * @default false
              */
             skip?: boolean | string | undefined;
+            /**
+             * An array of string labels associated with the test.
+             * Used together with `--experimental-test-tag-filter` to filter which
+             * tests run. Tags inherit from suites to nested tests by union. See
+             * [Test tags](https://nodejs.org/docs/latest-v26.x/api/test.html#test-tags).
+             * @default []
+             * @since v26.2.0
+             */
+            tags?: readonly string[] | undefined;
             /**
              * A number of milliseconds the test will fail after. If unspecified, subtests inherit this
              * value from their parent.

--- a/types/node/v8.d.ts
+++ b/types/node/v8.d.ts
@@ -89,23 +89,22 @@ declare module "node:v8" {
      * `total_allocated_bytes` The value of total allocated bytes since the Isolate
      * creation.
      *
-     * ```js
+     * ```json
      * {
-     *   total_heap_size: 7326976,
-     *   total_heap_size_executable: 4194304,
-     *   total_physical_size: 7326976,
-     *   total_available_size: 1152656,
-     *   used_heap_size: 3476208,
-     *   heap_size_limit: 1535115264,
-     *   malloced_memory: 16384,
-     *   peak_malloced_memory: 1127496,
-     *   does_zap_garbage: 0,
-     *   number_of_native_contexts: 1,
-     *   number_of_detached_contexts: 0,
-     *   total_global_handles_size: 8192,
-     *   used_global_handles_size: 3296,
-     *   external_memory: 318824,
-     *   total_allocated_bytes: 45224088
+     *   "total_heap_size": 7326976,
+     *   "total_heap_size_executable": 4194304,
+     *   "total_physical_size": 7326976,
+     *   "total_available_size": 1152656,
+     *   "used_heap_size": 3476208,
+     *   "heap_size_limit": 1535115264,
+     *   "malloced_memory": 16384,
+     *   "peak_malloced_memory": 1127496,
+     *   "does_zap_garbage": 0,
+     *   "number_of_native_contexts": 1,
+     *   "number_of_detached_contexts": 0,
+     *   "total_global_handles_size": 8192,
+     *   "used_global_handles_size": 3296,
+     *   "external_memory": 318824
      * }
      * ```
      * @since v1.0.0
@@ -386,12 +385,12 @@ declare module "node:v8" {
      * V8 [`GetHeapCodeAndMetadataStatistics`](https://v8docs.nodesource.com/node-13.2/d5/dda/classv8_1_1_isolate.html#a6079122af17612ef54ef3348ce170866) API. Returns an object with the
      * following properties:
      *
-     * ```js
+     * ```json
      * {
-     *   code_and_metadata_size: 212208,
-     *   bytecode_and_metadata_size: 161368,
-     *   external_script_source_size: 1410794,
-     *   cpu_profiler_metadata_size: 0,
+     *   "code_and_metadata_size": 212208,
+     *   "bytecode_and_metadata_size": 161368,
+     *   "external_script_source_size": 1410794,
+     *   "cpu_profiler_metadata_size": 0
      * }
      * ```
      * @since v12.8.0
@@ -963,8 +962,6 @@ declare module "node:v8" {
      * For example, if the `entry.js` contains the following script:
      *
      * ```js
-     * 'use strict';
-     *
      * import fs from 'node:fs';
      * import zlib from 'node:zlib';
      * import path from 'node:path';


### PR DESCRIPTION
- **crypto:** align verifyOneShot accepted types
- **doc,sqlite:** document entryPoint argument for loadExtension
- **doc:** update http2's `push` and `trailers` events with `rawHeaders` param
- **fs:** add `Temporal.Instant` support to `Stats` and `BigIntStats`
- **http:** add writeInformation to send arbitrary 1xx status codes
- **quic:** complete the internal implementation of QUIC
- **stream:** validate fromWritable() options before cache
- **test_runner:** add tags option and tag-name filter

The QUIC changes are very sizeable, but the module is still not exposed in release builds so it probably doesn't need reviewing in absurd detail. The documentation is available at https://github.com/nodejs/node/blob/v26.2.0/doc/api/quic.md for info.