### PR TITLE
Fix pg's PoolConfig onConnect is async

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -54,7 +54,7 @@ export interface PoolConfig extends ClientConfig {
     maxUses?: number | undefined;
     maxLifetimeSeconds?: number | undefined;
     Client?: (new() => ClientBase) | undefined;
-    onConnect?: ((client: ClientBase) => void) | undefined;
+    onConnect?: ((client: ClientBase) => void | Promise<void>) | undefined;
     verify?: ((client: PoolClient, done: (err?: Error) => void) => void) | undefined;
 }
 

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -8,6 +8,7 @@ import {
     DatabaseError,
     defaults,
     Pool,
+    PoolConfig,
     QueryArrayConfig,
     TypeOverrides as TypeOverridesNamed,
     types,
@@ -475,3 +476,31 @@ const poolWithVerify = new Pool({
 poolWithVerify.connect().then(client => {
     console.log("client connected");
 });
+
+const poolWithAsyncOnConnect = new Pool({
+    onConnect: async (client) => {
+        await client.query("SET search_path = app");
+        console.log("async onConnect callback is working!");
+    },
+});
+
+poolWithAsyncOnConnect.connect().then(client => {
+    console.log("client connected");
+});
+
+const poolWithPromiseOnConnect = new Pool({
+    onConnect: client => client.query("SET search_path = app").then(() => undefined),
+});
+
+poolWithPromiseOnConnect.connect().then(client => {
+    console.log("client connected");
+});
+
+declare const onConnectClient: ClientBase;
+const onConnectConfig: PoolConfig = {
+    onConnect: async client => {
+        await client.query("SET search_path = app");
+    },
+};
+// $ExpectType void | Promise<void>
+onConnectConfig.onConnect!(onConnectClient);


### PR DESCRIPTION
Follow-up correction to #74779

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/brianc/node-postgres/blob/df274d1ba9ad9d11a8f1079314faeafde7208207/docs/pages/apis/pool.mdx?plain=1#L71