### PR TITLE
[node] Update node to 26.3.0

### DIFF
--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -263,6 +263,7 @@ declare module "node:http" {
          *       Cannot be used together with `insecureHTTPParser`.
          *
          * @default 'strict'
+         * @since v26.3.0
          */
         httpValidation?: string | undefined;
         /**

--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -255,6 +255,17 @@ declare module "node:http" {
          */
         highWaterMark?: number | undefined;
         /**
+         * Controls HTTP header value validation strictness for incoming requests. Accepted values are:
+         * * `'strict'`: Strictest validation; rejects any non-ASCII or control characters in header values.
+         * * `'relaxed'`: Allows a limited set of non-ASCII characters in header values, aligning with the
+         *       [Fetch specification](https://fetch.spec.whatwg.org/).
+         * * `'insecure'`: Disables all header value validation (equivalent to `insecureHTTPParser: true`).
+         *       Cannot be used together with `insecureHTTPParser`.
+         *
+         * @default 'strict'
+         */
+        httpValidation?: string | undefined;
+        /**
          * Use an insecure HTTP parser that accepts invalid HTTP headers when `true`.
          * Using the insecure parser should be avoided.
          * See --insecure-http-parser for more information.

--- a/types/node/node-tests/http.ts
+++ b/types/node/node-tests/http.ts
@@ -41,6 +41,7 @@ import * as url from "node:url";
         headersTimeout: 50000,
         optimizeEmptyRequests: true,
         requireHostHeader: false,
+        httpValidation: "strict",
         rejectNonStandardBodyWrites: false,
         shouldUpgradeCallback(request) {
             request; // $ExpectType IncomingMessage

--- a/types/node/node-tests/process.ts
+++ b/types/node/node-tests/process.ts
@@ -177,6 +177,8 @@ process.env.TZ = "test";
 {
     process.permission.has("fs.read"); // $ExpectType boolean
     process.permission.has("fs.read", "./README.md"); // $ExpectType boolean
+    process.permission.drop("fs.read"); // $ExpectType void
+    process.permission.drop("fs.read", "./README.md"); // $ExpectType void
 }
 
 {

--- a/types/node/package.json
+++ b/types/node/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/node",
-    "version": "26.2.9999",
+    "version": "26.3.9999",
     "nonNpm": "conflict",
     "nonNpmDescription": "Node.js",
     "projects": [

--- a/types/node/process.d.ts
+++ b/types/node/process.d.ts
@@ -539,6 +539,7 @@ declare module "node:process" {
                  * * `fs.write` - File System write operations
                  * * `child` - Child process spawning operations
                  * * `worker` - Worker thread spawning operation
+                 * * `ffi` - Foreign function interface operations
                  *
                  * ```js
                  * // Check if the process has permission to read the README file
@@ -549,6 +550,57 @@ declare module "node:process" {
                  * @since v20.0.0
                  */
                 has(scope: string, reference?: string): boolean;
+                /**
+                 * Drops the specified permission from the current process. This operation is
+                 * **irreversible** — once a permission is dropped, it cannot be restored through
+                 * any Node.js API.
+                 *
+                 * If no reference is provided, the entire scope is dropped. For example,
+                 * `process.permission.drop('fs.read')` will revoke ALL file system read
+                 * permissions.
+                 *
+                 * When a reference is provided, only the permission for that specific resource
+                 * is dropped. For example, `process.permission.drop('fs.read', '/etc/myapp')`
+                 * will revoke read access to that directory while keeping other read
+                 * permissions intact.
+                 *
+                 * **Important:** You can only drop the exact resource that was explicitly
+                 * granted. The reference passed to `drop()` must match the original grant:
+                 *
+                 * * If a permission was granted using a wildcard (`*`), such as
+                 *   `--allow-fs-read=*`, individual paths cannot be dropped - only the entire
+                 *   scope can be dropped (by calling `drop()` without a reference).
+                 * * If a directory was granted (e.g. `--allow-fs-read=/my/folder`), you cannot
+                 *   drop access to individual files inside it. You must drop the same directory
+                 *   that was granted. Any remaining grants continue to apply.
+                 *
+                 * The available scopes are the same as [`process.permission.has()`][]:
+                 *
+                 * * `fs` - All File System (drops both read and write)
+                 * * `fs.read` - File System read operations
+                 * * `fs.write` - File System write operations
+                 * * `child` - Child process spawning operations
+                 * * `worker` - Worker thread spawning operation
+                 * * `net` - Network operations
+                 * * `inspector` - Inspector operations
+                 * * `wasi` - WASI operations
+                 * * `addon` - Native addon operations
+                 *
+                 * ```js
+                 * const fs = require('node:fs');
+                 *
+                 * // Read configuration during startup
+                 * const config = fs.readFileSync('/etc/myapp/config.json', 'utf8');
+                 *
+                 * // Drop read access to the config directory after initialization
+                 * process.permission.drop('fs.read', '/etc/myapp');
+                 *
+                 * // This will now throw ERR_ACCESS_DENIED
+                 * fs.readFileSync('/etc/myapp/config.json');
+                 * ```
+                 * @since v26.3.0
+                 */
+                drop(scope: string, reference?: string): void;
             }
             interface ProcessReport {
                 /**


### PR DESCRIPTION
Adds both features that changes the type definition from https://nodejs.org/en/blog/release/v26.3.0:

- https://github.com/nodejs/node/pull/61597
- https://github.com/nodejs/node/pull/62672

And updates the mentions of the scopes that can be checked with `has`

I hope these files aren't auto-generated 😅 I didn't see any mention of it in the docs, so apologies if I missed something

------

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://nodejs.org/en/blog/release/v26.3.0:)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
