### PR TITLE
Do not declare tags as direct members of the IntrinsicElements interface

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -4174,8 +4174,7 @@ declare namespace React {
         interface IntrinsicAttributes extends React.Attributes {}
         interface IntrinsicClassAttributes<T> extends React.ClassAttributes<T> {}
 
-        interface IntrinsicElements {
-            // HTML
+        interface IntrinsicHTMLElements {
             a: React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>;
             abbr: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
             address: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
@@ -4295,8 +4294,9 @@ declare namespace React {
             video: React.DetailedHTMLProps<React.VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement>;
             wbr: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
             webview: React.DetailedHTMLProps<React.WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement>;
+        }
 
-            // SVG
+        interface IntrinsicSVGElements {
             svg: React.SVGProps<SVGSVGElement>;
 
             animate: React.SVGProps<SVGElement>; // TODO: It is SVGAnimateElement but is not in TypeScript's lib.dom.d.ts for now.
@@ -4358,6 +4358,8 @@ declare namespace React {
             use: React.SVGProps<SVGUseElement>;
             view: React.SVGProps<SVGViewElement>;
         }
+
+        interface IntrinsicElements extends IntrinsicHTMLElements, IntrinsicSVGElements {}
     }
 }
 


### PR DESCRIPTION
This PR uses the TypeScript interface extension mechanism to declare HTML tags usable in JSX. Using this mechanism, the user remains free to extend these elements by augmenting the IntrinsicElements interface, something they can't do if the members are declared directly.

The same mechanism is used by https://github.com/preactjs/preact/blob/main/src/jsx.d.ts