### PR TITLE
[chrome] add chrome.tab.removeCSS() (MV2 only)

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -4743,6 +4743,25 @@ declare namespace chrome {
         type CSSOrigin = "author" | "user";
 
         /**
+         * Details of the CSS to remove. Either the code or the file property must be set, but both may not be set at the same time.
+         * @since Chrome 87
+         */
+        interface DeleteInjectionDetails {
+            /** If allFrames is `true`, implies that the CSS should be removed from all frames of current page. By default, it's `false` and is only removed from the top frame. If `true` and `frameId` is set, then the code is removed from the selected frame and all of its child frames. */
+            allFrames?: boolean;
+            /**  CSS code to remove. */
+            code?: string;
+            /** The origin of the CSS to remove. Defaults to `"author"`. */
+            cssOrigin?: CSSOrigin;
+            /** CSS file to remove. */
+            file?: string;
+            /** The frame from where the CSS should be removed. Defaults to 0 (the top-level frame). */
+            frameId?: number;
+            /** If matchAboutBlank is true, then the code is also removed from about:blank and about:srcdoc frames if your extension has access to its parent document. By default it is `false`. */
+            matchAboutBlank?: boolean;
+        }
+
+        /**
          * The document lifecycle of the frame.
          * @since Chrome 106
          */
@@ -11890,7 +11909,7 @@ declare namespace chrome {
          * MV2 only
          * @param tabId The ID of the tab in which to insert the CSS; defaults to the active tab of the current window.
          * @param details Details of the CSS text to insert. Either the code or the file property must be set, but both may not be set at the same time.
-         * @deprecated since Chrome 99. Replaced by {@link scripting.insertCSS} in Manifest V3.
+         * @deprecated since Chrome 91. Replaced by {@link scripting.insertCSS} in Manifest V3.
          */
         function insertCSS(details: extensionTypes.InjectDetails): Promise<void>;
         function insertCSS(tabId: number | undefined, details: extensionTypes.InjectDetails): Promise<void>;
@@ -11898,6 +11917,26 @@ declare namespace chrome {
         function insertCSS(
             tabId: number | undefined,
             details: extensionTypes.InjectDetails,
+            callback: () => void,
+        ): void;
+
+        /**
+         * Removes from a page CSS that was previously injected by a call to {@link tabs.insertCSS}.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
+         *
+         * MV2 only
+         * @param tabId The ID of the tab from which to remove the CSS; defaults to the active tab of the current window.
+         * @param details Details of the CSS text to remove. Either the code or the file property must be set, but both may not be set at the same time.
+         * @since Chrome 87
+         * @deprecated since Chrome 91. Replaced by {@link scripting.removeCSS} in Manifest V3.
+         */
+        function removeCSS(details: extensionTypes.DeleteInjectionDetails): Promise<void>;
+        function removeCSS(tabId: number | undefined, details: extensionTypes.DeleteInjectionDetails): Promise<void>;
+        function removeCSS(details: extensionTypes.DeleteInjectionDetails, callback: () => void): void;
+        function removeCSS(
+            tabId: number | undefined,
+            details: extensionTypes.DeleteInjectionDetails,
             callback: () => void,
         ): void;
 

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -3916,7 +3916,7 @@ async function testTabs() {
 
     const deleteInjectionDetails: chrome.extensionTypes.DeleteInjectionDetails = {
         allFrames: true,
-        code: "alert('hello world');",
+        code: "body { background: red }",
         cssOrigin: "author",
         frameId,
         matchAboutBlank: true,

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -3863,22 +3863,21 @@ async function testTabs() {
         zoomChangeInfo.zoomSettings; // $ExpectType ZoomSettings
     });
 
-    const details: chrome.extensionTypes.InjectDetails = {
+    const injectDetails: chrome.extensionTypes.InjectDetails = {
         allFrames: true,
         code: "alert('hello world');",
         cssOrigin: "author",
-        file: "file.js",
         frameId,
         matchAboutBlank: true,
         runAt: "document_idle",
     };
 
-    chrome.tabs.executeScript(details); // $ExpectType Promise<any[] | undefined>
-    chrome.tabs.executeScript(tabId, details); // $ExpectType Promise<any[] | undefined>
-    chrome.tabs.executeScript(details, (result) => { // $ExpectType void
+    chrome.tabs.executeScript(injectDetails); // $ExpectType Promise<any[] | undefined>
+    chrome.tabs.executeScript(tabId, injectDetails); // $ExpectType Promise<any[] | undefined>
+    chrome.tabs.executeScript(injectDetails, (result) => { // $ExpectType void
         result; // $ExpectType any[] | undefined
     });
-    chrome.tabs.executeScript(tabId, details, (result) => { // $ExpectType void
+    chrome.tabs.executeScript(tabId, injectDetails, (result) => { // $ExpectType void
         result; // $ExpectType any[] | undefined
     });
     // @ts-expect-error
@@ -3906,14 +3905,31 @@ async function testTabs() {
     // @ts-expect-error
     chrome.tabs.getSelected(() => {}).then(() => {});
 
-    chrome.tabs.insertCSS(details); // $ExpectType Promise<void>
-    chrome.tabs.insertCSS(tabId, details); // $ExpectType Promise<void>
-    chrome.tabs.insertCSS(undefined, details); // $ExpectType Promise<void>
-    chrome.tabs.insertCSS(details, () => {}); // $ExpectType void
-    chrome.tabs.insertCSS(tabId, details, () => {}); // $ExpectType void
-    chrome.tabs.insertCSS(undefined, details, () => {}); // $ExpectType void
+    chrome.tabs.insertCSS(injectDetails); // $ExpectType Promise<void>
+    chrome.tabs.insertCSS(tabId, injectDetails); // $ExpectType Promise<void>
+    chrome.tabs.insertCSS(undefined, injectDetails); // $ExpectType Promise<void>
+    chrome.tabs.insertCSS(injectDetails, () => {}); // $ExpectType void
+    chrome.tabs.insertCSS(tabId, injectDetails, () => {}); // $ExpectType void
+    chrome.tabs.insertCSS(undefined, injectDetails, () => {}); // $ExpectType void
     // @ts-expect-error
     chrome.tabs.insertCSS(() => {}).then(() => {});
+
+    const deleteInjectionDetails: chrome.extensionTypes.DeleteInjectionDetails = {
+        allFrames: true,
+        code: "alert('hello world');",
+        cssOrigin: "author",
+        frameId,
+        matchAboutBlank: true,
+    };
+
+    chrome.tabs.removeCSS(deleteInjectionDetails); // $ExpectType Promise<void>
+    chrome.tabs.removeCSS(tabId, deleteInjectionDetails); // $ExpectType Promise<void>
+    chrome.tabs.removeCSS(undefined, deleteInjectionDetails); // $ExpectType Promise<void>
+    chrome.tabs.removeCSS(deleteInjectionDetails, () => {}); // $ExpectType void
+    chrome.tabs.removeCSS(tabId, deleteInjectionDetails, () => {}); // $ExpectType void
+    chrome.tabs.removeCSS(undefined, deleteInjectionDetails, () => {}); // $ExpectType void
+    // @ts-expect-error
+    chrome.tabs.removeCSS(() => {}).then(() => {});
 
     const request = "Hello World!";
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/mv2/reference/tabs#method-removeCSS
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Note :
- add missing `chrome.tab.removeCSS()` for MV2 only

  <img width="576" height="222" alt="image" src="https://github.com/user-attachments/assets/c7536094-5610-480c-bc75-0fa065e8b972" />
