### PR TITLE
[react-dom] Add `reason` parameter to `browser()`

### DIFF
--- a/types/react-dom/canary.d.ts
+++ b/types/react-dom/canary.d.ts
@@ -40,7 +40,14 @@ export interface BrowserUsable {
 }
 
 declare module "." {
-    function browser(): BrowserUsable;
+    /**
+     * Creates an opaque Usable that opts a subtree into browser-only rendering.
+     * `reason` is diagnostic metadata: an SSR renderer uses it as the `cause` of
+     * the recoverable error it reports when deferring the subtree to the browser.
+     * A function is called lazily by that renderer; in the browser the reason is
+     * never observed.
+     */
+    function browser(reason?: string | (() => unknown)): BrowserUsable;
 }
 
 declare module "react" {

--- a/types/react-dom/test/canary-tests.tsx
+++ b/types/react-dom/test/canary-tests.tsx
@@ -113,4 +113,14 @@ function browserUsableTests() {
     // browser() returns an opaque, renderer-specific Usable that React.use accepts
     // $ExpectType unknown
     React.use(ReactDOM.browser());
+
+    // The reason can be a string or a lazy initializer whose return value an
+    // SSR renderer uses as the cause of the recoverable error.
+    // $ExpectType BrowserUsable
+    ReactDOM.browser("Only render this content in a browser");
+    // $ExpectType BrowserUsable
+    ReactDOM.browser(() => new Error("Only render this content in a browser"));
+
+    // @ts-expect-error -- the reason is a string or a zero-arg initializer, not an arbitrary value
+    ReactDOM.browser(new Error("Only render this content in a browser"));
 }


### PR DESCRIPTION
Types for https://github.com/react/react/pull/37241
