### PR TITLE
[office-js][office-js-preview] (WXP) Correct minimum supported task pane width

### DIFF
--- a/types/office-js-preview/index.d.ts
+++ b/types/office-js-preview/index.d.ts
@@ -9028,19 +9028,31 @@ declare namespace Office {
          *
          * **Requirement set**: {@link https://learn.microsoft.com/javascript/api/requirement-sets/common/task-pane-api-requirement-sets | TaskPaneApi 1.1}
          *
-         * **Important**: The default width of the task pane of an add-in varies depending on the platform.
+         * **Important**: The minimum and maximum width constraints vary by platform.
+         *
+         * - **Web (Excel)**: Between 350 and 500 px (inclusive)
+         *
+         * - **Web (Word)**: Between 330 and 500 px (inclusive)
+         *
+         * - **Windows**: Between 86 px and 50% of the client window
+         *
+         * - **Mac**: Between 270 px and 50% of the client window
+         * 
+         * The default width of the task pane of an add-in varies depending on the platform.
          *
          * - **Web (Excel)**: 350 px
          *
          * - **Web (Word)**: 330 px
          *
-         * - **Windows, Mac**: 51 px
+         * - **Windows**: 320 px
+         *
+         * - **Mac**: 270 px
          *
          * If you pass a width beyond the minimum and maximum constraints, the task pane isn't resized and no error is shown.
          *
-         * @param width The width of a task pane in pixels. The minimum and maximum constraints vary by platform. In Excel on the web, the width must be between
-         *              350 and 500 px (inclusive). In Word on the web, the width must be between 330 and 500 px (inclusive). In Office on Windows and on Mac, the width
-         *              must be between 51 px and 50% of the client window.
+         * The `setWidth` method isn't supported in PowerPoint on the web.
+         *
+         * @param width The width of a task pane in pixels.
          */
         setWidth(width: number): void;
     }

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -9028,19 +9028,31 @@ declare namespace Office {
          *
          * **Requirement set**: {@link https://learn.microsoft.com/javascript/api/requirement-sets/common/task-pane-api-requirement-sets | TaskPaneApi 1.1}
          *
-         * **Important**: The default width of the task pane of an add-in varies depending on the platform.
+         * **Important**: The minimum and maximum width constraints vary by platform.
+         *
+         * - **Web (Excel)**: Between 350 and 500 px (inclusive)
+         *
+         * - **Web (Word)**: Between 330 and 500 px (inclusive)
+         *
+         * - **Windows**: Between 86 px and 50% of the client window
+         *
+         * - **Mac**: Between 270 px and 50% of the client window
+         * 
+         * The default width of the task pane of an add-in varies depending on the platform.
          *
          * - **Web (Excel)**: 350 px
          *
          * - **Web (Word)**: 330 px
          *
-         * - **Windows, Mac**: 51 px
+         * - **Windows**: 320 px
+         *
+         * - **Mac**: 270 px
          *
          * If you pass a width beyond the minimum and maximum constraints, the task pane isn't resized and no error is shown.
          *
-         * @param width The width of a task pane in pixels. The minimum and maximum constraints vary by platform. In Excel on the web, the width must be between
-         *              350 and 500 px (inclusive). In Word on the web, the width must be between 330 and 500 px (inclusive). In Office on Windows and on Mac, the width
-         *              must be between 51 px and 50% of the client window.
+         * The `setWidth` method isn't supported in PowerPoint on the web.
+         *
+         * @param width The width of a task pane in pixels.
          */
         setWidth(width: number): void;
     }


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/OfficeDev/office-js/issues/6893>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.