### PR TITLE
[luxon] Restore *MaybeValid returns on factories

### DIFF
--- a/types/luxon/src/datetime.d.ts
+++ b/types/luxon/src/datetime.d.ts
@@ -430,6 +430,13 @@ export interface ExplainedFormat {
     invalidReason?: string | undefined;
 }
 
+/**
+ * A DateTime whose validity is not known statically.
+ *
+ * Checking `isValid` narrows this to `DateTime<true>` or `DateTime<false>`.
+ */
+export type DateTimeMaybeValid = CanBeInvalid extends true ? (DateTime<Valid> | DateTime<Invalid>) : DateTime;
+
 declare const tokenParserBrand: unique symbol;
 export interface TokenParser {
     [tokenParserBrand]: true;
@@ -594,7 +601,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
         second: number,
         millisecond: number,
         opts?: DateTimeJSOptions,
-    ): DateTime;
+    ): DateTimeMaybeValid;
     static local(
         year: number,
         month: number,
@@ -603,7 +610,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
         minute: number,
         second: number,
         opts?: DateTimeJSOptions,
-    ): DateTime;
+    ): DateTimeMaybeValid;
     static local(
         year: number,
         month: number,
@@ -611,11 +618,11 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
         hour: number,
         minute: number,
         opts?: DateTimeJSOptions,
-    ): DateTime;
-    static local(year: number, month: number, day: number, hour: number, opts?: DateTimeJSOptions): DateTime;
-    static local(year: number, month: number, day: number, opts?: DateTimeJSOptions): DateTime;
-    static local(year: number, month: number, opts?: DateTimeJSOptions): DateTime;
-    static local(year: number, opts?: DateTimeJSOptions): DateTime;
+    ): DateTimeMaybeValid;
+    static local(year: number, month: number, day: number, hour: number, opts?: DateTimeJSOptions): DateTimeMaybeValid;
+    static local(year: number, month: number, day: number, opts?: DateTimeJSOptions): DateTimeMaybeValid;
+    static local(year: number, month: number, opts?: DateTimeJSOptions): DateTimeMaybeValid;
+    static local(year: number, opts?: DateTimeJSOptions): DateTimeMaybeValid;
     static local(opts?: DateTimeJSOptions): DateTime<Valid>;
 
     /**
@@ -661,7 +668,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
         second: number,
         millisecond: number,
         options?: LocaleOptions,
-    ): DateTime;
+    ): DateTimeMaybeValid;
     static utc(
         year: number,
         month: number,
@@ -670,7 +677,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
         minute: number,
         second: number,
         options?: LocaleOptions,
-    ): DateTime;
+    ): DateTimeMaybeValid;
     static utc(
         year: number,
         month: number,
@@ -678,11 +685,11 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
         hour: number,
         minute: number,
         options?: LocaleOptions,
-    ): DateTime;
-    static utc(year: number, month: number, day: number, hour: number, options?: LocaleOptions): DateTime;
-    static utc(year: number, month: number, day: number, options?: LocaleOptions): DateTime;
-    static utc(year: number, month: number, options?: LocaleOptions): DateTime;
-    static utc(year: number, options?: LocaleOptions): DateTime;
+    ): DateTimeMaybeValid;
+    static utc(year: number, month: number, day: number, hour: number, options?: LocaleOptions): DateTimeMaybeValid;
+    static utc(year: number, month: number, day: number, options?: LocaleOptions): DateTimeMaybeValid;
+    static utc(year: number, month: number, options?: LocaleOptions): DateTimeMaybeValid;
+    static utc(year: number, options?: LocaleOptions): DateTimeMaybeValid;
     static utc(options?: LocaleOptions): DateTime<Valid>;
 
     /**
@@ -692,7 +699,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
      * @param options - configuration options for the DateTime
      * @param options.zone - the zone to place the DateTime into
      */
-    static fromJSDate(date: Date, options?: { zone?: string | Zone }): DateTime;
+    static fromJSDate(date: Date, options?: { zone?: string | Zone }): DateTimeMaybeValid;
 
     /**
      * Create a DateTime from a number of milliseconds since the epoch (meaning since 1 January 1970 00:00:00 UTC). Uses the default zone.
@@ -704,7 +711,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
      * @param options.outputCalendar - the output calendar to set on the resulting DateTime instance
      * @param options.numberingSystem - the numbering system to set on the resulting DateTime instance
      */
-    static fromMillis(milliseconds: number, options?: DateTimeJSOptions): DateTime;
+    static fromMillis(milliseconds: number, options?: DateTimeJSOptions): DateTimeMaybeValid;
 
     /**
      * Create a DateTime from a number of seconds since the epoch (meaning since 1 January 1970 00:00:00 UTC). Uses the default zone.
@@ -716,7 +723,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
      * @param options.outputCalendar - the output calendar to set on the resulting DateTime instance
      * @param options.numberingSystem - the numbering system to set on the resulting DateTime instance
      */
-    static fromSeconds(seconds: number, options?: DateTimeJSOptions): DateTime;
+    static fromSeconds(seconds: number, options?: DateTimeJSOptions): DateTimeMaybeValid;
 
     /**
      * Create a DateTime from a JavaScript object with keys like 'year' and 'hour' with reasonable defaults.
@@ -756,7 +763,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
      * @example
      * DateTime.fromObject({ localWeekYear: 2022, localWeekNumber: 1, localWeekday: 1 }, { locale: 'en-US' }).toISODate() //=> '2021-12-26'
      */
-    static fromObject(obj: DateObjectUnits, opts?: DateTimeJSOptions): DateTime;
+    static fromObject(obj: DateObjectUnits, opts?: DateTimeJSOptions): DateTimeMaybeValid;
 
     /**
      * Create a DateTime from an ISO 8601 string
@@ -780,7 +787,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
      * @example
      * DateTime.fromISO('2016-W05-4')
      */
-    static fromISO(text: string, opts?: DateTimeOptions): DateTime;
+    static fromISO(text: string, opts?: DateTimeOptions): DateTimeMaybeValid;
 
     /**
      * Create a DateTime from an RFC 2822 string
@@ -801,7 +808,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
      * @example
      * DateTime.fromRFC2822('25 Nov 2016 13:23 Z')
      */
-    static fromRFC2822(text: string, opts?: DateTimeOptions): DateTime;
+    static fromRFC2822(text: string, opts?: DateTimeOptions): DateTimeMaybeValid;
 
     /**
      * Create a DateTime from an HTTP header date
@@ -825,7 +832,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
      * @example
      * DateTime.fromHTTP('Sun Nov  6 08:49:37 1994')
      */
-    static fromHTTP(text: string, opts?: DateTimeOptions): DateTime;
+    static fromHTTP(text: string, opts?: DateTimeOptions): DateTimeMaybeValid;
 
     /**
      * Create a DateTime from an input string and format string.
@@ -850,12 +857,12 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
      * Will also set the resulting DateTime to this numbering system
      * @param opts.outputCalendar - the output calendar to set on the resulting DateTime instance
      */
-    static fromFormat(text: string, format: Tokens, opts?: DateTimeOptions): DateTime;
+    static fromFormat(text: string, format: Tokens, opts?: DateTimeOptions): DateTimeMaybeValid;
 
     /**
      * @deprecated use fromFormat instead
      */
-    static fromString(text: string, format: Tokens, options?: DateTimeOptions): DateTime;
+    static fromString(text: string, format: Tokens, options?: DateTimeOptions): DateTimeMaybeValid;
 
     /**
      * Create a DateTime from a SQL date, time, or datetime
@@ -886,7 +893,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
      * @example
      * DateTime.fromSQL('09:12:34.342')
      */
-    static fromSQL(text: string, opts?: DateTimeOptions): DateTime;
+    static fromSQL(text: string, opts?: DateTimeOptions): DateTimeMaybeValid;
 
     /**
      * Create an invalid DateTime.
@@ -1267,7 +1274,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
      * @param opts - options
      * @param opts.keepLocalTime - If true, adjust the underlying time so that the local time stays the same, but in the target zone. You should rarely need this. Defaults to false.
      */
-    setZone(zone?: string | Zone, opts?: ZoneOptions): DateTime;
+    setZone(zone?: string | Zone, opts?: ZoneOptions): DateTimeMaybeValid;
 
     /**
      * "Set" the locale, numberingSystem, or outputCalendar. Returns a newly-constructed DateTime.
@@ -1759,7 +1766,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
      * @param parser - parser from {@link buildFormatParser}
      * @param options options taken by {@link fromFormat}
      */
-    static fromFormatParser(text: string, parser: TokenParser, options?: DateTimeOptions): DateTime;
+    static fromFormatParser(text: string, parser: TokenParser, options?: DateTimeOptions): DateTimeMaybeValid;
 
     // FORMAT PRESETS
 

--- a/types/luxon/src/duration.d.ts
+++ b/types/luxon/src/duration.d.ts
@@ -86,6 +86,13 @@ export type DurationInput = Duration | number | DurationLikeObject;
  */
 export type DurationLike = Duration | DurationLikeObject | number;
 
+/**
+ * A Duration whose validity is not known statically.
+ *
+ * Checking `isValid` narrows this to `Duration<true>` or `Duration<false>`.
+ */
+export type DurationMaybeValid = CanBeInvalid extends true ? (Duration<Valid> | Duration<Invalid>) : Duration;
+
 export interface DurationFormatOptions {
     /**
      * Whether or not to floor numerical values.
@@ -174,7 +181,7 @@ export class Duration<IsValid extends boolean = DefaultValidity> {
      * @example
      * Duration.fromISO('P5Y3M').toObject() //=> { years: 5, months: 3 }
      */
-    static fromISO(text: string, opts?: DurationOptions): Duration;
+    static fromISO(text: string, opts?: DurationOptions): DurationMaybeValid;
 
     /**
      * Create a Duration from an ISO 8601 time string.
@@ -197,7 +204,7 @@ export class Duration<IsValid extends boolean = DefaultValidity> {
      * @example
      * Duration.fromISOTime('T1100').toObject() //=> { hours: 11, minutes: 0, seconds: 0 }
      */
-    static fromISOTime(text: string, opts?: DurationOptions): Duration;
+    static fromISOTime(text: string, opts?: DurationOptions): DurationMaybeValid;
 
     /**
      * Create an invalid Duration.

--- a/types/luxon/src/interval.d.ts
+++ b/types/luxon/src/interval.d.ts
@@ -8,7 +8,7 @@ import {
     LocaleOptions,
     ToISOTimeOptions,
 } from "./datetime";
-import { Duration, DurationLike, DurationUnit } from "./duration";
+import { Duration, DurationLike, DurationMaybeValid, DurationUnit } from "./duration";
 
 export interface IntervalObject {
     start?: DateTime | undefined;
@@ -18,6 +18,13 @@ export interface IntervalObject {
 export type DateInput = DateTime | DateObjectUnits | Date;
 
 export type CountOptions = _UseLocaleWeekOption;
+
+/**
+ * An Interval whose validity is not known statically.
+ *
+ * Checking `isValid` narrows this to `Interval<true>` or `Interval<false>`.
+ */
+export type IntervalMaybeValid = CanBeInvalid extends true ? (Interval<Valid> | Interval<Invalid>) : Interval;
 
 /**
  * An Interval object represents a half-open interval of time, where each endpoint is a {@link DateTime}.
@@ -51,7 +58,7 @@ export class Interval<IsValid extends boolean = DefaultValidity> {
      * @param start
      * @param end
      */
-    static fromDateTimes(start: DateInput, end: DateInput): Interval;
+    static fromDateTimes(start: DateInput, end: DateInput): IntervalMaybeValid;
 
     /**
      * Create an Interval from a start DateTime and a Duration to extend to.
@@ -59,7 +66,7 @@ export class Interval<IsValid extends boolean = DefaultValidity> {
      * @param start
      * @param duration - the length of the Interval.
      */
-    static after(start: DateInput, duration: DurationLike): Interval;
+    static after(start: DateInput, duration: DurationLike): IntervalMaybeValid;
 
     /**
      * Create an Interval from an end DateTime and a Duration to extend backwards to.
@@ -67,7 +74,7 @@ export class Interval<IsValid extends boolean = DefaultValidity> {
      * @param end
      * @param duration - the length of the Interval.
      */
-    static before(end: DateInput, duration: DurationLike): Interval;
+    static before(end: DateInput, duration: DurationLike): IntervalMaybeValid;
 
     /**
      * Create an Interval from an ISO 8601 string.
@@ -77,7 +84,7 @@ export class Interval<IsValid extends boolean = DefaultValidity> {
      * @param text - the ISO string to parse
      * @param opts - options to pass {@link DateTime.fromISO} and optionally {@link Duration.fromISO}
      */
-    static fromISO(text: string, opts?: DateTimeOptions): Interval;
+    static fromISO(text: string, opts?: DateTimeOptions): IntervalMaybeValid;
 
     /**
      * Check if an object is an Interval. Works across context boundaries
@@ -175,7 +182,7 @@ export class Interval<IsValid extends boolean = DefaultValidity> {
      * @param values.start - the starting DateTime
      * @param values.end - the ending DateTime
      */
-    set(values?: IntervalObject): Interval;
+    set(values?: IntervalObject): IntervalMaybeValid;
 
     /**
      * Split this Interval at each of the specified DateTimes
@@ -235,23 +242,23 @@ export class Interval<IsValid extends boolean = DefaultValidity> {
      * Return an Interval representing the union of this Interval and the specified Interval.
      * Specifically, the resulting Interval has the minimum start time and the maximum end time of the two Intervals.
      */
-    union(other: Interval): Interval;
+    union(other: Interval): IntervalMaybeValid;
 
     /**
      * Merge an array of Intervals into an equivalent minimal set of Intervals.
      * Combines overlapping and adjacent Intervals.
      */
-    static merge(intervals: Interval[]): Interval[];
+    static merge(intervals: Interval[]): IntervalMaybeValid[];
 
     /**
      * Return an array of Intervals representing the spans of time that only appear in one of the specified Intervals.
      */
-    static xor(intervals: Interval[]): Interval[];
+    static xor(intervals: Interval[]): IntervalMaybeValid[];
 
     /**
      * Return Intervals representing the spans of time in this Interval that not overlap with any of the specified Intervals.
      */
-    difference(...intervals: Interval[]): Interval[];
+    difference(...intervals: Interval[]): IntervalMaybeValid[];
 
     /**
      * Returns a string representation of this Interval appropriate for debugging.
@@ -347,7 +354,7 @@ export class Interval<IsValid extends boolean = DefaultValidity> {
      * @example
      * Interval.fromDateTimes(dt1, dt2).toDuration('seconds').toObject() //=> { seconds: 88489.257 }
      */
-    toDuration(unit?: DurationUnit | DurationUnit[], opts?: DiffOptions): Duration;
+    toDuration(unit?: DurationUnit | DurationUnit[], opts?: DiffOptions): DurationMaybeValid;
 
     /**
      * Run mapFn on the interval start and end, returning a new Interval from the resulting DateTimes
@@ -357,5 +364,5 @@ export class Interval<IsValid extends boolean = DefaultValidity> {
      * @example
      * Interval.fromDateTimes(dt1, dt2).mapEndpoints(endpoint => endpoint.plus({ hours: 2 }))
      */
-    mapEndpoints(mapFn: (d: DateTime) => DateTime): Interval;
+    mapEndpoints(mapFn: (d: DateTime) => DateTime): IntervalMaybeValid;
 }

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -38,13 +38,13 @@ function DateTime_staticFormatPresets() {
 
 function DateTime_localOverloads() {
     DateTime.local({ zone: "Atlantic/Azores" }); // $ExpectType DateTime<true>
-    DateTime.local(2021, 8, 28, { zone: "Atlantic/Azores" }); // $ExpectType DateTime<boolean>
+    DateTime.local(2021, 8, 28, { zone: "Atlantic/Azores" }); // $ExpectType DateTime<true> | DateTime<false>
 }
 
 function DateTime_utcOverloads() {
     DateTime.utc(); // $ExpectType DateTime<true>
     DateTime.utc({ locale: "en-US" }); // $ExpectType DateTime<true>
-    DateTime.utc(2018, 5, 31, 23, { numberingSystem: "arabext" }); // $ExpectType DateTime<boolean>
+    DateTime.utc(2018, 5, 31, 23, { numberingSystem: "arabext" }); // $ExpectType DateTime<true> | DateTime<false>
     // @ts-expect-error
     DateTime.utc(2019, { locale: "en-GB" }, 5);
 }
@@ -395,7 +395,7 @@ function DateTime_setZone() {
 }
 
 function DateTime_utcAndLocalConversions() {
-    DateTime.utc(2017, 5, 15); // $ExpectType DateTime<boolean>
+    DateTime.utc(2017, 5, 15); // $ExpectType DateTime<true> | DateTime<false>
     DateTime.utc(); // $ExpectType DateTime<true>
     DateTime.local().toUTC(); // $ExpectType DateTime<true>
     DateTime.utc().toLocal(); // $ExpectType DateTime<true>
@@ -599,11 +599,11 @@ function Interval_contains(i: Interval) {
 }
 
 function Interval_set(i: Interval) {
-    i.set({ end: DateTime.local(2020) }); // $ExpectType Interval<boolean>
+    i.set({ end: DateTime.local(2020) }); // $ExpectType Interval<true> | Interval<false>
 }
 
 function Interval_mapEndpoints(i: Interval) {
-    i.mapEndpoints(d => d); // $ExpectType Interval<boolean>
+    i.mapEndpoints(d => d); // $ExpectType Interval<true> | Interval<false>
 }
 
 function Interval_intersection(i: Interval) {
@@ -624,8 +624,8 @@ function Interval_toStringMethods(i: Interval) {
 }
 
 function Interval_toDuration(i: Interval) {
-    i.toDuration("months"); // $ExpectType Duration<boolean>
-    i.toDuration(); // $ExpectType Duration<boolean>
+    i.toDuration("months"); // $ExpectType Duration<true> | Duration<false>
+    i.toDuration(); // $ExpectType Duration<true> | Duration<false>
 }
 
 function Interval_divideEqually(i: Interval) {
@@ -807,8 +807,8 @@ function Zones_invalidZone(bogus: DateTime) {
 function Zones_setZone(local: DateTime) {
     local.zoneName; // $ExpectType string | null
     local.toString(); // $ExpectType string
-    local.setZone("America/Los_Angeles"); // $ExpectType DateTime<boolean>
-    local.setZone("America/Los_Angeles", { keepLocalTime: true }); // $ExpectType DateTime<boolean>
+    local.setZone("America/Los_Angeles"); // $ExpectType DateTime<true> | DateTime<false>
+    local.setZone("America/Los_Angeles", { keepLocalTime: true }); // $ExpectType DateTime<true> | DateTime<false>
 }
 
 function Zones_fromISOZoneName(iso: DateTime) {
@@ -817,8 +817,8 @@ function Zones_fromISOZoneName(iso: DateTime) {
 }
 
 function DateTime_zonesFromISOAndFromFormatWithZone() {
-    DateTime.fromISO("2017-05-15T09:10:23", { zone: "Europe/Paris", setZone: true }); // $ExpectType DateTime<boolean>
-    DateTime.fromFormat("2017-05-15T09:10:23 Europe/Paris", "yyyy-MM-dd'T'HH:mm:ss z"); // $ExpectType DateTime<boolean>
+    DateTime.fromISO("2017-05-15T09:10:23", { zone: "Europe/Paris", setZone: true }); // $ExpectType DateTime<true> | DateTime<false>
+    DateTime.fromFormat("2017-05-15T09:10:23 Europe/Paris", "yyyy-MM-dd'T'HH:mm:ss z"); // $ExpectType DateTime<true> | DateTime<false>
 }
 
 /*
@@ -863,57 +863,57 @@ function DateTime_formattingToFormat() {
 function DateTime_parsingFromObject() {
     // @ts-expect-error
     DateTime.fromObject();
-    DateTime.fromObject({}, { zone: "America/Los_Angeles" }); // $ExpectType DateTime<boolean>
-    DateTime.fromObject({ localWeekYear: 2022, localWeekNumber: 1, localWeekday: 1 }, { locale: "en-US" }); // $ExpectType DateTime<boolean>
+    DateTime.fromObject({}, { zone: "America/Los_Angeles" }); // $ExpectType DateTime<true> | DateTime<false>
+    DateTime.fromObject({ localWeekYear: 2022, localWeekNumber: 1, localWeekday: 1 }, { locale: "en-US" }); // $ExpectType DateTime<true> | DateTime<false>
 }
 
 function DateTime_parsingFromISO() {
     // @ts-expect-error
     DateTime.fromISO();
-    DateTime.fromISO("2016-05-25"); // $ExpectType DateTime<boolean>
+    DateTime.fromISO("2016-05-25"); // $ExpectType DateTime<true> | DateTime<false>
 }
 
 function DateTime_parsingFromJSDate() {
     // @ts-expect-error
     DateTime.fromJSDate();
-    DateTime.fromJSDate(new Date()); // $ExpectType DateTime<boolean>
+    DateTime.fromJSDate(new Date()); // $ExpectType DateTime<true> | DateTime<false>
 }
 
 function DateTime_parsingFromRFC2822() {
     // @ts-expect-error
     DateTime.fromRFC2822();
-    DateTime.fromRFC2822("Tue, 01 Nov 2016 13:23:12 +0630"); // $ExpectType DateTime<boolean>
+    DateTime.fromRFC2822("Tue, 01 Nov 2016 13:23:12 +0630"); // $ExpectType DateTime<true> | DateTime<false>
 }
 
 function DateTime_parsingFromHTTP() {
     // @ts-expect-error
     DateTime.fromHTTP();
-    DateTime.fromHTTP("Sunday, 06-Nov-94 08:49:37 GMT"); // $ExpectType DateTime<boolean>
+    DateTime.fromHTTP("Sunday, 06-Nov-94 08:49:37 GMT"); // $ExpectType DateTime<true> | DateTime<false>
 }
 
 function DateTime_parsingFromSQL() {
     // @ts-expect-error
     DateTime.fromSQL();
-    DateTime.fromSQL("2017-05-15 09:24:15"); // $ExpectType DateTime<boolean>
+    DateTime.fromSQL("2017-05-15 09:24:15"); // $ExpectType DateTime<true> | DateTime<false>
 }
 
 function DateTime_parsingFromMillis() {
     // @ts-expect-error
     DateTime.fromMillis();
-    DateTime.fromMillis(1542674993410); // $ExpectType DateTime<boolean>
+    DateTime.fromMillis(1542674993410); // $ExpectType DateTime<true> | DateTime<false>
 }
 
 function DateTime_parsingFromSeconds() {
     // @ts-expect-error
     DateTime.fromSeconds();
-    DateTime.fromSeconds(1542674993); // $ExpectType DateTime<boolean>
+    DateTime.fromSeconds(1542674993); // $ExpectType DateTime<true> | DateTime<false>
 }
 
 function DateTime_parsingFromFormat() {
     // @ts-expect-error
     DateTime.fromFormat();
-    DateTime.fromFormat("May 25 1982", "LLLL dd yyyy"); // $ExpectType DateTime<boolean>
-    DateTime.fromFormat("mai 25 1982", "LLLL dd yyyy", { locale: "fr" }); // $ExpectType DateTime<boolean>
+    DateTime.fromFormat("May 25 1982", "LLLL dd yyyy"); // $ExpectType DateTime<true> | DateTime<false>
+    DateTime.fromFormat("mai 25 1982", "LLLL dd yyyy", { locale: "fr" }); // $ExpectType DateTime<true> | DateTime<false>
 }
 
 function DateTime_parsingFromFormatExplain() {
@@ -975,9 +975,9 @@ function Math_plusShiftedDuration(dur: Duration) {
 }
 
 function Math_fromISO() {
-    Duration.fromISO("PY23", { conversionAccuracy: "longterm" }); // $ExpectType Duration<boolean>
-    Duration.fromISOTime("21:37.000"); // $ExpectType Duration<boolean>
-    Duration.fromISOTime("21:37.000", { conversionAccuracy: "longterm" }); // $ExpectType Duration<boolean>
+    Duration.fromISO("PY23", { conversionAccuracy: "longterm" }); // $ExpectType Duration<true> | Duration<false>
+    Duration.fromISOTime("21:37.000"); // $ExpectType Duration<true> | Duration<false>
+    Duration.fromISOTime("21:37.000", { conversionAccuracy: "longterm" }); // $ExpectType Duration<true> | Duration<false>
 }
 
 function Math_diffWithAccuracyAndUnits(end: DateTime, start: DateTime) {
@@ -991,7 +991,7 @@ function Math_reconfigure(dur: Duration<true>) {
 
 function Math_untilAndIntervalToDuration(end: DateTime, start: DateTime, i: Interval) {
     start.until(end); // $ExpectType Interval<true> | DateTime<false> || DateTime<false> | Interval<true>
-    i.toDuration(["years", "months", "days"]); // $ExpectType Duration<boolean>
+    i.toDuration(["years", "months", "days"]); // $ExpectType Duration<true> | Duration<false>
 }
 
 function Math_invalidProperties(dur: Duration<true>) {
@@ -1051,4 +1051,49 @@ function DateTime_typeGuardCheck(dt: DateTime): void {
     }
 
     dt; // $ExpectType DateTime<boolean>
+}
+
+/*
+ * ============================================================
+ * Validity narrowing
+ * ============================================================
+ */
+function DateTime_isValidNarrowsFactoryResult() {
+    const dt = DateTime.fromISO("2016-05-25");
+
+    if (dt.isValid) {
+        dt; // $ExpectType DateTime<true>
+        dt.toISO(); // $ExpectType string
+        dt.toISODate(); // $ExpectType string
+        return;
+    }
+
+    dt; // $ExpectType DateTime<false>
+    dt.toISO(); // $ExpectType null
+}
+
+function Duration_isValidNarrowsFactoryResult() {
+    const dur = Duration.fromISO("P3Y6M1W4DT12H30M5S");
+
+    if (dur.isValid) {
+        dur; // $ExpectType Duration<true>
+        dur.toISO(); // $ExpectType string
+        return;
+    }
+
+    dur; // $ExpectType Duration<false>
+    dur.toISO(); // $ExpectType null
+}
+
+function Interval_isValidNarrowsFactoryResult() {
+    const interval = Interval.fromISO("2016-05-25/2016-05-27");
+
+    if (interval.isValid) {
+        interval; // $ExpectType Interval<true>
+        interval.toISO(); // $ExpectType string
+        return;
+    }
+
+    interval; // $ExpectType Interval<false>
+    interval.toISO(); // $ExpectType "Invalid Interval"
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/75158
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

## Summary

Reported in #75158. Checking `isValid` stopped narrowing the generic parameter in 3.7.4:

```ts
const dt = DateTime.fromISO("2016-05-25");
if (dt.isValid) {
    dt; // DateTime<boolean>, was DateTime<true>
    dt.toISODate(); // string | null, was string
}
```

Running the repro from that discussion against each published version, this only reproduces on 3.7.4, and not on the TypeScript side:

```
                3.7.1     3.7.2     3.7.3     3.7.4
TS 5.4.5        narrows   narrows   narrows   fails
TS 5.9.3        narrows   narrows   narrows   fails
TS 6.0.3        narrows   narrows   narrows   fails
```

#75340 changed the factory and factory-like return types from `DateTimeMaybeValid`/`IntervalMaybeValid`/`DurationMaybeValid` to the bare classes. Those aliases resolve to a union of the valid and invalid instantiations. `if (x.isValid)` is discriminant narrowing, so it works by selecting a union member, and `DateTime<boolean>` is a single instantiation with nothing to select. The check proves `dt.isValid === true`, but that never reaches the type argument, so `toISO()`/`toISODate()` stay `string | null` in a branch where validity has already been checked.

On the reasoning in #75213 that `DateTimeMaybeValid == DateTime<boolean> == DateTime`: those are mutually assignable, but not interchangeable for narrowing, which needs the declared type to literally be a union.

## What this does and does not revert

The type guards keep the bare types they were given in #75213 and #75340, and `isValid` keeps the `IsValid` return from #75340:

```ts
static isDateTime(o: unknown): o is DateTime;
static isInterval(o: unknown): o is Interval;
static isDuration(o: unknown): o is Duration;
get isValid(): IsValid;
```

Excluding the class in the `else` branch of `isDateTime` (the bug behind #75213) and narrowing on `isValid` are independent. The first needs the guard to assert the bare type, the second needs the factories to return the union, and neither fix requires the other. Only the return types are restored.

## Tests

The suite covered validity narrowing only through a user-defined type guard (`isValidDateTime(dt): dt is DateTime<true>`), which keeps working regardless of what the factories return, so nothing caught this. Added tests that narrow a factory result directly for `DateTime`, `Duration` and `Interval`.

26 existing `$ExpectType` assertions change from `X<boolean>` to `X<true> | X<false>`, which is the union being visible again.

Checked against master with the source changes reverted: the new tests fail there with `DateTime<boolean>` where `DateTime<true>` is expected and `string | null` where `string` is expected. `pnpm test luxon` passes on TypeScript 5.6, 5.7, 5.8, 5.9 and 6.0.
