### PR TITLE
[sharedb] Type EditOp.op as any (OT-type-defined shape)

### DIFF
--- a/types/sharedb/lib/sharedb.d.ts
+++ b/types/sharedb/lib/sharedb.d.ts
@@ -106,7 +106,7 @@ export interface RawOp {
 
 export type CreateOp = Partial<RawOp> & { create: { type: string; data: any } };
 export type DeleteOp = Partial<RawOp> & { del: boolean };
-export type EditOp = Partial<RawOp> & { op: any[] };
+export type EditOp = Partial<RawOp> & { op: any };
 
 export type OTType = "ot-text" | "ot-json0" | "ot-json1" | "ot-text-tp2" | "rich-text";
 

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -351,6 +351,13 @@ const op1 = [{ insert: "Hello" }];
 const op2 = [{ retain: 5 }, { insert: " world!" }];
 const op3 = ShareDBClient.types.map["rich-text"].compose(op1, op2);
 
+// An EditOp's `op` belongs to the document's OT type; sharedb core is agnostic
+// to its shape. Most types (json0, ot-text, rich-text) use arrays, but a type
+// may serialize its op to an object instead — so `op` is `any`, not `any[]`.
+const arrayEditOp: ShareDB.EditOp = { op: [{ p: ["numClicks"], na: 1 }] };
+const objectEditOp: ShareDB.EditOp = { op: { ops: [{ retain: 5 }, { insert: " world!" }] } };
+console.log(arrayEditOp.op, objectEditOp.op);
+
 ShareDB.logger.setMethods({
     warn: (...args: any[]) => console.log(...args),
 });


### PR DESCRIPTION
### Summary

`EditOp.op` is currently typed as `any[]`, but an EditOp's `op` is the operation for the document's **OT type** — `sharedb` core is agnostic to it, and its shape is whatever the OT type defines. It is not necessarily an array.

- Most OT types (`json0`, `ot-text`, `rich-text`) use arrays.
- A type may instead serialize its op to an **object** — e.g. a rich-text variant that composes queued ops into a single delta sent as `{ ops: [...] }`.

Because the op payload belongs entirely to the OT type, the core type should be agnostic to its shape. Typing it as `any[]` is too narrow and forces `as any` casts wherever a non-array OT type is handled.

```ts
- export type EditOp = Partial<RawOp> & { op: any[] };
+ export type EditOp = Partial<RawOp> & { op: any };
```

`op` stays a **required** property, so discriminating `CreateOp | DeleteOp | EditOp` by property presence is unaffected. This is a non-breaking widening — existing `any[]` usages still type-check.

`sharedb-tests.ts` covers both the array and `{ ops: [...] }` object shapes. There are even tests in sharedb core that tests simple integer as an op:
https://github.com/share/sharedb/blob/0bfe7d5201c2a3d99c48b2c9357f0ac37d0fb6d9/test/client/submit.js#L1280-L1291

---

Supersedes #75417, as per comment here:
- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/75417#discussion_r3850331234

cc @alecgibson @ericyhwang @ziejka @pxpeterxu