### PR TITLE
[forge-viewer] Fix Viewer3DImpl.rayIntersect return type and add test

### DIFF
--- a/types/forge-viewer/forge-viewer-tests.ts
+++ b/types/forge-viewer/forge-viewer-tests.ts
@@ -49,6 +49,7 @@ Autodesk.Viewing.Initializer(options, async () => {
     modelTests(model);
     modelStructurePanelTests(viewer);
     preferencesTests(viewer);
+    rayIntersectTests(viewer);
     showHideTests(viewer);
     worldUpTests(viewer);
     selectionTests(viewer);
@@ -568,6 +569,20 @@ async function visualClustersTests(viewer: Autodesk.Viewing.GuiViewer3D): Promis
 
     await ext.setLayoutActive(true);
     ext.reset();
+}
+
+function rayIntersectTests(viewer: Autodesk.Viewing.GuiViewer3D): void {
+    const ray = new THREE.Ray(new THREE.Vector3(0, 0, 0), new THREE.Vector3(0, 0, -1));
+
+    // $ExpectType HitTestResult | undefined
+    const result = viewer.impl.rayIntersect(ray, true, [2120], [viewer.model.id]);
+
+    if (result) {
+        // $ExpectType number
+        result.dbId;
+        // $ExpectType Vector3
+        result.point;
+    }
 }
 
 function worldUpTests(viewer: Autodesk.Viewing.GuiViewer3D): void {

--- a/types/forge-viewer/index.d.ts
+++ b/types/forge-viewer/index.d.ts
@@ -2304,7 +2304,7 @@ declare namespace Autodesk {
                     modelId?: number[],
                     intersections?: any[],
                     options?: any,
-                ): HitTestResult;
+                ): HitTestResult | undefined;
                 getRenderProxy(model: Model, fragId: number): any;
                 sceneUpdated(param: boolean): void;
                 setDoNotCut(model: Model, doNotCut: boolean): void;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change.
- [x] Follow the advice from the readme.
- [x] Avoid common mistakes.
- [x] Run `pnpm test forge-viewer`.

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

## Summary
- `Viewer3DImpl.rayIntersect` can return `undefined` when nothing is hit; its return type is now `HitTestResult | undefined`
- Added `rayIntersectTests` to assert the return type via `$ExpectType`