### PR TITLE
[office-js][office-js-preview] (WXP) Document the property to configure visibility on a custom tab

### DIFF
--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -4961,9 +4961,19 @@ declare namespace Office {
          */
         id: string;
         /**
-         * Indicates whether the control should be enabled or disabled. The default is true.
+         * Indicates whether the control should be enabled or disabled. The default is `true`.
          */
         enabled?: boolean;
+        /**
+         * Specifies whether the control is shown or hidden on a custom tab. The default is `true`.
+         *
+         * @remarks
+         *
+          * **Requirement set**: {@link https://learn.microsoft.com/javascript/api/requirement-sets/common/ribbon-api-requirement-sets | RibbonApi 1.3}
+          *
+          * **Important**: The visibility of buttons and menu controls can be configured, but the visibility of individual items within a menu can't be configured.
+         */
+        visible?: boolean;
     }
     /**
      * Represents an XML node in a tree in a document.
@@ -7503,6 +7513,14 @@ declare namespace Office {
           * When the `Group` object is part of an {@link Office.RibbonUpdaterData} object passed to the `requestUpdate` method of {@link Office.Ribbon}, the `controls` properties of the various {@link Office.Group} objects specify which controls have their enabled status changed; the `controls` property of the `Group` object's parent `Tab` object is ignored. 
           */
          controls?: Control[];
+         /**
+          * Specifies whether the group of controls is shown or hidden on a custom tab.
+          *
+          * @remarks
+          *
+          * **Requirement set**: {@link https://learn.microsoft.com/javascript/api/requirement-sets/common/ribbon-api-requirement-sets | RibbonApi 1.3}
+          */
+         visible?: boolean;
     }
     /**
      * Represents a binding in two dimensions of rows and columns.

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -4961,9 +4961,19 @@ declare namespace Office {
          */
         id: string;
         /**
-         * Indicates whether the control should be enabled or disabled. The default is true.
+         * Indicates whether the control should be enabled or disabled. The default is `true`.
          */
         enabled?: boolean;
+        /**
+         * Specifies whether the control is shown or hidden on a custom tab. The default is `true`.
+         *
+         * @remarks
+         *
+          * **Requirement set**: {@link https://learn.microsoft.com/javascript/api/requirement-sets/common/ribbon-api-requirement-sets | RibbonApi 1.3}
+          *
+          * **Important**: The visibility of buttons and menu controls can be configured, but the visibility of individual items within a menu can't be configured.
+         */
+        visible?: boolean;
     }
     /**
      * Represents an XML node in a tree in a document.
@@ -7503,6 +7513,14 @@ declare namespace Office {
           * When the `Group` object is part of an {@link Office.RibbonUpdaterData} object passed to the `requestUpdate` method of {@link Office.Ribbon}, the `controls` properties of the various {@link Office.Group} objects specify which controls have their enabled status changed; the `controls` property of the `Group` object's parent `Tab` object is ignored. 
           */
          controls?: Control[];
+         /**
+          * Specifies whether the group of controls is shown or hidden on a custom tab.
+          *
+          * @remarks
+          *
+          * **Requirement set**: {@link https://learn.microsoft.com/javascript/api/requirement-sets/common/ribbon-api-requirement-sets | RibbonApi 1.3}
+          */
+         visible?: boolean;
     }
     /**
      * Represents a binding in two dimensions of rows and columns.


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: None
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.