### PR TITLE
[autosuggest-highlight] Make empty index.d.ts a module

### DIFF
--- a/types/autosuggest-highlight/index.d.ts
+++ b/types/autosuggest-highlight/index.d.ts
@@ -1,0 +1,4 @@
+// Despite not having any definitions, this file must exist on DefinitelyTyped.
+// Currently, the tooling assumes that this file exists and performs extra lints,
+// as well as using it to figure out where things are.
+export {};


### PR DESCRIPTION
The `autosuggest-highlight` implementation has no root export (consumers import `autosuggest-highlight/match` and `autosuggest-highlight/parse` only). The root `index.d.ts` is therefore empty (0 bytes).

TypeScript skips empty files. When `@types/autosuggest-highlight` is picked up as an implicit type library, `tsc` then reports:

```
error TS6053: File '.../node_modules/@types/autosuggest-highlight/index.d.ts' not found.
  The file is in the program because:
    Entry point for implicit type library 'autosuggest-highlight'
```

This breaks tools that typecheck without `"types"` / `"skipLibCheck"` covering that case (for example `ts-to-zod` validating generated files).

Fix: `export {}` so the file is a non-empty module. Same pattern as `types/graphql-upload/index.d.ts`. Subpath types and tests are unchanged.

This package is in use via `autosuggest-highlight/match` and `autosuggest-highlight/parse`.