### PR TITLE
ssh2: add missing term property to PseudoTtyInfo

### DIFF
--- a/types/ssh2/index.d.ts
+++ b/types/ssh2/index.d.ts
@@ -1487,6 +1487,8 @@ export interface Session extends ServerChannel {
 }
 
 export interface PseudoTtyInfo {
+    /** The value of the TERM environment variable requested for the pseudo-TTY (defaults to "vt100" if the client did not specify one). */
+    term: string;
     /** The number of columns for the pseudo-TTY. */
     cols: number;
     /** The number of rows for the pseudo-TTY. */

--- a/types/ssh2/ssh2-tests.ts
+++ b/types/ssh2/ssh2-tests.ts
@@ -407,6 +407,14 @@ new ssh2.Server({
                 stream.exit(0);
                 stream.end();
             });
+            session.once("pty", (accept, reject, info) => {
+                info.term; // $ExpectType string
+                info.cols; // $ExpectType number
+                info.rows; // $ExpectType number
+                info.width; // $ExpectType number
+                info.height; // $ExpectType number
+                accept?.();
+            });
         });
     }).on("end", () => {
         console.log("Client disconnected");


### PR DESCRIPTION
## Summary

`PseudoTtyInfo` (emitted on a `Session`'s `'pty'` event) is missing the `term` property.

ref:
https://github.com/mscdex/ssh2/blob/master/lib/protocol/handlers.misc.js#L1092-L1116

Added `$ExpectType` coverage in `ssh2-tests.ts` on the existing example server's `session.once("pty", ...)` handler (that block previously only exercised `"exec"`, nothing touched `pty`/`term` at all) so a future regression on any `PseudoTtyInfo` field gets caught.