### PR TITLE
[chrome] update since Chrome 151

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -2831,11 +2831,28 @@ declare namespace chrome {
      * Manifest: "devtools_page"
      */
     export namespace devtools.inspectedWindow {
+        interface SetContentResult {
+            code: string;
+            description: string;
+            details: string[];
+            isError?: boolean;
+        }
+
         /** A resource within the inspected page, such as a document, a script, or an image. */
         interface Resource {
             /** The URL of the resource. */
             url: string;
-            /** Gets the content of the resource. */
+            /**
+             * Gets the content of the resource.
+             *
+             * Can return its result via Promise in Manifest V3 or later since Chrome 151.
+             */
+            getContent(): Promise<{
+                /** Content of the resource (potentially encoded). */
+                content: string;
+                /** Empty if the content is not encoded, encoding name otherwise. Currently, only base64 is supported.*/
+                encoding: string;
+            }>;
             getContent(
                 callback: (
                     /** Content of the resource (potentially encoded). */
@@ -2848,14 +2865,17 @@ declare namespace chrome {
              * Sets the content of the resource.
              * @param content New content of the resource. Only resources with the text type are currently supported.
              * @param commit True if the user has finished editing the resource, and the new content of the resource should be persisted; false if this is a minor change sent in progress of the user editing the resource.
+             *
+             * Can return its result via Promise in Manifest V3 or later since Chrome 151.
              */
             setContent(
                 content: string,
                 commit: boolean,
-                callback?: (
-                    /** Set to undefined if the resource content was set successfully; describes error otherwise. */
-                    error?: object,
-                ) => void,
+            ): Promise<undefined>;
+            setContent(
+                content: string,
+                commit: boolean,
+                callback: (result: SetContentResult) => void,
             ): void;
         }
 
@@ -2895,7 +2915,13 @@ declare namespace chrome {
          * @param expression An expression to evaluate.
          * @param options The options parameter can contain one or more options.
          * @param callback A function called when evaluation completes.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 151.
          */
+        function eval<T = { [key: string]: unknown }>(
+            expression: string,
+            options?: EvalOptions,
+        ): Promise<{ result: T; exceptionInfo: EvaluationExceptionInfo }>;
         function eval<T = { [key: string]: unknown }>(
             expression: string,
             callback?: (result: T, exceptionInfo: EvaluationExceptionInfo) => void,
@@ -2906,7 +2932,12 @@ declare namespace chrome {
             callback?: (result: T, exceptionInfo: EvaluationExceptionInfo) => void,
         ): void;
 
-        /** Retrieves the list of resources from the inspected page. */
+        /**
+         * Retrieves the list of resources from the inspected page.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 151.
+         */
+        function getResources(): Promise<Resource[]>;
         function getResources(callback: (resources: Resource[]) => void): void;
 
         /** Fired when a new resource is added to the inspected page. */

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -8549,6 +8549,17 @@ declare namespace chrome {
      */
     export namespace privacy {
         /**
+         * Categories of Autofill data.
+         * @since Chrome 151
+         */
+        enum AutofillBlockedType {
+            CONTACT_INFO = "contact_info",
+            PAYMENTS = "payments",
+            IDENTITY_DOCS = "identity_docs",
+            TRAVEL = "travel",
+        }
+
+        /**
          * The IP handling policy of WebRTC.
          * @since Chrome 48
          */

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -7462,6 +7462,66 @@ declare namespace chrome {
     }
 
     ////////////////////
+    // MimeHandler
+    ////////////////////
+    /**
+     * Use the `chrome.mimeHandler` API to handle MIME type streams in third-party extensions.
+     * @since Chrome 151, MV3
+     */
+    export namespace mimeHandler {
+        interface MimeHandlerOptions {
+            /** Whether this handler is active for the given MIME type. */
+            enabled: boolean;
+        }
+
+        interface StreamInfo {
+            /** True if loaded in an embedded context (iframe/embed/object). */
+            embedded: boolean;
+            /** The MIME type of the intercepted content. */
+            mimeType: string;
+            /** The original URL the user navigated to. */
+            originalUrl: string;
+            /** HTTP response headers as key-value pairs. */
+            responseHeaders: { [key: string]: unknown };
+            /** The URL to fetch the stream data from. */
+            streamUrl: string;
+            /** The tab ID containing the document. */
+            tabId: number;
+        }
+
+        /**
+         * Aborts current stream handling and hands the content off to the user agent's native handler. After this call the extension frame will be torn down; callers should not expect further execution.
+         *
+         * Can return its result via Promise
+         */
+        function abortAndFallbackToNativeHandler(): Promise<void>;
+        function abortAndFallbackToNativeHandler(callback: () => void): void;
+
+        /**
+         * Reads the persisted options for a MIME type. Returns defaults (enabled=true) if none have been stored.
+         * @param mimeType The MIME type whose options to read.
+         *
+         * Can return its result via Promise
+         */
+        function getMimeHandlerOptions(mimeType: string): Promise<MimeHandlerOptions>;
+        function getMimeHandlerOptions(mimeType: string, callback: (options: MimeHandlerOptions) => void): void;
+
+        /** Retrieves stream information for the current MIME handler context. Must be called from within a MIME handler extension page. */
+        function getStreamInfo(): Promise<StreamInfo>;
+        function getStreamInfo(callback: (info: StreamInfo) => void): void;
+
+        /**
+         * Sets the configuration options for a specified MIME type.
+         * @param mimeType The MIME type to configure.
+         * @param options The new options to use.
+         *
+         * Can return its result via Promise
+         */
+        function setMimeHandlerOptions(mimeType: string, options: MimeHandlerOptions): Promise<void>;
+        function setMimeHandlerOptions(mimeType: string, options: MimeHandlerOptions, callback: () => void): void;
+    }
+
+    ////////////////////
     // Notifications
     ////////////////////
     /**
@@ -9666,6 +9726,18 @@ declare namespace chrome {
                 /** Indicates whether the extension's options page will be opened in a new tab. If set to `false`, the extension's options page is embedded in `chrome://extensions` rather than opened in a new tab. */
                 open_in_tab?: boolean | undefined;
             } | undefined;
+            /**
+             * Maps MIME types to the extension pages that render them. As of Chrome 151, `application/pdf` is the only MIME type available to public handlers. Declaring an unsupported MIME type causes an installation warning.
+             * @since Chrome 151
+             */
+            mime_types_handler?: {
+                "application/pdf": {
+                    /** The HTML file to display when a document of the corresponding MIME type is opened. This file must be located within your extension. */
+                    handler_url: string;
+                    /** Specifies whether to handle documents embedded in `<embed>`, `<object>`, or `<iframe>` elements. Defaults to `false`, meaning the handler only receives top-level navigations. */
+                    can_embed?: boolean;
+                };
+            };
             /** Declares optional permissions for your extension. */
             optional_permissions?: ManifestOptionalPermission[] | undefined;
             /** Declares optional host permissions for your extension. */

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -2970,7 +2970,17 @@ declare namespace chrome {
     export namespace devtools.network {
         /** Represents a network request for a document resource (script, image and so on). See HAR Specification for reference. */
         interface Request extends HARFormatEntry {
-            /** Returns content of the response body. */
+            /**
+             * Returns content of the response body.
+             *
+             * Can return its result via Promise in Manifest V3 or later since Chrome 151.
+             */
+            getContent(): Promise<{
+                /** Content of the response body (potentially encoded). */
+                content: string;
+                /** Empty if content is not encoded, encoding name otherwise. Currently, only base64 is supported. */
+                encoding: string;
+            }>;
             getContent(
                 callback: (
                     /** Content of the response body (potentially encoded). */
@@ -2981,7 +2991,12 @@ declare namespace chrome {
             ): void;
         }
 
-        /** Returns HAR log that contains all known network requests. */
+        /**
+         * Returns HAR log that contains all known network requests.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 151.
+         */
+        function getHAR(): Promise<HARFormatLog>;
         function getHAR(
             callback: (
                 /** A HAR log. See HAR specification for details. */

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -7767,6 +7767,11 @@ function testAccessibilityFeatures() {
 
 // https://developer.chrome.com/docs/extensions/reference/api/privacy
 function testPrivacy() {
+    chrome.privacy.AutofillBlockedType.CONTACT_INFO === "contact_info";
+    chrome.privacy.AutofillBlockedType.PAYMENTS === "payments";
+    chrome.privacy.AutofillBlockedType.IDENTITY_DOCS === "identity_docs";
+    chrome.privacy.AutofillBlockedType.TRAVEL === "travel";
+
     chrome.privacy.IPHandlingPolicy.DEFAULT === "default";
     chrome.privacy.IPHandlingPolicy.DEFAULT_PUBLIC_AND_PRIVATE_INTERFACES === "default_public_and_private_interfaces";
     chrome.privacy.IPHandlingPolicy.DEFAULT_PUBLIC_INTERFACE_ONLY === "default_public_interface_only";

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -2007,7 +2007,6 @@ function testDevtoolsInspectedWindow() {
         });
         // @ts-expect-error
         resource.setContent(() => {}).then(() => {});
-
     });
     // @ts-expect-error
     chrome.devtools.inspectedWindow.getResources(() => {}).then(() => {});
@@ -2039,9 +2038,12 @@ function testDevtoolsPerformance() {
 
 // https://developer.chrome.com/docs/extensions/reference/api/devtools/network
 function testDevtoolsNetwork() {
+    chrome.devtools.network.getHAR(); // $ExpectType Promise<Log>
     chrome.devtools.network.getHAR((harLog) => { // $ExpectType void
         harLog; // $ExpectType Log
     });
+    // @ts-expect-error
+    chrome.devtools.network.getHAR(() => {}).then(() => {});
 
     checkChromeEvent(chrome.devtools.network.onNavigated, (url) => {
         url; // $ExpectType string
@@ -2049,6 +2051,14 @@ function testDevtoolsNetwork() {
 
     checkChromeEvent(chrome.devtools.network.onRequestFinished, (request) => {
         request; // $ExpectType Request
+
+        request.getContent(); // $ExpectType Promise<{ content: string; encoding: string }>
+        request.getContent((content, encoding) => { // $ExpectType void
+            content; // $ExpectType string
+            encoding; // $ExpectType string
+        });
+        // @ts-expect-error
+        request.getContent(() => {}).then(() => {});
     });
 }
 

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1966,8 +1966,8 @@ function testDevtoolsInspectedWindow() {
         useContentScriptContext: true,
     };
 
-    chrome.devtools.inspectedWindow.eval(expression); // $ExpectType void
-    chrome.devtools.inspectedWindow.eval(expression, evalOptions); // $ExpectType void
+    chrome.devtools.inspectedWindow.eval(expression); // $ExpectType Promise<{ result: { [key: string]: unknown; }; exceptionInfo: EvaluationExceptionInfo}>
+    chrome.devtools.inspectedWindow.eval(expression, evalOptions); // $ExpectType Promise<{ result: { [key: string]: unknown; }; exceptionInfo: EvaluationExceptionInfo}>
     chrome.devtools.inspectedWindow.eval(expression, evalOptions, (result, exceptionInfo) => { // $ExpectType void
         result; // $ExpectType { [key: string]: unknown; }
 
@@ -1978,16 +1978,39 @@ function testDevtoolsInspectedWindow() {
         exceptionInfo.isException; // $ExpectType boolean
         exceptionInfo.value; // $ExpectType string
     });
-    chrome.devtools.inspectedWindow.eval(expression, (result) => { // $ExpectType void
+    chrome.devtools.inspectedWindow.eval(expression, (result, exceptionInfo) => { // $ExpectType void
         result; // $ExpectType { [key: string]: unknown; }
     });
     chrome.devtools.inspectedWindow.eval<{ title: string }>(expression, evalOptions, (result) => { // $ExpectType void
         result.title; // $ExpectType string
     });
 
-    chrome.devtools.inspectedWindow.getResources((resources) => { // $ExpectType void
-        resources; // $ExpectType Resource[]
+    chrome.devtools.inspectedWindow.getResources(); // $ExpectType Promise<Resource[]>
+    chrome.devtools.inspectedWindow.getResources(([resource]) => { // $ExpectType void
+        resource; // $ExpectType Resource
+        resource.url; // $ExpectType string
+
+        resource.getContent(); // $ExpectType  Promise<{ content: string; encoding: string}>
+        resource.getContent((content, string) => { // $ExpectType void
+            content; // $ExpectType string
+            string; // $ExpectType string
+        });
+        // @ts-expect-error
+        resource.getContent(() => {}).then(() => {});
+
+        resource.setContent("content", false); // Promise<undefined>
+        resource.setContent("content", false, ({ code, description, details, isError }) => { // $ExpectType void
+            code; // $ExpectType string
+            description; // $ExpectType string
+            details; // $ExpectType string[]
+            isError; // $ExpectType boolean | undefined
+        });
+        // @ts-expect-error
+        resource.setContent(() => {}).then(() => {});
+
     });
+    // @ts-expect-error
+    chrome.devtools.inspectedWindow.getResources(() => {}).then(() => {});
 
     const reloadOptions: chrome.devtools.inspectedWindow.ReloadOptions = {
         ignoreCache: true,

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -3100,6 +3100,42 @@ async function testManagement() {
     });
 }
 
+// https://developer.chrome.com/docs/extensions/reference/api/mimeHandler
+async function testMineHandler() {
+    const mimeType = "image/jpeg";
+
+    chrome.mimeHandler.abortAndFallbackToNativeHandler(); // $ExpectType Promise<void>
+    chrome.mimeHandler.abortAndFallbackToNativeHandler(() => void 0); // $ExpectType void
+    // @ts-expect-error
+    chrome.mimeHandler.abortAndFallbackToNativeHandler(() => {}).then(() => {});
+
+    chrome.mimeHandler.getMimeHandlerOptions(mimeType); // $ExpectType Promise<MimeHandlerOptions>
+    chrome.mimeHandler.getMimeHandlerOptions(mimeType, (options) => { // $ExpectType void
+        options; // $ExpectType MimeHandlerOptions
+        options.enabled; // $ExpectType boolean
+    });
+    // @ts-expect-error
+    chrome.mimeHandler.getMimeHandlerOptions(mimeType, () => {}).then(() => {});
+
+    chrome.mimeHandler.getStreamInfo(); // $ExpectType Promise<StreamInfo>
+    chrome.mimeHandler.getStreamInfo((info) => { // $ExpectType void
+        info; // $ExpectType StreamInfo
+        info.embedded; // $ExpectType boolean
+        info.mimeType; // $ExpectType string
+        info.originalUrl; // $ExpectType string
+        info.responseHeaders; // $ExpectType { [key: string]: unknown }
+        info.streamUrl; // $ExpectType string
+        info.tabId; // $ExpectType number
+    });
+    // @ts-expect-error
+    chrome.mimeHandler.getStreamInfo(() => {}).then(() => {});
+
+    chrome.mimeHandler.setMimeHandlerOptions(mimeType, { enabled: true }); // $ExpectType Promise<void>
+    chrome.mimeHandler.setMimeHandlerOptions(mimeType, { enabled: true }, () => void 0); // $ExpectType void
+    // @ts-expect-error
+    chrome.mimeHandler.setMimeHandlerOptions(mimeType, { enabled: true }, () => {}).then(() => {});
+}
+
 // https://developer.chrome.com/docs/extensions/reference/api/scripting
 async function testScripting() {
     chrome.scripting.ExecutionWorld.ISOLATED === "ISOLATED";


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://developer.chrome.com/docs/extensions/reference/api/devtools/inspectedWindow
  - https://developer.chrome.com/docs/extensions/reference/api/devtools/network
  - https://developer.chrome.com/docs/extensions/reference/api/privacy#type-AutofillBlockedType
  - https://developer.chrome.com/docs/extensions/reference/api/mimeHandler
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Notes:
- add `chrome.mimeHandler` namespace
 
  <img width="832" height="502" alt="image" src="https://github.com/user-attachments/assets/fe338e88-73ec-4604-b7f5-78682ce32b3a" />

- udpate `chrome.devtools.inspectedWindow.getResources()`: can return a promise

  <img width="902" height="75" alt="image" src="https://github.com/user-attachments/assets/bbfd2dbf-9de8-4d4a-b2e1-aebe2f499dc9" />
- udpate `chrome.devtools.inspectedWindow.Resource.getContent()`: can return a promise

  <img width="655" height="120" alt="image" src="https://github.com/user-attachments/assets/551f42b7-6084-4fbb-b1c5-72abc5dec33f" />
- udpate `chrome.devtools.inspectedWindow.Resource.setContent()`: can return a promise

  <img width="847" height="115" alt="image" src="https://github.com/user-attachments/assets/a4b055e7-8247-4387-a1ef-598bfc0127d0" />

- udpate `chrome.devtools.inspectedWindow.eval()`: can return a promise

  <img width="910" height="127" alt="image" src="https://github.com/user-attachments/assets/5a931fb9-7370-4331-b050-233e68d56e14" />

- udpate `chrome.devtools.network.getHAR()`: can return a promise

  <img width="681" height="62" alt="image" src="https://github.com/user-attachments/assets/4ac1cffb-2fa5-45fd-8783-9470c9f7f1ad" />

- udpate `chrome.devtools.network.Request.getContent()`: can return a promise (on `chrome.devtools.network.onRequestFinished.addListener()`)

- add `chrome.privacy.AutofillBlockedType` enum

  <img width="800" height="177" alt="image" src="https://github.com/user-attachments/assets/0ef7fd98-7380-49fe-bb72-67cd88a7aa25" />
