### PR TITLE
[selenium-webdriver] add missing WebElement W3C commands

### DIFF
--- a/types/selenium-webdriver/index.d.ts
+++ b/types/selenium-webdriver/index.d.ts
@@ -1172,6 +1172,43 @@ export interface IWebElement {
     getAttribute(attributeName: string): Promise<string | null>;
 
     /**
+     * Get the value of the given attribute of the element.
+     *
+     * This method, unlike {@link getAttribute}, returns the value of the attribute with the
+     * given name but not the property with the same name.
+     *
+     * See the [W3C WebDriver specification](https://w3c.github.io/webdriver/#get-element-attribute)
+     * for more details.
+     *
+     * @param {string} attributeName The name of the attribute to query.
+     * @return {!Promise<?string>} A promise that will be resolved with the
+     *     attribute's value, or null if the attribute is not set.
+     */
+    getDomAttribute(attributeName: string): Promise<string | null>;
+
+    /**
+     * Get the given property of the referenced web element.
+     * @param {string} propertyName The name of the property to query.
+     * @return {!Promise<string>} A promise that will be resolved with the
+     *     element's property value.
+     */
+    getProperty(propertyName: string): Promise<string>;
+
+    /**
+     * Get the computed WAI-ARIA role of the element.
+     * @return {!Promise<string>} A promise that will be resolved with the
+     *     element's computed role.
+     */
+    getAriaRole(): Promise<string>;
+
+    /**
+     * Get the computed WAI-ARIA label of the element.
+     * @return {!Promise<string>} A promise that will be resolved with the
+     *     element's computed label.
+     */
+    getAccessibleName(): Promise<string>;
+
+    /**
      * Get the visible (i.e. not hidden by CSS) innerText of this element,
      * including sub-elements, without any leading or trailing whitespace.
      * @return {!Promise} A promise that will be resolved with the
@@ -1565,6 +1602,43 @@ export class WebElement implements Serializable<IWebElementId> {
      *     either a string or null.
      */
     getAttribute(attributeName: string): Promise<string | null>;
+
+    /**
+     * Get the value of the given attribute of the element.
+     *
+     * This method, unlike {@link getAttribute}, returns the value of the attribute with the
+     * given name but not the property with the same name.
+     *
+     * See the [W3C WebDriver specification](https://w3c.github.io/webdriver/#get-element-attribute)
+     * for more details.
+     *
+     * @param {string} attributeName The name of the attribute to query.
+     * @return {!Promise<?string>} A promise that will be resolved with the
+     *     attribute's value, or null if the attribute is not set.
+     */
+    getDomAttribute(attributeName: string): Promise<string | null>;
+
+    /**
+     * Get the given property of the referenced web element.
+     * @param {string} propertyName The name of the property to query.
+     * @return {!Promise<string>} A promise that will be resolved with the
+     *     element's property value.
+     */
+    getProperty(propertyName: string): Promise<string>;
+
+    /**
+     * Get the computed WAI-ARIA role of the element.
+     * @return {!Promise<string>} A promise that will be resolved with the
+     *     element's computed role.
+     */
+    getAriaRole(): Promise<string>;
+
+    /**
+     * Get the computed WAI-ARIA label of the element.
+     * @return {!Promise<string>} A promise that will be resolved with the
+     *     element's computed label.
+     */
+    getAccessibleName(): Promise<string>;
 
     /**
      * Get the visible (i.e. not hidden by CSS) innerText of this element,

--- a/types/selenium-webdriver/test/index.ts
+++ b/types/selenium-webdriver/test/index.ts
@@ -519,6 +519,15 @@ function TestWebElement() {
             v.toUpperCase();
         }
     });
+    const maybeDomAttr: Promise<string | null> = element.getDomAttribute("class");
+    maybeDomAttr.then(v => {
+        if (v !== null) {
+            v.toUpperCase();
+        }
+    });
+    stringPromise = element.getProperty("value");
+    stringPromise = element.getAriaRole();
+    stringPromise = element.getAccessibleName();
     stringPromise = element.getCssValue("display");
     driver = element.getDriver();
     element.getLocation().then((location: webdriver.ILocation) => {});


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [`lib/webdriver.js`](https://github.com/SeleniumHQ/selenium/blob/trunk/javascript/selenium-webdriver/lib/webdriver.js)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json` — n/a, all four predate the declared version.

`getDomAttribute`, `getProperty`, `getAriaRole` and `getAccessibleName` have shipped for years but are not declared, so calling them needs a cast.

Signatures follow the implementation's JSDoc. Added to `IWebElement` and `WebElement`, as the existing methods are; `WebElementPromise` inherits them.
