### PR TITLE
[forge-apis] Add missing setDebug export

### DIFF
--- a/types/forge-apis/forge-apis-tests.ts
+++ b/types/forge-apis/forge-apis-tests.ts
@@ -11,9 +11,13 @@ import {
     ItemsApi,
     ObjectsApi,
     ProjectsApi,
+    setDebug,
     UserProfileApi,
     VersionsApi,
 } from "forge-apis";
+
+// $ExpectType void
+setDebug(true);
 
 const authToken: AuthToken = {
     access_token: "",

--- a/types/forge-apis/index.d.ts
+++ b/types/forge-apis/index.d.ts
@@ -16,6 +16,11 @@
 /// <reference types="node" />
 
 /**
+ * Optionally enable debugging, which sets `isDebugMode` on the shared `ApiClient` instance.
+ */
+export function setDebug(isDebug: boolean): void;
+
+/**
  * https://forge.autodesk.com/en/docs/oauth/v2/developers_guide/scopes
  */
 export type Scope =


### PR DESCRIPTION
`forge-apis` exports `setDebug` from its entry point, but `@types/forge-apis` never
declared it, so calling it fails to compile even though it works at runtime:

```ts
import { setDebug } from "forge-apis";
setDebug(true);
// error TS2305: Module '"forge-apis"' has no exported member 'setDebug'.
```

Upstream, in `src/index.js`:

```js
/**
 * Optionally enable debugging
 * @param isDebug
 */
setDebug: function (isDebug) {
    ApiClient.instance.isDebugMode = isDebug;
}
```

Added the declaration and a test line.

### Also missing, deliberately left out

The same entry point exports `ApiClient` and `IssuesApi`, neither of which is declared
here either. I left both out of this PR rather than guess: `IssuesApi` has 13 methods
(`GetIssues`, `PostIssue`, `GetComments`, `PostAttachments`, …) and `ApiClient` carries
configuration state, so both need signatures written against the upstream source rather
than a one-line addition. Happy to follow up with either if that would be useful.

### Verification

`tsc` over `index.d.ts` + `forge-apis-tests.ts` with the package's own compiler options
(`module: node16`, `strictNullChecks`, `strictFunctionTypes`, `noImplicitAny`) passes
clean. I could not run `dtslint` locally — it needs the full DT dev environment and I
worked from a sparse checkout — so CI is the real check on the lint rules.
