### PR TITLE
[d3-shape] Add digits accessor

### DIFF
--- a/types/d3-shape/d3-shape-tests.ts
+++ b/types/d3-shape/d3-shape-tests.ts
@@ -19,6 +19,7 @@ let context: CanvasRenderingContext2D | null = document.querySelector("canvas")!
 let num: number;
 let padAngleMaybe: number | undefined;
 let pathStringMaybe: string | null;
+let digitsMaybe: number | null;
 
 // -----------------------------------------------------------------------------------
 // Test Arc Generator
@@ -90,6 +91,13 @@ if (context !== null) {
 context = canvasArc.context();
 
 svgArc = svgArc.context(null); // use as path string generator for SVG
+
+// digits(...) ----------------------------------------------------------------------
+
+svgArc = svgArc.digits(3);
+svgArc = svgArc.digits(null); // full precision
+
+digitsMaybe = svgArc.digits();
 
 // innerRadius(...) -------------------------------------------------------------------
 
@@ -416,6 +424,13 @@ context = defaultLine.context();
 
 line = line.context(null); // use as path string generator for SVG
 
+// digits(...) ----------------------------------------------------------------------
+
+line = line.digits(3);
+line = line.digits(null); // full precision
+
+digitsMaybe = line.digits();
+
 // x(...) ----------------------------------------------------------------------------
 
 defaultLine = defaultLine.x(30);
@@ -495,6 +510,13 @@ if (context !== null) {
 context = defaultLineRadial.context();
 
 lineRadial = lineRadial.context(null); // use as path string generator for SVG
+
+// digits(...) ----------------------------------------------------------------------
+
+lineRadial = lineRadial.digits(3);
+lineRadial = lineRadial.digits(null); // full precision
+
+digitsMaybe = lineRadial.digits();
 
 // angle(...) ----------------------------------------------------------------------------
 
@@ -613,6 +635,13 @@ if (context !== null) {
 context = defaultArea.context();
 
 area = area.context(null); // use as path string generator for SVG
+
+// digits(...) ----------------------------------------------------------------------
+
+area = area.digits(3);
+area = area.digits(null); // full precision
+
+digitsMaybe = area.digits();
 
 // x(...) ----------------------------------------------------------------------------
 
@@ -752,6 +781,13 @@ if (context !== null) {
 context = defaultAreaRadial.context();
 
 areaRadial = areaRadial.context(null); // use as path string generator for SVG
+
+// digits(...) ----------------------------------------------------------------------
+
+areaRadial = areaRadial.digits(3);
+areaRadial = areaRadial.digits(null); // full precision
+
+digitsMaybe = areaRadial.digits();
 
 // angle(...) ----------------------------------------------------------------------------
 
@@ -1208,6 +1244,18 @@ context = defaultArea.context();
 
 area = area.context(null); // use as path string generator for SVG
 
+// digits(...) ----------------------------------------------------------------------
+
+link = link.digits(3);
+link = link.digits(null); // full precision
+
+digitsMaybe = link.digits();
+
+radialLink = radialLink.digits(3);
+radialLink = radialLink.digits(null); // full precision
+
+digitsMaybe = radialLink.digits();
+
 // Use link generators ===============================================================
 
 // Render to canvas ------------------------------------------------------------------
@@ -1304,6 +1352,13 @@ if (context !== null) {
 context = canvasSymbol.context();
 
 svgSymbol = svgSymbol.context(null); // use as path string generator for SVG
+
+// digits(...) ----------------------------------------------------------------------
+
+svgSymbol = svgSymbol.digits(3);
+svgSymbol = svgSymbol.digits(null); // full precision
+
+digitsMaybe = svgSymbol.digits();
 
 // size() ----------------------------------------------------------------------------
 

--- a/types/d3-shape/index.d.ts
+++ b/types/d3-shape/index.d.ts
@@ -317,6 +317,20 @@ export interface Arc<This, Datum> {
      * If context is not specified, returns the current context, which defaults to null.
      */
     context(context: CanvasRenderingContext2D | null): this;
+
+    /**
+     * Returns the maximum number of digits after the decimal separator, which defaults to 3.
+     */
+    digits(): number | null;
+    /**
+     * Sets the maximum number of digits after the decimal separator and returns this arc generator.
+     *
+     * This option only applies when the associated context is null, as when this arc generator is used
+     * to produce path data.
+     *
+     * @param digits The maximum number of digits after the decimal separator, or null for full precision.
+     */
+    digits(digits: number | null): this;
 }
 
 /**
@@ -750,6 +764,20 @@ export interface Line<Datum> {
      * Sets the context and returns this line generator.
      */
     context(context: CanvasRenderingContext2D | null): this;
+
+    /**
+     * Returns the maximum number of digits after the decimal separator, which defaults to 3.
+     */
+    digits(): number | null;
+    /**
+     * Sets the maximum number of digits after the decimal separator and returns this line generator.
+     *
+     * This option only applies when the associated context is null, as when this line generator is used
+     * to produce path data.
+     *
+     * @param digits The maximum number of digits after the decimal separator, or null for full precision.
+     */
+    digits(digits: number | null): this;
 }
 
 /**
@@ -915,6 +943,20 @@ export interface LineRadial<Datum> {
      * Equivalent to line.context.
      */
     context(context: CanvasRenderingContext2D | null): this;
+
+    /**
+     * Returns the maximum number of digits after the decimal separator, which defaults to 3.
+     */
+    digits(): number | null;
+    /**
+     * Sets the maximum number of digits after the decimal separator and returns this radial line generator.
+     *
+     * This option only applies when the associated context is null, as when this radial line generator is used
+     * to produce path data.
+     *
+     * @param digits The maximum number of digits after the decimal separator, or null for full precision.
+     */
+    digits(digits: number | null): this;
 }
 
 /**
@@ -1182,6 +1224,20 @@ export interface Area<Datum> {
      * Sets the context and returns this area generator.
      */
     context(context: CanvasRenderingContext2D | null): this;
+
+    /**
+     * Returns the maximum number of digits after the decimal separator, which defaults to 3.
+     */
+    digits(): number | null;
+    /**
+     * Sets the maximum number of digits after the decimal separator and returns this area generator.
+     *
+     * This option only applies when the associated context is null, as when this area generator is used
+     * to produce path data.
+     *
+     * @param digits The maximum number of digits after the decimal separator, or null for full precision.
+     */
+    digits(digits: number | null): this;
 
     /**
      * Returns a new line generator that has this area generator’s current defined accessor, curve and context.
@@ -1457,6 +1513,20 @@ export interface AreaRadial<Datum> {
      * Equivalent to line.context.
      */
     context(context: CanvasRenderingContext2D | null): this;
+
+    /**
+     * Returns the maximum number of digits after the decimal separator, which defaults to 3.
+     */
+    digits(): number | null;
+    /**
+     * Sets the maximum number of digits after the decimal separator and returns this radial area generator.
+     *
+     * This option only applies when the associated context is null, as when this radial area generator is used
+     * to produce path data.
+     *
+     * @param digits The maximum number of digits after the decimal separator, or null for full precision.
+     */
+    digits(digits: number | null): this;
 
     /**
      * Returns a new radial line generator that has this radial area generator’s current defined accessor, curve and context.
@@ -1931,6 +2001,20 @@ export interface Link<This, LinkDatum, NodeDatum> {
      * Sets the context and returns this link generator.
      */
     context(context: CanvasRenderingContext2D | null): this;
+
+    /**
+     * Returns the maximum number of digits after the decimal separator, which defaults to 3.
+     */
+    digits(): number | null;
+    /**
+     * Sets the maximum number of digits after the decimal separator and returns this link generator.
+     *
+     * This option only applies when the associated context is null, as when this link generator is used
+     * to produce path data.
+     *
+     * @param digits The maximum number of digits after the decimal separator, or null for full precision.
+     */
+    digits(digits: number | null): this;
 }
 
 /**
@@ -2129,6 +2213,20 @@ export interface LinkRadial<This, LinkDatum, NodeDatum> {
      * Sets the context and returns this link generator.
      */
     context(context: CanvasRenderingContext2D | null): this;
+
+    /**
+     * Returns the maximum number of digits after the decimal separator, which defaults to 3.
+     */
+    digits(): number | null;
+    /**
+     * Sets the maximum number of digits after the decimal separator and returns this radial link generator.
+     *
+     * This option only applies when the associated context is null, as when this radial link generator is used
+     * to produce path data.
+     *
+     * @param digits The maximum number of digits after the decimal separator, or null for full precision.
+     */
+    digits(digits: number | null): this;
 }
 
 /**
@@ -2280,6 +2378,20 @@ export interface Symbol<This, Datum> {
      * Sets the context and returns this symbol generator.
      */
     context(context: CanvasRenderingContext2D | null): this;
+
+    /**
+     * Returns the maximum number of digits after the decimal separator, which defaults to 3.
+     */
+    digits(): number | null;
+    /**
+     * Sets the maximum number of digits after the decimal separator and returns this symbol generator.
+     *
+     * This option only applies when the associated context is null, as when this symbol generator is used
+     * to produce path data.
+     *
+     * @param digits The maximum number of digits after the decimal separator, or null for full precision.
+     */
+    digits(digits: number | null): this;
 }
 
 /**

--- a/types/d3-shape/package.json
+++ b/types/d3-shape/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/d3-shape",
-    "version": "3.1.9999",
+    "version": "3.2.9999",
     "projects": [
         "https://github.com/d3/d3-shape/",
         "https://d3js.org/d3-shape"


### PR DESCRIPTION
`d3-shape` 3.2 added a `digits` accessor to every generator built on `withPath` — `arc`, `line`, `lineRadial`, `area`, `areaRadial`, `linkHorizontal`/`linkVertical`/`linkRadial`, and `symbol` — but it was never added here. It caps the number of decimals written into the path data string, defaults to `3`, and accepts `null` for full precision. `pie` produces no path output and is unaffected. `@types/d3-path` already has the matching `pathRound`.

I hit this in a charts library, where dropping line and area paths from three decimals to one cut a 10k-point area render by 16% and its paint by 15%; the only way to reach the API today is a local `declare module` merge.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://d3js.org/d3-shape/line#line_digits and https://github.com/d3/d3-shape/blob/v3.2.0/src/path.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`. (3.1.9999 → 3.2.9999)

I verified against `d3-shape@3.2.0` at runtime that all nine generators expose `digits`, that the getter returns `3` by default, and that the setter returns the generator itself; `pie` does not have it. `pnpm test d3-shape` passes, and reverting only `index.d.ts` makes the new test lines fail to compile, so they do exercise the added declarations.