### PR TITLE
[react-dom] Add `browser()`

### DIFF
--- a/types/react-dom/canary.d.ts
+++ b/types/react-dom/canary.d.ts
@@ -44,7 +44,7 @@ declare module "." {
 }
 
 declare module "react" {
-    interface RendererUsable {
+    interface RendererUsable<T> {
         "react-dom/browser": BrowserUsable;
     }
 

--- a/types/react-dom/canary.d.ts
+++ b/types/react-dom/canary.d.ts
@@ -33,7 +33,21 @@ import ReactDOM = require(".");
 
 export {};
 
+declare const browserUsable: unique symbol;
+
+export interface BrowserUsable {
+    readonly [browserUsable]: never;
+}
+
+declare module "." {
+    export function browser(): BrowserUsable;
+}
+
 declare module "react" {
+    interface RendererUsable {
+        "react-dom/browser": BrowserUsable;
+    }
+
     // @enableViewTransition
     interface ViewTransitionPseudoElement extends Animatable {
         getComputedStyle: () => CSSStyleDeclaration;

--- a/types/react-dom/canary.d.ts
+++ b/types/react-dom/canary.d.ts
@@ -40,7 +40,7 @@ export interface BrowserUsable {
 }
 
 declare module "." {
-    export function browser(): BrowserUsable;
+    function browser(): BrowserUsable;
 }
 
 declare module "react" {

--- a/types/react-dom/test/canary-tests.tsx
+++ b/types/react-dom/test/canary-tests.tsx
@@ -108,3 +108,9 @@ function formrelatedEventTests() {
         }}
     />;
 }
+
+function browserUsableTests() {
+    // browser() returns an opaque, renderer-specific Usable that React.use accepts
+    // $ExpectType unknown
+    React.use(ReactDOM.browser());
+}

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1959,7 +1959,16 @@ declare namespace React {
         | FulfilledReactPromise<T>
         | RejectedReactPromise<T>;
 
-    export type Usable<T> = ReactPromise<T> | Context<T>;
+    /**
+     * A registry of renderer-specific {@link Usable} types.
+     *
+     * Renderers (e.g. `react-dom`) augment this interface via `declare module "react"`,
+     * adding an entry keyed by a renderer-specific string whose type becomes a valid
+     * argument to {@link use}. Only renderers should augment this interface.
+     */
+    export interface RendererUsable {}
+
+    export type Usable<T> = ReactPromise<T> | Context<T> | RendererUsable[keyof RendererUsable];
 
     export function use<T>(usable: Usable<T>): T;
 

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1966,9 +1966,9 @@ declare namespace React {
      * adding an entry keyed by a renderer-specific string whose type becomes a valid
      * argument to {@link use}. Only renderers should augment this interface.
      */
-    export interface RendererUsable {}
+    export interface RendererUsable<T> {}
 
-    export type Usable<T> = ReactPromise<T> | Context<T> | RendererUsable[keyof RendererUsable];
+    export type Usable<T> = ReactPromise<T> | Context<T> | RendererUsable<T>[keyof RendererUsable<T>];
 
     export function use<T>(usable: Usable<T>): T;
 

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -1958,7 +1958,16 @@ declare namespace React {
         | FulfilledReactPromise<T>
         | RejectedReactPromise<T>;
 
-    export type Usable<T> = ReactPromise<T> | Context<T>;
+    /**
+     * A registry of renderer-specific {@link Usable} types.
+     *
+     * Renderers (e.g. `react-dom`) augment this interface via `declare module "react"`,
+     * adding an entry keyed by a renderer-specific string whose type becomes a valid
+     * argument to {@link use}. Only renderers should augment this interface.
+     */
+    export interface RendererUsable {}
+
+    export type Usable<T> = ReactPromise<T> | Context<T> | RendererUsable[keyof RendererUsable];
 
     export function use<T>(usable: Usable<T>): T;
 

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -1965,9 +1965,9 @@ declare namespace React {
      * adding an entry keyed by a renderer-specific string whose type becomes a valid
      * argument to {@link use}. Only renderers should augment this interface.
      */
-    export interface RendererUsable {}
+    export interface RendererUsable<T> {}
 
-    export type Usable<T> = ReactPromise<T> | Context<T> | RendererUsable[keyof RendererUsable];
+    export type Usable<T> = ReactPromise<T> | Context<T> | RendererUsable<T>[keyof RendererUsable<T>];
 
     export function use<T>(usable: Usable<T>): T;
 


### PR DESCRIPTION
Types for https://github.com/react/react/pull/37143

Adds a `RendererUsable<T>` to the React module that can be augmented by renderers to allow  renderer specific Usables. 

`react-dom` augments `RendererUsable` with the return type of `browser()`