### PR TITLE
[sharetribe-flex-sdk][sharetribe-flex-integration-sdk] Add file attachment types

### DIFF
--- a/types/sharetribe-flex-integration-sdk/index.d.ts
+++ b/types/sharetribe-flex-integration-sdk/index.d.ts
@@ -95,6 +95,9 @@ export interface TransactionRelationships {
     messages?: {
         data: ResourceReference[];
     };
+    protectedFileAttachments?: {
+        data: ResourceReference[];
+    };
 }
 
 /**
@@ -143,6 +146,9 @@ export interface UserRelationships {
     };
     stripeAccount?: {
         data?: ResourceReference;
+    };
+    privateFileAttachments?: {
+        data: ResourceReference[];
     };
 }
 
@@ -198,6 +204,9 @@ export interface ListingRelationships {
     images?: {
         data: ResourceReference[];
     };
+    protectedFileAttachments?: {
+        data: ResourceReference[];
+    };
 }
 
 /**
@@ -216,6 +225,7 @@ export interface Listing {
 export interface MessageAttributes {
     content: string;
     createdAt: string;
+    deleted?: boolean;
 }
 
 /**
@@ -227,6 +237,9 @@ export interface MessageRelationships {
     };
     sender: {
         data: ResourceReference;
+    };
+    publicFileAttachments?: {
+        data: ResourceReference[];
     };
 }
 
@@ -290,7 +303,8 @@ export interface File {
 }
 
 /**
- * File attachment relationships. The `message` relationship is only present when the file is attached to a message.
+ * File attachment relationships. Exactly one of `message`, `listing` or `transaction` is present,
+ * naming the resource the file is attached to.
  */
 export interface FileAttachmentRelationships {
     file: {
@@ -299,19 +313,77 @@ export interface FileAttachmentRelationships {
     message?: {
         data: ResourceReference;
     };
+    listing?: {
+        data: ResourceReference;
+    };
+    transaction?: {
+        data: ResourceReference;
+    };
 }
 
 /**
- * File attachment resource (links a file to a transaction message)
+ * Visibility of a file attachment. `protected` and `private` files are readable only by the
+ * resource owner and marketplace operators; `protected` ones can additionally be revealed to
+ * transaction parties by a transaction process action.
+ */
+export type FileAttachmentScope = "public" | "protected" | "private";
+
+/**
+ * File attachment resource (links a file to a message, listing or transaction)
  */
 export interface FileAttachment {
     id: UUID;
     type: "fileAttachment";
     attributes: {
-        scope: "public";
+        scope: FileAttachmentScope;
         deleted: boolean;
     };
     relationships: FileAttachmentRelationships;
+}
+
+/**
+ * A file to attach, as accepted by the `protectedFileAttachments` and `privateFileAttachments`
+ * body parameters
+ */
+export interface FileAttachmentParam {
+    fileId: UUID | string;
+}
+
+/**
+ * A presigned upload target returned by `integrationSdk.fileUploads.create()`
+ */
+export interface FileUpload {
+    id: UUID;
+    type: "fileUpload";
+    attributes: {
+        fileId: UUID;
+        url: string;
+        method: string;
+        headers: Record<string, string>;
+        expiresAt: string;
+    };
+}
+
+/**
+ * A short-lived download URL returned by `integrationSdk.fileDownloads.create()`
+ */
+export interface FileDownload {
+    id: UUID;
+    type: "fileDownload";
+    attributes: {
+        fileId: UUID;
+        url: string;
+        expiresAt: string;
+    };
+}
+
+/**
+ * File metadata extracted by `file.metadata()`, suitable for `integrationSdk.files.create()`
+ */
+export interface FileMetadata {
+    name: string;
+    mimeType: string;
+    size: number;
 }
 
 /**
@@ -581,6 +653,7 @@ export interface IntegrationSdk {
                 protectedData?: Record<string, unknown>;
                 privateData?: Record<string, unknown>;
                 profileImageId?: UUID;
+                privateFileAttachments?: FileAttachmentParam[];
             },
             options?: PerRequestOptions,
         ) => Promise<MutationResponse<User>>;
@@ -645,6 +718,7 @@ export interface IntegrationSdk {
                 privateData?: Record<string, unknown>;
                 metadata?: Record<string, unknown>;
                 images?: Array<UUID | string>;
+                protectedFileAttachments?: FileAttachmentParam[];
             },
             options?: PerRequestOptions & { include?: string[] },
         ) => Promise<MutationResponse<Listing>>;
@@ -664,6 +738,7 @@ export interface IntegrationSdk {
                 privateData?: Record<string, unknown>;
                 metadata?: Record<string, unknown>;
                 images?: Array<UUID | string>;
+                protectedFileAttachments?: FileAttachmentParam[];
             },
             options?: PerRequestOptions,
         ) => Promise<MutationResponse<Listing>>;
@@ -854,6 +929,19 @@ export interface IntegrationSdk {
                 & PaginationParams
                 & BaseQueryParams,
         ) => Promise<QueryResponse<File>>;
+        /**
+         * Register a file with the Integration API (first step of the upload flow). The created
+         * file starts in the `pendingUpload` state.
+         */
+        create: (
+            params: {
+                ownerId: UUID | string;
+                name: string;
+                mimeType: string;
+                size: number;
+            },
+            options?: PerRequestOptions,
+        ) => Promise<MutationResponse<File>>;
     };
 
     fileAttachments: {
@@ -866,10 +954,32 @@ export interface IntegrationSdk {
                     ids?: Array<UUID | string>;
                     fileIds?: Array<UUID | string>;
                     messageId?: UUID | string;
+                    listingId?: UUID | string;
+                    transactionId?: UUID | string;
                 }
                 & PaginationParams
                 & BaseQueryParams,
         ) => Promise<QueryResponse<FileAttachment>>;
+    };
+
+    fileUploads: {
+        /**
+         * Request a presigned upload URL for a file in the `pendingUpload` state
+         */
+        create: (
+            params: { fileId: UUID | string },
+            options?: PerRequestOptions,
+        ) => Promise<MutationResponse<FileUpload>>;
+    };
+
+    fileDownloads: {
+        /**
+         * Request a short-lived download URL for a file
+         */
+        create: (
+            params: { fileId: UUID | string },
+            options?: PerRequestOptions,
+        ) => Promise<MutationResponse<FileDownload>>;
     };
 
     /**
@@ -927,4 +1037,27 @@ export namespace util {
      * Production-ready command rate limiter configuration
      */
     const prodCommandLimiterConfig: unknown;
+}
+
+/**
+ * Helpers for the file upload flow
+ */
+export namespace file {
+    /**
+     * Extract the metadata needed for `integrationSdk.files.create()` from a `File` object.
+     * @param file - A `File` object, e.g. from an `<input type="file">` element
+     */
+    function metadata(file: unknown): FileMetadata;
+    /**
+     * Upload a file directly to cloud storage using a presigned URL obtained from
+     * `integrationSdk.fileUploads.create()`. This bypasses the SDK interceptor pipeline.
+     * @returns A promise that resolves when the upload is complete
+     */
+    function upload(params: {
+        url: string;
+        file: unknown;
+        method?: string;
+        headers?: Record<string, string>;
+        onUploadProgress?: (progressEvent: unknown) => void;
+    }): Promise<unknown>;
 }

--- a/types/sharetribe-flex-integration-sdk/package.json
+++ b/types/sharetribe-flex-integration-sdk/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/sharetribe-flex-integration-sdk",
-    "version": "1.13.9999",
+    "version": "1.14.9999",
     "projects": [
         "https://github.com/sharetribe/flex-integration-sdk-js"
     ],

--- a/types/sharetribe-flex-integration-sdk/sharetribe-flex-integration-sdk-tests.ts
+++ b/types/sharetribe-flex-integration-sdk/sharetribe-flex-integration-sdk-tests.ts
@@ -1,4 +1,4 @@
-import { createInstance, util } from "sharetribe-flex-integration-sdk";
+import { createInstance, file, FileAttachmentScope, util } from "sharetribe-flex-integration-sdk";
 
 const sdk = createInstance({
     clientId: "client-id",
@@ -149,7 +149,80 @@ sdk.files.query({
 sdk.fileAttachments.query({ messageId: "message-id", fileIds: ["file-id"], include: ["file"] }).then((response) => {
     const firstAttachment = response.data.data[0];
     if (firstAttachment) {
-        const scope: "public" = firstAttachment.attributes.scope;
+        const scope: FileAttachmentScope = firstAttachment.attributes.scope;
+    }
+});
+
+// Attachments on listings and transactions can be filtered by their attaching resource
+// (API changelog 2026-07-13)
+sdk.fileAttachments.query({ listingId: "listing-id" }).then((response) => {
+    const firstAttachment = response.data.data[0];
+    if (firstAttachment && firstAttachment.relationships.listing) {
+        const listingId: string = firstAttachment.relationships.listing.data.id.uuid;
+    }
+});
+sdk.fileAttachments.query({ transactionId: "transaction-id", include: ["file"] }).then((response) => {
+    const totalItems: number | undefined = response.data.meta.totalItems;
+});
+
+// File upload flow: create the file record, get an upload URL, then PUT the bytes
+// (added in integration-sdk 1.14)
+declare const fileLike: unknown;
+const fileMetadata = file.metadata(fileLike);
+sdk.files.create({
+    ownerId: "user-id",
+    name: fileMetadata.name,
+    mimeType: fileMetadata.mimeType,
+    size: fileMetadata.size,
+}).then((response) => {
+    const fileId = response.data.data.id;
+    return sdk.fileUploads.create({ fileId }).then((uploadResponse) => {
+        const upload = uploadResponse.data.data.attributes;
+        return file.upload({
+            url: upload.url,
+            method: upload.method,
+            headers: upload.headers,
+            file: fileLike,
+        });
+    });
+});
+
+// Download URLs are requested per file (added in integration-sdk 1.14)
+sdk.fileDownloads.create({ fileId: "file-id" }, { expand: true }).then((response) => {
+    const url: string = response.data.data.attributes.url;
+});
+
+// Files can be attached to listings and read back as a relationship (API changelog 2026-07-13)
+sdk.listings.update({
+    id: "listing-id",
+    protectedFileAttachments: [{ fileId: "file-id" }],
+}).then((response) => {
+    const listingId: string = response.data.data.id.uuid;
+});
+sdk.listings.show({ id: "listing-id", include: ["protectedFileAttachments.file"] }).then((response) => {
+    const attachments = response.data.data.relationships?.protectedFileAttachments;
+    if (attachments) {
+        const attachmentId: string = attachments.data[0].id.uuid;
+    }
+});
+
+// Users carry private file attachments, set through updateProfile (API changelog 2026-08-10)
+sdk.users.updateProfile({
+    id: "user-id",
+    privateFileAttachments: [{ fileId: "file-id" }],
+}).then((response) => {
+    const userId: string = response.data.data.id.uuid;
+});
+
+// Messages expose their public attachments and a deleted flag (API changelog 2026-03-25, 2026-05-25)
+sdk.messages.query({ transactionId: "transaction-id", include: ["publicFileAttachments.file"] }).then((response) => {
+    const firstMessage = response.data.data[0];
+    if (firstMessage) {
+        const isDeleted: boolean | undefined = firstMessage.attributes.deleted;
+        const attachments = firstMessage.relationships.publicFileAttachments;
+        if (attachments) {
+            const attachmentId: string = attachments.data[0].id.uuid;
+        }
     }
 });
 

--- a/types/sharetribe-flex-sdk/index.d.ts
+++ b/types/sharetribe-flex-sdk/index.d.ts
@@ -212,6 +212,15 @@ export interface UserRelationships {
 }
 
 /**
+ * Current user relationships. Private file attachments are readable only by the user themselves.
+ */
+export interface CurrentUserRelationships extends UserRelationships {
+    privateFileAttachments?: {
+        data: ResourceReference[];
+    };
+}
+
+/**
  * User resource
  */
 export interface User {
@@ -237,9 +246,10 @@ export interface CurrentUserAttributes extends UserAttributes {
 /**
  * Current user resource
  */
-export interface CurrentUser extends Omit<User, "attributes" | "type"> {
+export interface CurrentUser extends Omit<User, "attributes" | "type" | "relationships"> {
     type: "currentUser";
     attributes: CurrentUserAttributes;
+    relationships?: CurrentUserRelationships;
 }
 
 /**
@@ -312,10 +322,20 @@ export interface Listing {
 }
 
 /**
+ * Own listing relationships. Protected file attachments are readable only by the listing author.
+ */
+export interface OwnListingRelationships extends ListingRelationships {
+    protectedFileAttachments?: {
+        data: ResourceReference[];
+    };
+}
+
+/**
  * Own listing resource (has additional private fields)
  */
-export interface OwnListing extends Omit<Listing, "type"> {
+export interface OwnListing extends Omit<Listing, "type" | "relationships"> {
     type: "ownListing";
+    relationships?: OwnListingRelationships;
 }
 
 /**
@@ -368,6 +388,9 @@ export interface TransactionRelationships {
     messages?: {
         data: ResourceReference[];
     };
+    protectedFileAttachments?: {
+        data: ResourceReference[];
+    };
 }
 
 /**
@@ -407,6 +430,7 @@ export interface Booking {
 export interface MessageAttributes {
     content: string;
     createdAt: string;
+    deleted?: boolean;
 }
 
 /**
@@ -415,6 +439,9 @@ export interface MessageAttributes {
 export interface MessageRelationships {
     sender: {
         data: ResourceReference;
+    };
+    publicFileAttachments?: {
+        data: ResourceReference[];
     };
 }
 
@@ -630,6 +657,39 @@ export interface FileDownload {
 }
 
 /**
+ * Visibility of a file attachment. `protected` and `private` files are readable only by the
+ * resource owner and marketplace operators; `protected` ones can additionally be revealed to
+ * transaction parties by a transaction process action.
+ */
+export type FileAttachmentScope = "public" | "protected" | "private";
+
+/**
+ * A link between a file and the resource it is attached to. File attachments are read through
+ * relationships on the attaching resource rather than queried directly.
+ */
+export interface FileAttachment {
+    id: UUID;
+    type: "fileAttachment";
+    attributes: {
+        scope: FileAttachmentScope;
+        deleted: boolean;
+    };
+    relationships: {
+        file: {
+            data: ResourceReference;
+        };
+    };
+}
+
+/**
+ * A file to attach, as accepted by the `publicFileAttachments`, `protectedFileAttachments` and
+ * `privateFileAttachments` body parameters
+ */
+export interface FileAttachmentParam {
+    fileId: UUID | string;
+}
+
+/**
  * File metadata extracted by `file.metadata()`, suitable for `sdk.ownFiles.create()`
  */
 export interface FileMetadata {
@@ -736,6 +796,7 @@ export interface MarketplaceSdk {
                 protectedData?: Record<string, unknown>;
                 privateData?: Record<string, unknown>;
                 profileImageId?: UUID;
+                privateFileAttachments?: FileAttachmentParam[];
             },
             queryParams?: { expand?: boolean },
             opts?: PerRequestOptions,
@@ -757,10 +818,11 @@ export interface MarketplaceSdk {
             opts?: PerRequestOptions,
         ) => Promise<MutationResponse<CurrentUser>>;
         /**
-         * Delete current user
+         * Delete current user. `deleteFromStripe` additionally deletes the associated Stripe
+         * Account and Stripe Customer, which requires the account to have a zero balance.
          */
         delete: (
-            params?: Record<string, never>,
+            params?: { currentPassword?: string; deleteFromStripe?: boolean },
             queryParams?: { expand?: boolean },
             opts?: PerRequestOptions,
         ) => Promise<MutationResponse<CurrentUser>>;
@@ -896,6 +958,7 @@ export interface MarketplaceSdk {
                 availabilityPlan?: unknown;
                 publicData?: Record<string, unknown>;
                 privateData?: Record<string, unknown>;
+                protectedFileAttachments?: FileAttachmentParam[];
             },
             queryParams?: { expand?: boolean },
             opts?: PerRequestOptions,
@@ -912,6 +975,7 @@ export interface MarketplaceSdk {
                 availabilityPlan?: unknown;
                 publicData?: Record<string, unknown>;
                 privateData?: Record<string, unknown>;
+                protectedFileAttachments?: FileAttachmentParam[];
             },
             queryParams?: { expand?: boolean },
             opts?: PerRequestOptions,
@@ -945,6 +1009,7 @@ export interface MarketplaceSdk {
                 availabilityPlan?: unknown;
                 publicData?: Record<string, unknown>;
                 privateData?: Record<string, unknown>;
+                protectedFileAttachments?: FileAttachmentParam[];
             },
             queryParams?: { expand?: boolean },
             opts?: PerRequestOptions,
@@ -1104,16 +1169,22 @@ export interface MarketplaceSdk {
 
     messages: {
         /**
-         * Query messages in a transaction
+         * Query messages. Either `transactionId` or `ids` must be provided.
          */
         query: (
-            params: { transactionId: UUID } & PaginationParams & BaseQueryParams,
+            params:
+                & (
+                    | { transactionId: UUID; ids?: Array<UUID | string> }
+                    | { transactionId?: UUID; ids: Array<UUID | string> }
+                )
+                & PaginationParams
+                & BaseQueryParams,
         ) => Promise<QueryResponse<Message>>;
         /**
          * Send a message in a transaction
          */
         send: (
-            params: { transactionId: UUID; content: string },
+            params: { transactionId: UUID; content: string; publicFileAttachments?: FileAttachmentParam[] },
             queryParams?: { expand?: boolean },
             opts?: PerRequestOptions,
         ) => Promise<MutationResponse<Message>>;
@@ -1293,9 +1364,12 @@ export interface MarketplaceSdk {
 
     files: {
         /**
-         * Show a file accessible to the current user
+         * Show a file accessible to the current user, identified by the ID of the file attachment
+         * that links it to the attaching resource
          */
-        show: (params: { id: UUID | string } & BaseQueryParams) => Promise<ShowResponse<File>>;
+        show: (
+            params: { fileAttachmentId: UUID | string } & BaseQueryParams,
+        ) => Promise<ShowResponse<File>>;
     };
 
     fileUploads: {
@@ -1322,10 +1396,11 @@ export interface MarketplaceSdk {
 
     fileDownloads: {
         /**
-         * Request a short-lived download URL for a file accessible to the current user
+         * Request a short-lived download URL for a file attached to a resource the current user
+         * has access to
          */
         create: (
-            params: { fileId: UUID | string },
+            params: { fileAttachmentId: UUID | string },
             queryParams?: { expand?: boolean },
             opts?: PerRequestOptions,
         ) => Promise<MutationResponse<FileDownload>>;

--- a/types/sharetribe-flex-sdk/sharetribe-flex-sdk-tests.ts
+++ b/types/sharetribe-flex-sdk/sharetribe-flex-sdk-tests.ts
@@ -1,6 +1,9 @@
 import {
     createInstance,
     file,
+    FileAttachment,
+    FileAttachmentScope,
+    FileState,
     FileUpload,
     Marketplace,
     MutationResponse,
@@ -35,8 +38,70 @@ sdk.ownFiles.create({ name: meta.name, mimeType: meta.mimeType, size: meta.size 
     },
 );
 
-sdk.fileDownloads.create({ fileId: "a5d04285-07da-4fa0-b80b-ebabb8bac9e5" }).then(response => {
+// Files attached to another resource are reached through the attachment ID, not the file ID
+sdk.fileDownloads.create({ fileAttachmentId: "a5d04285-07da-4fa0-b80b-ebabb8bac9e5" }).then(response => {
     const downloadUrl: string = response.data.data.attributes.url;
+});
+
+sdk.files.show({ fileAttachmentId: "a5d04285-07da-4fa0-b80b-ebabb8bac9e5" }).then(response => {
+    const state: FileState = response.data.data.attributes.state;
+});
+
+// Listings carry protected attachments readable by their author (API changelog 2026-07-13)
+sdk.ownListings.create({
+    title: "Bike",
+    protectedFileAttachments: [{ fileId: "a5d04285-07da-4fa0-b80b-ebabb8bac9e5" }],
+}).then(response => {
+    const attachments = response.data.data.relationships?.protectedFileAttachments;
+    if (attachments) {
+        const attachmentId: string = attachments.data[0].id.uuid;
+    }
+});
+
+// Users carry private attachments, set through updateProfile (API changelog 2026-08-10)
+sdk.currentUser.updateProfile({
+    privateFileAttachments: [{ fileId: "a5d04285-07da-4fa0-b80b-ebabb8bac9e5" }],
+}).then(response => {
+    const attachments = response.data.data.relationships?.privateFileAttachments;
+    if (attachments) {
+        const attachmentId: string = attachments.data[0].id.uuid;
+    }
+});
+
+// Messages take public attachments and can be queried by ids (API changelog 2026-03-25, 2026-05-25)
+sdk.messages.send({
+    transactionId: { _sdkType: "UUID", uuid: "b1b9e5f9-1a4a-4f0e-9d2f-0f3a3c1f2b7d" },
+    content: "Here is the manual",
+    publicFileAttachments: [{ fileId: "a5d04285-07da-4fa0-b80b-ebabb8bac9e5" }],
+}).then(response => {
+    const messageId: string = response.data.data.id.uuid;
+});
+
+sdk.messages.query({ ids: ["b1b9e5f9-1a4a-4f0e-9d2f-0f3a3c1f2b7d"], include: ["publicFileAttachments.file"] }).then(
+    response => {
+        const firstMessage = response.data.data[0];
+        if (firstMessage) {
+            const isDeleted: boolean | undefined = firstMessage.attributes.deleted;
+            const attachments = firstMessage.relationships.publicFileAttachments;
+            if (attachments) {
+                const attachmentId: string = attachments.data[0].id.uuid;
+            }
+        }
+        // Attachments themselves arrive as included resources
+        const included = response.data.included ?? [];
+        const attachment = included.find(resource => resource.type === "fileAttachment") as
+            | FileAttachment
+            | undefined;
+        if (attachment) {
+            const scope: FileAttachmentScope = attachment.attributes.scope;
+            const fileId: string = attachment.relationships.file.data.id.uuid;
+        }
+    },
+);
+
+// Deleting the current user can cascade to Stripe (API changelog 2025-11-13)
+sdk.currentUser.delete({ currentPassword: "hunter2", deleteFromStripe: true }).then(response => {
+    const status: number = response.status;
 });
 
 // Query string utilities (added in flex-sdk 1.23)


### PR DESCRIPTION
## Summary
- Sharetribe's Marketplace and Integration APIs now support file attachments: creating/uploading/downloading files, and attaching them (public/protected/private scope) to users, listings, messages and transactions. This is driven by the [API changelog](https://www.sharetribe.com/api-reference/changelog.html) through 2026-08-17.
- `sharetribe-flex-integration-sdk`'s `files.create`, `fileUploads.create` and `fileDownloads.create` endpoints (and the `file.metadata`/`file.upload` helpers) were also added in the real npm 1.14.0 release, so that package's version is bumped from `1.13.9999` to `1.14.9999` to match. `sharetribe-flex-sdk`'s package.json is left as-is since its most recent release (1.24.1) was dependency-only; its file-attachment additions here are purely API-changelog-driven.
- Testcases were added to both `*-tests.ts` files exercising the new surface (file upload/download flow, attaching files to listings/messages/transactions/users, querying by the new filters).

## Test plan
- [x] `npm test -- sharetribe-flex-sdk` (dtslint) passes
- [x] `npm test -- sharetribe-flex-integration-sdk` (dtslint) passes