### PR TITLE
[jsdom] Update undici-types dependency to match upstream dependency

### DIFF
--- a/types/jsdom/package.json
+++ b/types/jsdom/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/jsdom",
-    "version": "28.0.9999",
+    "version": "30.0.9999",
     "projects": [
         "https://github.com/jsdom/jsdom"
     ],
@@ -14,7 +14,7 @@
         "@types/node": "*",
         "@types/tough-cookie": "*",
         "parse5": "^8.0.0",
-        "undici-types": "^7.21.0"
+        "undici-types": "^8.9.0"
     },
     "minimumTypeScriptVersion": "5.3",
     "devDependencies": {

--- a/types/karma-jsdom-launcher/package.json
+++ b/types/karma-jsdom-launcher/package.json
@@ -1,12 +1,12 @@
 {
     "private": true,
     "name": "@types/karma-jsdom-launcher",
-    "version": "8.0.9999",
+    "version": "21.0.9999",
     "projects": [
         "https://github.com/badeball/karma-jsdom-launcher#readme"
     ],
     "dependencies": {
-        "@types/jsdom": "*",
+        "@types/jsdom": ">=22 <=29",
         "@types/karma": "*"
     },
     "devDependencies": {


### PR DESCRIPTION
In the following commits, jsdom updated its undici dependency and is now on major version 8:

https://github.com/jsdom/jsdom/commit/0c51df6d80567202e969ba273c32db01de43c26e https://github.com/jsdom/jsdom/commit/f32245cfedf894b933bf4625b5649c284422da45

Match the dependency undici-types to the same version.

When updating the jsdom version, this resulted in a new test failure of karma-jsdom-launcher:

```
  15:21  error  TypeScript@5.6 compile error:
Type 'ProxyAgent' is not assignable to type 'Dispatcher'.
  Types of property 'dispatch' are incompatible.
    Type '(options: import("/home/jon/devel/DefinitelyTyped/DefinitelyTyped/types/karma-jsdom-launcher/node_modules/.pnpm/undici-types@7.29.0/node_modules/undici-types/agent").default.DispatchOptions, handler: import("/home/jon/devel/DefinitelyTyped/DefinitelyTyped/types/karma-jsdom-launcher/node_modules/.pnpm/undici-types@7....' is not assignable to type '(options: import("/home/jon/devel/DefinitelyTyped/DefinitelyTyped/types/jsdom/node_modules/.pnpm/undici-types@8.10.0/node_modules/undici-types/dispatcher").default.DispatchOptions, handler: import("/home/jon/devel/DefinitelyTyped/DefinitelyTyped/types/jsdom/node_modules/.pnpm/undici-types@8.10.0/node_modules/undici-...'.
      Types of parameters 'handler' and 'handler' are incompatible.
        Type 'import("/home/jon/devel/DefinitelyTyped/DefinitelyTyped/types/jsdom/node_modules/.pnpm/undici-types@8.10.0/node_modules/undici-types/dispatcher").default.DispatchHandler' is not assignable to type 'import("/home/jon/devel/DefinitelyTyped/DefinitelyTyped/types/karma-jsdom-launcher/node_modules/.pnpm/undici-types@7.29.0/node_modules/undici-types/dispatcher").default.DispatchHandler'.
          Types of property 'onBodySent' are incompatible.
            Type '((chunk: Buffer) => void) | undefined' is not assignable to type '((chunkSize: number, totalBytesSent: number) => void) | undefined'.
              Type '(chunk: Buffer) => void' is not assignable to type '(chunkSize: number, totalBytesSent: number) => void'.
                Types of parameters 'chunk' and 'chunkSize' are incompatible.
                  Type 'number' is not assignable to type 'Buffer'                                                                    @definitelytyped/expect
  15:21  error  TypeScript@5.7, 5.8, 5.9, 6.0 compile error:
Type 'ProxyAgent' is not assignable to type 'Dispatcher'.
  Types of property 'dispatch' are incompatible.
    Type '(options: import("/home/jon/devel/DefinitelyTyped/DefinitelyTyped/types/karma-jsdom-launcher/node_modules/.pnpm/undici-types@7.29.0/node_modules/undici-types/agent").default.DispatchOptions, handler: import("/home/jon/devel/DefinitelyTyped/DefinitelyTyped/types/karma-jsdom-launcher/node_modules/.pnpm/undici-types@7....' is not assignable to type '(options: import("/home/jon/devel/DefinitelyTyped/DefinitelyTyped/types/jsdom/node_modules/.pnpm/undici-types@8.10.0/node_modules/undici-types/dispatcher").default.DispatchOptions, handler: import("/home/jon/devel/DefinitelyTyped/DefinitelyTyped/types/jsdom/node_modules/.pnpm/undici-types@8.10.0/node_modules/undici-...'.
      Types of parameters 'handler' and 'handler' are incompatible.
        Type 'import("/home/jon/devel/DefinitelyTyped/DefinitelyTyped/types/jsdom/node_modules/.pnpm/undici-types@8.10.0/node_modules/undici-types/dispatcher").default.DispatchHandler' is not assignable to type 'import("/home/jon/devel/DefinitelyTyped/DefinitelyTyped/types/karma-jsdom-launcher/node_modules/.pnpm/undici-types@7.29.0/node_modules/undici-types/dispatcher").default.DispatchHandler'.
          Types of property 'onBodySent' are incompatible.
            Type '((chunk: Buffer<ArrayBufferLike>) => void) | undefined' is not assignable to type '((chunkSize: number, totalBytesSent: number) => void) | undefined'.
              Type '(chunk: Buffer<ArrayBufferLike>) => void' is not assignable to type '(chunkSize: number, totalBytesSent: number) => void'.
                Types of parameters 'chunk' and 'chunkSize' are incompatible.
                  Type 'number' is not assignable to type 'Buffer<ArrayBufferLike>'  @definitelytyped/expect
```

This failure has been resolved by pinning its jsdom dependency to match its upstream version:

https://github.com/badeball/karma-jsdom-launcher/commit/ebfcdfe6197cd00f6e9bef76166857a79381e39e

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
