### PR TITLE
[node] add name and fn to TestOptions

### DIFF
--- a/types/node/node-tests/test.ts
+++ b/types/node/node-tests/test.ts
@@ -104,6 +104,8 @@ test("options with values", {
     skip: "reason for skip",
     timeout: Infinity,
     todo: "reason for todo",
+    fn: () => {},
+    name: "options with values",
 });
 
 test("options with booleans", {

--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -1464,6 +1464,18 @@ declare module "node:test" {
              * @since v22.2.0
              */
             plan?: number | undefined;
+
+            /**
+             * The test function. If this option _and_ a test function are
+             * provided to {@link test}, this takes precedence.
+             */
+            fn?: TestFn | undefined;
+
+            /**
+             * The test name. If this option _and_ a test name are provided to
+             * {@link test}, this takes precedence.
+             */
+            name?: string | undefined;
         }
         /**
          * This function creates a hook that runs before executing a suite.


### PR DESCRIPTION
This formalizes `fn` and `name` as valid properties for `TestOptions`.

These were added to the documentation in commit https://github.com/nodejs/node/commit/63fbd59e64 and it can be seen [in the documentation](https://beta.docs.nodejs.org/test.html#testname-options-fn).

Ref: https://github.com/nodejs/node/pull/64946

* * *

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

> [!NOTE]
> Running `pnpm test node` fails:
> ```
> Error:
> /Users/boneskull/projects/definitelytyped/definitelytyped/types/node/ts5.6/index.d.ts
>  29:21  error  TypeScript@5.1 tsconfig.dom.json, 5.1 tsconfig.non-dom.json, 5.1 tsconfig.webworker.json compile error:
> Cannot find lib definition for 'esnext.disposable'  @definitelytyped/expect
> ```
>
> and an "Incorrect .npmignore" error.
>
> I don't think this is related to my changes, but may have something to do with my working copy state? FWIW, I've _never_ been able to get DT's tests running properly.

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://beta.docs.nodejs.org/test.html#testname-options-fn
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

