### PR TITLE
[chrome] fix chrome.tabs.insertCSS()

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -11145,7 +11145,7 @@ declare namespace chrome {
              * The last time the tab became active in its window as the number of milliseconds since epoch.
              * @since Chrome 121
              */
-            lastAccessed?: number | undefined;
+            lastAccessed: number;
         }
 
         /** The tab's loading status. */
@@ -11715,8 +11715,11 @@ declare namespace chrome {
         function insertCSS(details: extensionTypes.InjectDetails): Promise<void>;
         function insertCSS(tabId: number | undefined, details: extensionTypes.InjectDetails): Promise<void>;
         function insertCSS(details: extensionTypes.InjectDetails, callback: () => void): void;
-        function insertCSS(tabId: number | undefined, details: extensionTypes.InjectDetails): Promise<void>;
-        function insertCSS(tabId: number, details: extensionTypes.InjectDetails, callback: () => void): void;
+        function insertCSS(
+            tabId: number | undefined,
+            details: extensionTypes.InjectDetails,
+            callback: () => void,
+        ): void;
 
         /**
          * Highlights the given tabs and focuses on the first of group. Will appear to do nothing if the specified tab is currently active.

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -3760,8 +3760,10 @@ async function testTabs() {
 
     chrome.tabs.insertCSS(details); // $ExpectType Promise<void>
     chrome.tabs.insertCSS(tabId, details); // $ExpectType Promise<void>
+    chrome.tabs.insertCSS(undefined, details); // $ExpectType Promise<void>
     chrome.tabs.insertCSS(details, () => {}); // $ExpectType void
     chrome.tabs.insertCSS(tabId, details, () => {}); // $ExpectType void
+    chrome.tabs.insertCSS(undefined, details, () => {}); // $ExpectType void
     // @ts-expect-error
     chrome.tabs.insertCSS(() => {}).then(() => {});
 
@@ -8211,6 +8213,7 @@ function testDesktopCapture() {
         selected: false,
         discarded: false,
         autoDiscardable: false,
+        lastAccessed: 0,
         groupId: 0,
     };
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/api/tabs
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Notes:
- update `chrome.tabs.insertCSS`: allow explicite `undefined` for `tabId`

  <img width="886" height="62" alt="image" src="https://github.com/user-attachments/assets/62afda46-8946-4b36-a6c1-e48407f06a17" />
