### PR TITLE
ci: add names to matrix and ghostbust steps for readability

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,7 +41,8 @@ jobs:
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
-      - id: matrix
+      - name: Build CI test matrix
+        id: matrix
         run: |
           if [ "${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}" == "true" ]; then
             TESTS=all

--- a/.github/workflows/ghostbuster.yml
+++ b/.github/workflows/ghostbuster.yml
@@ -29,7 +29,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - if: ${{ inputs.skipPR == 'true' }}
+      - name: Commit and push ghostbust changes
+        if: ${{ inputs.skipPR == 'true' }}
         run: |
           if [ -n "`git status -s`" ]; then
             git config --global user.email "290192711+typescript-automation[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Problem

Some workflow `run` steps are unnamed and longer than **300 characters**. In the GitHub Actions UI those steps collapse into generic labels, which hurts readability when matrix setup or ghostbust commits fail.

## Changes

Semantics are unchanged: same step `id`s / `if` conditions, same scripts, and the same output wiring.

### `.github/workflows/CI.yml`
- Add `name: Build CI test matrix` to `id: matrix`

### `.github/workflows/ghostbuster.yml`
- Add `name: Commit and push ghostbust changes` to the existing skipPR push step

## Test plan
- [ ] Confirm `setup-matrix.outputs.matrix` still comes from `steps.matrix.outputs.matrix`
- [ ] Confirm the ghostbust skipPR commit/push script is unchanged
