### PR TITLE
[mparticle__web-sdk] Document logPurchase deprecation

### DIFF
--- a/types/mparticle__web-sdk/index.d.ts
+++ b/types/mparticle__web-sdk/index.d.ts
@@ -614,6 +614,9 @@ export namespace eCommerce {
     const logImpression: LogImpression;
     const logProductAction: LogProductAction;
     const logPromotion: LogPromotion;
+    /**
+     * @deprecated Use logProductAction with ProductActionType.Purchase instead.
+     */
     const logPurchase: LogPurchase;
     /**
      * @deprecated logRefund has been deprecated
@@ -899,6 +902,9 @@ declare class mParticleInstance {
         logImpression: LogImpression;
         logProductAction: LogProductAction;
         logPromotion: LogPromotion;
+        /**
+         * @deprecated Use logProductAction with ProductActionType.Purchase instead.
+         */
         logPurchase: LogPurchase;
         logRefund: LogRefund;
         setCurrencyCode: SetCurrencyCode;


### PR DESCRIPTION
- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mParticle/mparticle-web-sdk/pull/1314/files#diff-60fde1161452ff041bfc8457e597ca629667f17f07e57d494c7d738489b2ba8d
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

## Summary

Documents the existing `logPurchase` deprecation on both the global `mParticle.eCommerce` API and named SDK instances. TypeScript-aware editors will direct developers to `logProductAction` with `ProductActionType.Purchase`.

The existing global and instance type tests already invoke `logPurchase`, covering both annotated declarations. No signatures or runtime behavior change.

## Validation

`pnpm test mparticle__web-sdk --onlyTestTsNext`