### PR TITLE
[postcss-media-query-parser] change walk method return type to boolean

### DIFF
--- a/types/postcss-media-query-parser/index.d.ts
+++ b/types/postcss-media-query-parser/index.d.ts
@@ -9,8 +9,8 @@ export interface Node {
     sourceIndex: number;
     nodes?: Child[] | undefined;
 
-    walk(filter: string | RegExp, callback: WalkerCallback): void;
-    walk(callback: WalkerCallback): void;
+    walk(filter: string | RegExp, callback: WalkerCallback): boolean;
+    walk(callback: WalkerCallback): boolean;
 }
 
 export interface Child extends Node {

--- a/types/postcss-media-query-parser/postcss-media-query-parser-tests.ts
+++ b/types/postcss-media-query-parser/postcss-media-query-parser-tests.ts
@@ -24,9 +24,11 @@ if (result.nodes) {
     }
 }
 
+// $ExpectType boolean
 result.walk("", child => {
     child.parent.type;
 });
+// $ExpectType boolean
 result.walk(child => {
     child.parent.type;
 });


### PR DESCRIPTION
The `walk` method will always return a boolean value. Even the `WalkerCallback` always returns void, the `walk` method still returns true.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/dryoma/postcss-media-query-parser#:~:text=each%20of%20them.-,Returns%20false%20if%20traversing%20has%20stopped%20by%20means%20of%20callback%20returning%20false%2C%20and%20true%20otherwise.,-In%20both%20cases
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.