### PR TITLE
[plotly.js] Add missing d2p/l2p axis typings

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -1135,6 +1135,7 @@ export interface LayoutAxis extends Axis {
     angle: any;
     griddash: Dash;
     l2p: (v: Datum) => number;
+    d2p: (v: Datum) => number;
 
     autotickangles: number[];
     insiderange: any[];

--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -1134,8 +1134,8 @@ export interface LayoutAxis extends Axis {
     automargin: boolean;
     angle: any;
     griddash: Dash;
-    l2p: (v: Datum) => number;
-    d2p: (v: Datum) => number;
+    l2p: (v: number) => number;
+    d2p: (v: Datum, clip?: any, calendar?: any) => number;
 
     autotickangles: number[];
     insiderange: any[];

--- a/types/plotly.js/test/index-tests.ts
+++ b/types/plotly.js/test/index-tests.ts
@@ -1658,3 +1658,9 @@ function rand() {
 
     Plotly.newPlot("myDiv", data, layout);
 })();
+
+(() => {
+    const axis = {} as Plotly.LayoutAxis;
+    const dataPixel: number = axis.d2p(2.5);
+    const linearizedPixel: number = axis.l2p(2.5);
+})();

--- a/types/plotly.js/test/index-tests.ts
+++ b/types/plotly.js/test/index-tests.ts
@@ -1662,5 +1662,7 @@ function rand() {
 (() => {
     const axis = {} as Plotly.LayoutAxis;
     const dataPixel: number = axis.d2p(2.5);
+    const logPixel: number = axis.d2p(2.5, true);
+    const datePixel: number = axis.d2p("2024-01-01", undefined, "gregorian");
     const linearizedPixel: number = axis.l2p(2.5);
 })();


### PR DESCRIPTION
## Summary

Adds missing Plotly axis typings for `d2p`, including argument support for clip/calendar forms and linearized input typing for `l2p`.

## Motivation

These methods exist in runtime usage but are not fully represented in current type definitions, causing gaps for TS users.
