### PR TITLE
[chrome] fix chrome.identity.getAuthToken()

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -6366,8 +6366,11 @@ declare namespace chrome {
          * Can return its result via Promise since Chrome 105.
          */
         function getAuthToken(details?: TokenDetails): Promise<GetAuthTokenResult>;
-        function getAuthToken(details: TokenDetails, callback: (result: GetAuthTokenResult) => void): void;
-        function getAuthToken(callback: (result: GetAuthTokenResult) => void): void;
+        function getAuthToken(
+            details: TokenDetails | undefined,
+            callback: (token?: string, grantedScopes?: string[]) => void,
+        ): void;
+        function getAuthToken(callback: (token?: string, grantedScopes?: string[]) => void): void;
 
         /**
          * Retrieves email address and obfuscated gaia id of the user signed into a profile.

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -5947,13 +5947,13 @@ function testIdentity() {
 
     chrome.identity.getAuthToken(); // $ExpectType Promise<GetAuthTokenResult>
     chrome.identity.getAuthToken(tokenDetails); // $ExpectType Promise<GetAuthTokenResult>
-    chrome.identity.getAuthToken(result => { // $ExpectType void
-        result.token; // $ExpectType string | undefined
-        result.grantedScopes; // $ExpectType string[] | undefined
+    chrome.identity.getAuthToken((token, grantedScopes) => { // $ExpectType void
+        token; // $ExpectType string | undefined
+        grantedScopes; // $ExpectType string[] | undefined
     });
-    chrome.identity.getAuthToken(tokenDetails, result => { // $ExpectType void
-        result.token; // $ExpectType string | undefined
-        result.grantedScopes; // $ExpectType string[] | undefined
+    chrome.identity.getAuthToken(tokenDetails, (token, grantedScopes) => { // $ExpectType void
+        token; // $ExpectType string | undefined
+        grantedScopes; // $ExpectType string[] | undefined
     });
     // @ts-expect-error
     chrome.identity.getAuthToken(() => {}).then(() => {});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/api/identity#method-getAuthToken
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Notes :
- `callback` param return a function with 2 params


  <img width="1197" height="281" alt="image" src="https://github.com/user-attachments/assets/1deb8f21-fc82-4055-ab55-bc5620fe40a5" />
- allow explicite `undefined` for tokenDetails (tsconfig: `exactOptionalPropertyTypes`)


close https://github.com/DefinitelyTyped/DefinitelyTyped/issues/75310
