### PR TITLE
Update dprint and use plugins from npm

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -44,10 +44,10 @@
     },
     // NOTE: if extending this list, also update settings.template.json.
     "plugins": [
-        "https://plugins.dprint.dev/typescript-0.93.3.wasm",
-        "https://plugins.dprint.dev/json-0.19.4.wasm",
-        "https://plugins.dprint.dev/markdown-0.17.8.wasm",
-        "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.0.wasm"
+        "npm:@dprint/typescript@0.96.1",
+        "npm:@dprint/json@0.23.0",
+        "npm:@dprint/markdown@0.22.1",
+        "npm:dprint-plugin-yaml@0.6.0"
     ],
     "indentWidth": 4,
     "lineWidth": 120,

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -95,7 +95,7 @@ const allFiles = [...danger.git.created_files, ...danger.git.modified_files];
 for (const files of chunked(allFiles, 50)) {
     const result = cp.spawnSync(
         process.execPath,
-        ["node_modules/dprint/bin.js", "check", "--list-different", ...files],
+        ["node_modules/dprint/bin.cjs", "check", "--list-different", ...files],
         { encoding: "utf8", maxBuffer: 100 * 1024 * 1024 },
     );
     // https://dprint.dev/cli/#exit-codes

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -80,81 +80,64 @@ newPackageJsonFiles.forEach(p => {
     }
 });
 
-function chunked<T>(arr: T[], size: number): T[][] {
-    const result: T[][] = [];
-    for (let i = 0; i < arr.length; i += size) {
-        result.push(arr.slice(i, i + size));
-    }
-    return result;
-}
-
-const unformatted = [];
-const dprintErrors = [];
 const allFiles = [...danger.git.created_files, ...danger.git.modified_files];
-// We batch this in chunks to avoid hitting max arg length issues.
-for (const files of chunked(allFiles, 50)) {
-    const result = cp.spawnSync(
-        process.execPath,
-        ["node_modules/dprint/bin.cjs", "check", "--list-different", ...files],
-        { encoding: "utf8", maxBuffer: 100 * 1024 * 1024 },
-    );
-    // https://dprint.dev/cli/#exit-codes
-    switch (result.status) {
-        case 0:
-        case 14:
-            // No change or no files matched
-            break;
-        case 20:
-            for (const line of result.stdout.split(/\r?\n/)) {
-                if (line) {
-                    unformatted.push(path.relative(process.cwd(), line));
-                }
-            }
-            break;
-        default:
-            dprintErrors.push(result.stderr.trim());
-            break;
-    }
-}
+// The file paths are provided over stdin to avoid hitting max arg length issues.
+const result = cp.spawnSync(
+    process.execPath,
+    ["node_modules/dprint/bin.cjs", "check", "--list-different", "--stdin-files"],
+    { encoding: "utf8", input: allFiles.join("\n"), maxBuffer: 100 * 1024 * 1024 },
+);
+// https://dprint.dev/cli/#exit-codes
+switch (result.status) {
+    case 0:
+    case 14:
+        // No change or no files matched
+        break;
+    case 20: {
+        const unformatted = result.stdout.split(/\r?\n/)
+            .filter(line => line)
+            .map(line => path.relative(process.cwd(), line));
+        const message = [
+            "## Formatting",
+            "",
+        ];
 
-if (dprintErrors.length > 0) {
-    fail("dprint failed to execute");
-
-    // Try and make sure no reasonable error could ever close the code block.
-    // You can open a code block with as many backticks as you want, so long as
-    // you close it with the same string. Inside of the code block, any lower
-    // number of backticks cannot close the block.
-    const codeBlock = "``````````";
-    const message = [
-        "## Formatting errors",
-        "",
-        codeBlock,
-        dprintErrors.join("\n\n"),
-        codeBlock,
-    ];
-
-    markdown(message.join("\n"));
-} else if (unformatted.length > 0) {
-    const message = [
-        "## Formatting",
-        "",
-    ];
-
-    message.push(
-        `The following files are not formatted:
+        message.push(
+            `The following files are not formatted:
 1. ` + unformatted.slice(0, 5).join("\n1. "),
-    );
-    if (unformatted.length > 5) {
-        const extras = unformatted.slice(5);
-        message.push(`
+        );
+        if (unformatted.length > 5) {
+            const extras = unformatted.slice(5);
+            message.push(`
 <details>
 <summary>as well as these ${extras.length} other files...</summary>
 <p>${extras.join(", ")}</p>
 </details>
 `);
+        }
+
+        message.push("\nConsider running `pnpm dprint fmt` on these files to make review easier.");
+
+        markdown(message.join("\n"));
+        break;
     }
+    default: {
+        fail("dprint failed to execute");
 
-    message.push("\nConsider running `pnpm dprint fmt` on these files to make review easier.");
+        // Try and make sure no reasonable error could ever close the code block.
+        // You can open a code block with as many backticks as you want, so long as
+        // you close it with the same string. Inside of the code block, any lower
+        // number of backticks cannot close the block.
+        const codeBlock = "``````````";
+        const message = [
+            "## Formatting errors",
+            "",
+            codeBlock,
+            result.stderr.trim(),
+            codeBlock,
+        ];
 
-    markdown(message.join("\n"));
+        markdown(message.join("\n"));
+        break;
+    }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "@definitelytyped/header-parser": "latest",
         "@definitelytyped/typescript-versions": "latest",
         "@definitelytyped/utils": "latest",
-        "dprint": "^0.56.0",
+        "dprint": "^0.56.1",
         "eslint-plugin-jsdoc": "^44.2.7",
         "husky": "^9.1.7",
         "lint-staged": "^15.2.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "@definitelytyped/header-parser": "latest",
         "@definitelytyped/typescript-versions": "latest",
         "@definitelytyped/utils": "latest",
-        "dprint": "^0.49.0",
+        "dprint": "^0.56.0",
         "eslint-plugin-jsdoc": "^44.2.7",
         "husky": "^9.1.7",
         "lint-staged": "^15.2.0",

--- a/types/lodash-es/scripts/generate-modules.ts
+++ b/types/lodash-es/scripts/generate-modules.ts
@@ -114,7 +114,7 @@ import { ${flattenModules.map(val => `${val} as ${val}1`).join(",")}} from 'loda
 function findDprint() {
     let p = __dirname;
     while (true) {
-        const dprintPath = path.join(p, "node_modules", "dprint", "bin.js");
+        const dprintPath = path.join(p, "node_modules", "dprint", "bin.cjs");
         if (fs.existsSync(dprintPath)) {
             return dprintPath;
         }

--- a/types/node/scripts/generate-docs/docs.ts
+++ b/types/node/scripts/generate-docs/docs.ts
@@ -84,7 +84,7 @@ const ignoreFiles = new Set([
 function findDprint() {
     let p = __dirname;
     while (true) {
-        const dprintPath = join(p, "node_modules", "dprint", "bin.js");
+        const dprintPath = join(p, "node_modules", "dprint", "bin.cjs");
         if (fs.existsSync(dprintPath)) {
             return dprintPath;
         }


### PR DESCRIPTION
Updates dprint and uses the dprint plugins found on npm.

We need to run a formatting run on this, which updates 12 test files that have extra parens in places that they don't need it. What's the best way to do that without notifying a bunch of package authors about needing to review the PR?