### PR TITLE
feature(jasmine) add new jasmine 7 API

### DIFF
--- a/types/jasmine-reporters/jasmine-reporters-tests.ts
+++ b/types/jasmine-reporters/jasmine-reporters-tests.ts
@@ -48,7 +48,7 @@ function JUnitXmlReporterSpec_js() {
         filename: "text",
         failedExpectations: [],
         deprecationWarnings: [],
-        status: "text",
+        status: "passed",
         duration: null,
         properties: null,
     };

--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -377,10 +377,6 @@ declare namespace jasmine {
      * @returns {Clock}
      */
     function clock(): Clock;
-    /**
-     * @deprecated Private method that may be changed or removed in the future
-     */
-    function DiffBuilder(): DiffBuilder;
 
     /**
      * Formats a value for display, taking into account the current set of
@@ -734,16 +730,6 @@ declare namespace jasmine {
         message?: string | undefined;
     }
 
-    /**
-     * @deprecated Private type that may be changed or removed in the future
-     */
-    interface DiffBuilder {
-        setRoots(actual: any, expected: any): void;
-        recordMismatch(formatter?: (actual: any, expected: any, path?: any, prettyPrinter?: any) => string): void;
-        withPath(pathComponent: string, block: () => void): void;
-        getMessage(): string;
-    }
-
     interface MatchersUtil {
         equals(a: any, b: any): boolean;
         contains<T>(
@@ -801,14 +787,6 @@ declare namespace jasmine {
          * @since 2.0.0
          */
         topSuite(): Suite;
-    }
-
-    interface HtmlReporter {
-        new(): any;
-    }
-
-    interface HtmlSpecFilter {
-        new(): any;
     }
 
     interface Result {
@@ -1518,29 +1496,11 @@ declare namespace jasmine {
         extend(destination: any, source: any): any;
     }
 
-    interface JsApiReporter extends CustomReporter {
-        new(): any;
-
-        started: boolean;
-        finished: boolean;
-        runDetails: JasmineDoneInfo;
-
-        status(): string;
-        suiteResults(index: number, length: number): SuiteResult[];
-        specResults(index: number, length: number): SpecResult[];
-        suites(): { [id: string]: SuiteResult };
-        specs(): SpecResult[];
-        executionTime(): number;
-    }
-
     interface Jasmine {
         Spec: Spec;
         clock: Clock;
         util: Util;
     }
-
-    var HtmlReporter: HtmlReporter;
-    var HtmlSpecFilter: HtmlSpecFilter;
 
     /**
      * Default number of milliseconds Jasmine will wait for an asynchronous spec to complete.

--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -52,9 +52,19 @@ declare function xit(expectation: string, assertion?: jasmine.ImplementationCall
 /**
  * Mark a spec as pending, expectation results will be ignored.
  * If you call the function pending anywhere in the spec body, no matter the expectations, the spec will be marked pending.
- * @param reason Reason the spec is pending.
+ * @param reason Reason why the spec is pending.
  */
 declare function pending(reason?: string): void;
+
+/**
+ * Mark a spec as not applicable. This is similar to {@link pending} except
+ * that the spec is never expected to pass in the current environment.
+ *
+ * If you call the function notApplicable anywhere in the spec body, no matter the expectations, the spec will be marked not applicable.
+ * @since 7.0.0
+ * @param reason Reason why the spec is not applicable.
+ */
+declare function notApplicable(reason: string): void;
 
 /**
  * Sets a user-defined property that will be provided to reporters as
@@ -308,8 +318,9 @@ declare namespace jasmine {
          * Whether to forbid duplicate spec or suite names. If set to true, using
          * the same name multiple times in the same immediate parent suite is an
          * error.
+         * @deprecated Deprecated in jasmine 7.
          * @since 5.5.0
-         * @default false
+         * @default true
          */
         forbidDuplicateNames?: boolean | undefined;
         /**
@@ -1314,7 +1325,7 @@ declare namespace jasmine {
         /**
          * Once the spec has completed, this string represents the pass/fail status of this spec.
          */
-        status: string;
+        status: "excluded" | "pending" | "notApplicable" | "failed" | "passed";
 
         /**
          * The time in ms used by the spec execution, including any before/afterEach.
@@ -1338,6 +1349,11 @@ declare namespace jasmine {
          */
         pendingReason: string;
 
+        /**
+         * If the spec is not applicable, this will be the reason.
+         */
+        notApplicableReason: string;
+
         debugLogs: DebugLogEntry[] | null;
 
         /**
@@ -1352,7 +1368,7 @@ declare namespace jasmine {
     }
 
     interface JasmineDoneInfo {
-        overallStatus: string;
+        overallStatus: "incomplete" | "failed" | "passed";
         totalTime: number;
         incompleteReason: string;
         order: Order;

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -447,6 +447,11 @@ describe("Pending specs", () => {
         pending(); // without reason
         pending("this is why it is pending");
     });
+
+    it("can be declared by calling 'notApplicable' in the spec body", () => {
+        expect(true).toBe(false);
+        notApplicable("this is why it is not applicable");
+    });
 });
 
 describe("setSpecProperty", () => {

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -1305,33 +1305,6 @@ describe("jasmine.any", () => {
     });
 });
 
-describe("DiffBuilder", () => {
-    it("records the actual and expected objects", () => {
-        const diffBuilder = jasmine.DiffBuilder();
-        diffBuilder.setRoots({ x: "actual" }, { x: "expected" });
-        diffBuilder.recordMismatch();
-
-        expect(diffBuilder.getMessage()).toEqual(
-            "Expected Object({ x: 'actual' }) to equal Object({ x: 'expected' }).",
-        );
-    });
-
-    it("allows customization of the message", () => {
-        const diffBuilder = jasmine.DiffBuilder();
-        diffBuilder.setRoots({ x: "bar" }, { x: "foo" });
-
-        function darthVaderFormatter(actual: any, expected: any, path: any) {
-            return `I find your lack of ${expected} disturbing. (was ${actual}, at ${path})`;
-        }
-
-        diffBuilder.withPath("x", () => {
-            diffBuilder.recordMismatch(darthVaderFormatter);
-        });
-
-        expect(diffBuilder.getMessage()).toEqual("I find your lack of foo disturbing. (was bar, at $.x)");
-    });
-});
-
 describe("custom asymmetry", () => {
     const tester: jasmine.AsymmetricMatcher<string> = {
         asymmetricMatch: (actual: string, matchersUtil: jasmine.MatchersUtil) => {
@@ -2541,70 +2514,6 @@ describe("Debug logging", function() {
         jasmine.debugLog("test");
     });
 });
-
-(() => {
-    // from boot.js
-    const env = jasmine.getEnv();
-
-    const htmlReporter = new jasmine.HtmlReporter();
-    env.addReporter(htmlReporter);
-
-    const specFilter = new jasmine.HtmlSpecFilter();
-    env.configure({
-        specFilter: spec => {
-            return specFilter.matches(spec.getFullName());
-        },
-    });
-
-    env.setSpecProperty("name", "value");
-    env.setSuiteProperty("other-name", null);
-
-    const currentWindowOnload = window.onload;
-    window.onload = () => {
-        if (currentWindowOnload) {
-            (currentWindowOnload as any)(null);
-        }
-        htmlReporter.initialize();
-        env.execute();
-    };
-
-    afterAll(() => {
-        const jsApiReporter: jasmine.JsApiReporter = (window as any).jsApiReporter;
-        const suites = jsApiReporter.suites();
-        const time = jsApiReporter.executionTime();
-
-        console.log("time", time);
-
-        for (const k in suites) {
-            const suite: jasmine.SuiteResult = suites[k];
-            console.log(suite);
-            console.log("id", suite.id);
-            console.log("description", suite.description);
-            console.log("fullName", suite.fullName);
-            console.log("filename", suite.filename);
-            console.log("fe", suite.failedExpectations);
-
-            for (const fe of suite.failedExpectations) {
-                console.log(">> matcherName:", fe.matcherName);
-                console.log(">> passed:", fe.passed);
-                console.log(">> expected:", fe.expected);
-                console.log(">> actual:", fe.actual);
-                console.log(">> message:", fe.message);
-                console.log(">> stack:", fe.stack);
-            }
-
-            console.log("dw", suite.deprecationWarnings);
-
-            for (const fe of suite.deprecationWarnings) {
-                console.log(">> message:", fe.message);
-            }
-
-            console.log("status", suite.status);
-            console.log("duraiton", suite.duration);
-            console.log("properties", suite.properties);
-        }
-    });
-})();
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;
 jasmine.MAX_PRETTY_PRINT_DEPTH = 40;

--- a/types/jasmine/package.json
+++ b/types/jasmine/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/jasmine",
-    "version": "6.0.9999",
+    "version": "7.0.9999",
     "projects": [
         "http://jasmine.github.io"
     ],

--- a/types/protractor-beautiful-reporter/protractor-beautiful-reporter-tests.ts
+++ b/types/protractor-beautiful-reporter/protractor-beautiful-reporter-tests.ts
@@ -289,6 +289,7 @@ function app_reporter_js() {
     const result: jasmine.SpecResult = {
         passedExpectations: [],
         pendingReason: "text",
+        notApplicableReason: "",
         debugLogs: [],
         id: "text",
         filename: "text",
@@ -296,7 +297,7 @@ function app_reporter_js() {
         fullName: "text",
         failedExpectations: [],
         deprecationWarnings: [],
-        status: "text",
+        status: "passed",
         duration: 0,
         properties: {},
     };


### PR DESCRIPTION
And change `status` property to `string` lateral union.

drop DiffBuilder, HtmlReporter, JsApiReporter

ref https://github.com/jasmine/jasmine/blob/main/release_notes/7.0.0.md

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

I also adjusted two other tests. 
I do not think many users of this will be affected by the `status` changes but will be happy to have help when 
reacting to the status.
