### PR TITLE
[dom-webcodecs] Align `AudioDataInit.data` with `lib.dom.d.ts`

### DIFF
--- a/types/dom-webcodecs/test/dom-webcodecs-tests.ts
+++ b/types/dom-webcodecs/test/dom-webcodecs-tests.ts
@@ -266,6 +266,36 @@ new AudioData({
     sampleRate: 48000,
 });
 
+// AudioDataInit.data is a plain BufferSource, as in the spec and in lib.dom.d.ts, so any
+// ArrayBuffer-backed view is accepted alongside the ArrayBuffer itself.
+// $ExpectType AudioData
+new AudioData({
+    data: new Uint8Array(1024),
+    timestamp: 100,
+    format: "f32",
+    numberOfChannels: 2,
+    numberOfFrames: 1,
+    sampleRate: 48000,
+});
+
+// $ExpectType AudioData
+new AudioData({
+    data: new DataView(audioBuffer),
+    timestamp: 100,
+    format: "f32",
+    numberOfChannels: 2,
+    numberOfFrames: 1,
+    sampleRate: 48000,
+});
+
+// copyTo, unlike AudioDataInit.data, is AllowShared in both the spec and lib.dom.d.ts, so a
+// SharedArrayBuffer-backed destination is accepted here. Keeping the two apart is what stops
+// this file from colliding with the lib.dom.d.ts declarations it merges into.
+declare const sharedDestination: Uint8Array<SharedArrayBuffer>;
+
+// $ExpectType void
+audioFrame.copyTo(sharedDestination, { planeIndex: 0 });
+
 // $ExpectType AudioData
 audioFrame.clone();
 

--- a/types/dom-webcodecs/tsconfig.json
+++ b/types/dom-webcodecs/tsconfig.json
@@ -3,6 +3,7 @@
         "module": "node16",
         "lib": [
             "es6",
+            "es2017.sharedmemory",
             "dom"
         ],
         "noImplicitAny": true,

--- a/types/dom-webcodecs/webcodecs.generated.d.ts
+++ b/types/dom-webcodecs/webcodecs.generated.d.ts
@@ -10,7 +10,10 @@ interface AudioDataCopyToOptions {
 }
 
 interface AudioDataInit {
-    data: AllowSharedBufferSource;
+    // The WebCodecs spec declares this as a plain `BufferSource`, and so does lib.dom.d.ts.
+    // Chromium's IDL marks it `[AllowShared]`, but declaring it as `AllowSharedBufferSource`
+    // here conflicts with the lib.dom.d.ts declaration once SharedArrayBuffer is in scope.
+    data: BufferSource;
     format: AudioSampleFormat;
     numberOfChannels: number;
     numberOfFrames: number;


### PR DESCRIPTION
Fixes #74157

## Problem

`AudioDataInit.data` in `@types/dom-webcodecs` is declared as `AllowSharedBufferSource`, but `lib.dom.d.ts` declares the same property as `BufferSource`. Because both declare the *same global interface*, they merge — and since TypeScript 5.9 the two aliases are no longer identical, so the merge fails:

```
node_modules/@types/dom-webcodecs/webcodecs.generated.d.ts(13,5): error TS2717:
  Subsequent property declarations must have the same type.
  Property 'data' must be of type 'BufferSource', but here has type 'AllowSharedBufferSource'.
```

## Root cause

`@types/dom-webcodecs` is generated from [Chromium's `audio_data_init.idl`](https://chromium.googlesource.com/chromium/src/+/main/third_party/blink/renderer/modules/webcodecs/audio_data_init.idl), which marks the member `[AllowShared]`:

```webidl
required AllowSharedBufferSource data;
```

`lib.dom.d.ts` is generated from the [WebCodecs specification](https://w3c.github.io/webcodecs/#dictdef-audiodatainit), which does not:

```webidl
required BufferSource data;
```

That divergence was harmless while the two aliases were structurally identical. The `ArrayBuffer` generics introduced in TypeScript 5.9 separated them:

```ts
type AllowSharedBufferSource = ArrayBufferLike | ArrayBufferView<ArrayBufferLike>;
type BufferSource            = ArrayBufferView<ArrayBuffer> | ArrayBuffer;
```

`ArrayBufferLike` resolves to `ArrayBuffer` alone unless `SharedArrayBuffer` is in scope. So the conflict only surfaces when the consuming project's `lib` pulls in `es2017.sharedmemory` — which `esnext` does. That is why the failure looked arbitrary in the issue report, and why the package's own tests did not catch it (`"lib": ["es6", "dom"]`).

This matches [@Renegade334's diagnosis on the issue](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/74157#issuecomment-3592754937): the `lib.dom` type has not changed, the mismatch was simply unmasked.

## Changes

**`webcodecs.generated.d.ts`** — declare `AudioDataInit.data` as `BufferSource`, matching the spec and `lib.dom.d.ts`, with a comment recording why it deviates from the Chromium IDL the rest of the file follows.

**`tsconfig.json`** — add `es2017.sharedmemory` to `lib`. Without it `ArrayBufferLike` narrows to `ArrayBuffer`, the two aliases stay identical, and this class of regression is invisible to CI. With it, the package's own test compile reproduces exactly what users hit.

**`test/dom-webcodecs-tests.ts`** — cover the buffer forms `AudioDataInit.data` accepts, and pin the `data` vs `copyTo` asymmetry. See the note at the end.

`AudioDataInit.data` is the only member affected — I compiled the whole package against `--lib esnext,dom` and it is the sole conflict with `lib.dom.d.ts`.

## Verification

Before the fix, with the `tsconfig.json` change in place, `pnpm test dom-webcodecs` reproduces the reported error:

```
types/dom-webcodecs/webcodecs.generated.d.ts
  16:5  error  TypeScript@5.9, 6.0 compile error:
  Subsequent property declarations must have the same type.
  Property 'data' must be of type 'BufferSource', but here has type 'AllowSharedBufferSource'
```

After the fix it passes clean on every supported version (5.8 through 6.0):

```
$ pnpm test dom-webcodecs
dtslint@0.2.46
```

TypeScript 5.8 is unaffected either way — there `AllowSharedBufferSource` and `BufferSource` are still identical.

### A note on the tests

`dom-webcodecs-tests.ts` gains coverage for the buffer forms `AudioDataInit.data` accepts, and pins the asymmetry this fix rests on: `AudioData.copyTo` *is* `AllowShared` in both the spec and `lib.dom.d.ts`, and does take a `SharedArrayBuffer`-backed destination, while `AudioDataInit.data` does not.

Those assertions are not what catches *this* regression, though, and it's worth being explicit that no assertion in that file can:

- **`$ExpectType` asserts nothing here.** `lib.dom.d.ts` wins the merge, so the checker prints the same type for `init.data` whether or not the bug is present — and prints a *different* string on 5.8 (`ArrayBufferView<ArrayBufferLike> | ArrayBuffer`) than on 5.9+ (`ArrayBuffer | ArrayBufferView<ArrayBuffer>`), so no single literal passes on all supported versions.
- **A negative assertion is impossible.** `// @ts-expect-error` on a `SharedArrayBuffer`-backed `data` fails as an *unused* directive on 5.8, where `BufferSource` is `ArrayBufferView | ArrayBuffer` and a shared-backed view is still assignable.

The defect is a declaration-merge conflict, so the only thing that expresses it is compiling this package against a `lib` where the two aliases differ — which is what the `tsconfig.json` change does. See [this comment](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/75389#issuecomment-5293208770) for the full per-version probe. Happy to restructure if a maintainer sees an assertion form I've missed.

## Compatibility

Not a breaking change for correct code. `BufferSource` is what `lib.dom.d.ts` already enforced on any project where the two types differed — those projects did not compile at all. Anyone passing a `SharedArrayBuffer`-backed buffer to the `AudioData` constructor was relying on a Chromium extension that the spec does not sanction, and `lib.dom.d.ts` already rejects.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://w3c.github.io/webcodecs/#dictdef-audiodatainit
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json` — n/a, this is a correctness fix against the existing 0.1 baseline, no API surface added or removed.
