### PR TITLE
[react-virtualized] Make columnIndex optional in CellMeasurerCache.getHeight/getWidth

### DIFF
--- a/types/react-virtualized/dist/es/CellMeasurer.d.ts
+++ b/types/react-virtualized/dist/es/CellMeasurer.d.ts
@@ -29,8 +29,8 @@ export class CellMeasurerCache implements CellMeasurerCacheInterface {
     readonly defaultWidth: number;
     hasFixedHeight(): boolean;
     hasFixedWidth(): boolean;
-    getHeight(rowIndex: number, columnIndex: number): number;
-    getWidth(rowIndex: number, columnIndex: number): number;
+    getHeight(rowIndex: number, columnIndex?: number): number;
+    getWidth(rowIndex: number, columnIndex?: number): number;
     has(rowIndex: number, columnIndex: number): boolean;
     rowHeight: (params: { index: number }) => number;
     set(rowIndex: number, columnIndex: number, width: number, height: number): void;

--- a/types/react-virtualized/package.json
+++ b/types/react-virtualized/package.json
@@ -36,6 +36,10 @@
         {
             "name": "Adam Zmenak",
             "githubUsername": "azmenak"
+        },
+        {
+            "name": "Viktor Kolyshkin",
+            "githubUsername": "Viktor-Kolyshkin"
         }
     ]
 }

--- a/types/react-virtualized/react-virtualized-tests.tsx
+++ b/types/react-virtualized/react-virtualized-tests.tsx
@@ -1810,3 +1810,11 @@ export class GridCellRangeRendererExample extends PureComponent<{}, any> {
         return renderedCells;
     }
 }
+
+// CellMeasurerCache.getHeight / getWidth: columnIndex is optional (the library
+// defaults it to 0), matching CellMeasurerCacheInterface. Common for single-column List/Table.
+const singleColumnMeasurerCache = new CellMeasurerCache({ fixedWidth: true });
+const measuredRowHeight: number = singleColumnMeasurerCache.getHeight(0);
+const measuredRowWidth: number = singleColumnMeasurerCache.getWidth(0);
+const measuredCellHeight: number = singleColumnMeasurerCache.getHeight(0, 1);
+const measuredCellWidth: number = singleColumnMeasurerCache.getWidth(0, 1);


### PR DESCRIPTION
`CellMeasurerCache.getHeight` and `getWidth` declare `columnIndex` as a
required parameter, but:

1. The library defaults it to `0` at runtime, so a single-argument call is valid.
2. The upstream interface already types it as optional.
3. This package's own `CellMeasurerCacheInterface` already declares
   `columnIndex?: number` — the class currently contradicts the interface it `implements`.

As a result the common single-column pattern `cache.getHeight(0)` /
`cache.getWidth(0)` (typical for one-column `List` / `Table`) fails to
compile with `TS2554: Expected 2 arguments, but got 1`. This PR makes the
parameter optional on the class to match the runtime, the upstream
interface, and the package's own interface. Two-argument calls remain valid
(covered by the added test).

I'm also adding myself as a package owner to help maintain these types.

- [x] Use a meaningful title for the pull request.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change.
- [x] Provide a URL to source code which provides context:
  - Default value (`columnIndex: number = 0`): https://github.com/bvaughn/react-virtualized/blob/master/source/CellMeasurer/CellMeasurerCache.js#L141-L153
  - Upstream interface (`getHeight`/`getWidth` optional, `has` required): https://github.com/bvaughn/react-virtualized/blob/master/source/CellMeasurer/types.js#L6-L14
