### PR TITLE
[chrome] fix chrome.alarms.AlarmCreateInfo()

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -407,7 +407,7 @@ declare namespace chrome {
                     /** If set, the onAlarm event should fire every `periodInMinutes` minutes after the initial event specified by `when` or `delayInMinutes`. If not set, the alarm will only fire once. */
                     periodInMinutes?: number | undefined;
                     /** Time at which the alarm should fire, in milliseconds past the epoch (e.g. `Date.now() + n`). */
-                    when?: never | undefined;
+                    when?: undefined;
                 }
                 | {
                     /** Length of time in minutes after which the {@link onAlarm} event should fire.  */
@@ -415,11 +415,11 @@ declare namespace chrome {
                     /** If set, the onAlarm event should fire every `periodInMinutes` minutes after the initial event specified by `when` or `delayInMinutes`. If not set, the alarm will only fire once. */
                     periodInMinutes: number;
                     /** Time at which the alarm should fire, in milliseconds past the epoch (e.g. `Date.now() + n`). */
-                    when?: number | undefined;
+                    when?: undefined;
                 }
                 | {
                     /** Length of time in minutes after which the {@link onAlarm} event should fire.  */
-                    delayInMinutes?: never | undefined;
+                    delayInMinutes?: undefined;
                     /** If set, the onAlarm event should fire every `periodInMinutes` minutes after the initial event specified by `when` or `delayInMinutes`. If not set, the alarm will only fire once. */
                     periodInMinutes?: number | undefined;
                     /** Time at which the alarm should fire, in milliseconds past the epoch (e.g. `Date.now() + n`). */

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -2670,7 +2670,6 @@ async function testAlarms() {
     const alarmCreateInfo: chrome.alarms.AlarmCreateInfo = {
         delayInMinutes: 1,
         periodInMinutes: 1,
-        when: 1,
         persistAcrossSessions: true,
     };
 
@@ -2681,7 +2680,7 @@ async function testAlarms() {
     // @ts-expect-error Must set at least one of when, delayInMinutes, or periodInMinutes.
     chrome.alarms.create("name", { persistAcrossSessions: true }, () => {});
     // @ts-expect-error Cannot set both when and delayInMinutes.
-    chrome.alarms.create("name", { when: 1, delayInMinutes: 1 }, () => {});
+    chrome.alarms.create("name", { when: 1, delayInMinutes: 1, periodInMinutes: 1 }, () => {});
     // @ts-expect-error
     chrome.alarms.create("name", alarmCreateInfo, () => {}).then(() => {});
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/api/alarms#type-AlarmCreateInfo
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Notes:
- fix `chrome.alarms.AlarmCreateInfo`: cannot use both `delayInMinutes`, `when` and `periodInMinutes`  

  <img width="795" height="60" alt="image" src="https://github.com/user-attachments/assets/07ba7d30-4e02-4663-982f-27cce005aab5" />
