### PR TITLE
[pg] Add SSL negotiation and query pipeline types

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -31,6 +31,7 @@ export interface ClientConfig {
     types?: CustomTypesConfig | undefined;
     options?: string | undefined;
     client_encoding?: string | undefined;
+    pipeline?: boolean | undefined;
 }
 
 export type ConnectionConfig = ClientConfig;
@@ -303,6 +304,7 @@ export class Client extends ClientBase {
     host: string;
     password?: string | undefined;
     ssl: boolean;
+    readonly pipeline: boolean;
     readonly connection: Connection;
 
     constructor(config?: string | ClientConfig);

--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -20,6 +20,7 @@ export interface ClientConfig {
     stream?: () => stream.Duplex | undefined;
     statement_timeout?: false | number | undefined;
     ssl?: boolean | ConnectionOptions | undefined;
+    sslnegotiation?: "postgres" | "direct" | undefined;
     query_timeout?: number | undefined;
     lock_timeout?: number | undefined;
     keepAliveInitialDelayMillis?: number | undefined;

--- a/types/pg/package.json
+++ b/types/pg/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/pg",
-    "version": "8.22.9999",
+    "version": "8.23.9999",
     "projects": [
         "https://github.com/brianc/node-postgres"
     ],

--- a/types/pg/package.json
+++ b/types/pg/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/pg",
-    "version": "8.21.9999",
+    "version": "8.22.9999",
     "projects": [
         "https://github.com/brianc/node-postgres"
     ],

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -40,7 +40,12 @@ const client = new Client({
     keepAlive: true,
     ssl: true,
     sslnegotiation: "direct",
+    pipeline: true,
 });
+// $ExpectType boolean
+client.pipeline;
+// @ts-expect-error – pipeline is readonly
+client.pipeline = false;
 client.setTypeParser(20, val => Number(val));
 client.getTypeParser(20);
 
@@ -247,6 +252,7 @@ const poolParameterlessCtor = new Pool();
 const poolOne = new Pool({
     connectionString: "postgresql://dbuser:secretpassword@database.server.com:3211/mydb",
     sslnegotiation: "postgres",
+    pipeline: true,
 });
 
 class MyClient extends Client {

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -38,6 +38,8 @@ const client = new Client({
     password: "secretpassword!!",
     application_name: "DefinitelyTyped",
     keepAlive: true,
+    ssl: true,
+    sslnegotiation: "direct",
 });
 client.setTypeParser(20, val => Number(val));
 client.getTypeParser(20);
@@ -244,6 +246,7 @@ const poolParameterlessCtor = new Pool();
 
 const poolOne = new Pool({
     connectionString: "postgresql://dbuser:secretpassword@database.server.com:3211/mydb",
+    sslnegotiation: "postgres",
 });
 
 class MyClient extends Client {


### PR DESCRIPTION
The `sslnegotiation` option was introduced in 8.22 and the `pipeline` option and read-only `Client.pipeline` property was introduced in 8.23.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

---

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    - Direct SSL negotiation [documentation](https://github.com/brianc/node-postgres/blob/b617619f9fb6fbd231731823e2732a2927ded4be/docs/pages/features/ssl.mdx#direct-ssl-negotiation) and [implementation PR](https://github.com/brianc/node-postgres/pull/3688)
     - Query pipelining [documentation](https://github.com/brianc/node-postgres/blob/df274d1ba9ad9d11a8f1079314faeafde7208207/docs/pages/features/pipelining.mdx#enabling-pipelining), [some more docs](https://github.com/brianc/node-postgres/blob/df274d1ba9ad9d11a8f1079314faeafde7208207/docs/pages/apis/client.mdx#clientpipeline) and [implementation PR](https://github.com/brianc/node-postgres/pull/3652)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.