### PR TITLE
[chrome] fix chrome.system.display.setMirrorMode()

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -10824,15 +10824,10 @@ declare namespace chrome {
 
         interface MirrorModeInfo {
             /** The mirror mode that should be set. */
-            mode?: `${MirrorMode}`;
-        }
-
-        interface MirrorModeInfoMixed extends MirrorModeInfo {
-            /** The mirror mode that should be set. */
-            mode: "mixed";
-            /** The id of the mirroring source display. */
+            mode: `${MirrorMode}`;
+            /** The id of the mirroring source display. This is only valid for 'mixed'. */
             mirroringSourceId?: string | undefined;
-            /** The ids of the mirroring destination displays. */
+            /** The ids of the mirroring destination displays. This is only valid for 'mixed'. */
             mirroringDestinationIds?: string[] | undefined;
         }
 
@@ -10973,8 +10968,8 @@ declare namespace chrome {
          * @param info The information of the mirror mode that should be applied to the display mode.
          * @since Chrome 65
          */
-        function setMirrorMode(info: MirrorModeInfo | MirrorModeInfoMixed, callback: () => void): void;
-        function setMirrorMode(info: MirrorModeInfo | MirrorModeInfoMixed): Promise<void>;
+        function setMirrorMode(info: MirrorModeInfo, callback: () => void): void;
+        function setMirrorMode(info: MirrorModeInfo): Promise<void>;
 
         /** Fired when anything changes to the display configuration. */
         const onDisplayChanged: chrome.events.Event<() => void>;

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -3309,7 +3309,7 @@ async function testSystemDisplay() {
         layouts; // $ExpectType DisplayLayout[]
     });
     // @ts-expect-error
-    chrome.printing.getPrinterInfo(() => {}).then(() => {});
+    chrome.system.display.getDisplayLayout(() => {}).then(() => {});
 
     const flags = { singleUnified: true };
     chrome.system.display.getInfo(); // $ExpectType Promise<DisplayUnitInfo[]>
@@ -3358,9 +3358,11 @@ async function testSystemDisplay() {
     // @ts-expect-error
     chrome.system.display.setDisplayProperties("id", displayProperties, () => {}).then(() => {});
 
-    const mirrorModeInfo = {
-        mode: "off",
-    } as const;
+    const mirrorModeInfo: chrome.system.display.MirrorModeInfo = {
+        mode: "mixed",
+        mirroringDestinationIds: ["id"],
+        mirroringSourceId: "id",
+    };
     chrome.system.display.setMirrorMode(mirrorModeInfo); // $ExpectType Promise<void>
     chrome.system.display.setMirrorMode(mirrorModeInfo, () => {}); // $ExpectType void
     // @ts-expect-error


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/api/system/display#type-MirrorModeInfo
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Notes:
- `mode` key is required

  <img width="955" height="147" alt="image" src="https://github.com/user-attachments/assets/8774a414-5d8a-4062-805e-c147da3c4cae" />
  
 - merge `MirrorModeInfoMixed` in `MirrorModeInfo` 
