### PR TITLE
[d3-selection] Implement type-safe events

### DIFF
--- a/types/d3-selection/d3-selection-tests.ts
+++ b/types/d3-selection/d3-selection-tests.ts
@@ -1119,6 +1119,152 @@ if (listener) {
 // remove listener
 body = body.on("click", null); // check chaining return type by re-assigning
 
+// Utils --------------------------------------------
+
+let test_ExtractEventNames: [
+    // $ExpectType 'a'
+    d3Selection.Selection.ExtractEventNames<"a">,
+    // $ExpectType 'a'
+    d3Selection.Selection.ExtractEventNames<"a.1">,
+    // $ExpectType 'a' | 'b'
+    d3Selection.Selection.ExtractEventNames<"a b">,
+    // $ExpectType 'a' | 'b' | 'c'
+    d3Selection.Selection.ExtractEventNames<"a b c">,
+    // $ExpectType 'a' | 'b'
+    d3Selection.Selection.ExtractEventNames<"a.1 b">,
+    // $ExpectType 'a' | 'b'
+    d3Selection.Selection.ExtractEventNames<"a.1 b.2">,
+    // $ExpectType 'a' | 'b'
+    d3Selection.Selection.ExtractEventNames<"a b.2">,
+    // $ExpectType 'a'
+    d3Selection.Selection.ExtractEventNames<"a ">,
+    // $ExpectType 'a'
+    d3Selection.Selection.ExtractEventNames<" a">,
+    // $ExpectType 'a'
+    d3Selection.Selection.ExtractEventNames<" a ">,
+    // $ExpectType 'a' | 'b'
+    d3Selection.Selection.ExtractEventNames<" a   b ">,
+];
+
+let test_GetEventMapForElement: [
+    // $ExpectType HTMLElementEventMap
+    d3Selection.Selection.GetEventMapForElement<HTMLDivElement>,
+    // $ExpectType SVGElementEventMap
+    d3Selection.Selection.GetEventMapForElement<SVGGElement>,
+    // $ExpectType ElementEventMap & GlobalEventHandlersEventMap
+    d3Selection.Selection.GetEventMapForElement<Element>,
+    // $ExpectType GlobalEventHandlersEventMap
+    d3Selection.Selection.GetEventMapForElement<ParentNode>,
+    // $ExpectType GlobalEventHandlersEventMap
+    d3Selection.Selection.GetEventMapForElement<Node>,
+    // $ExpectType WindowEventMap
+    d3Selection.Selection.GetEventMapForElement<Window>,
+    // $ExpectType DocumentEventMap
+    d3Selection.Selection.GetEventMapForElement<Document>,
+    // $ExpectType never
+    d3Selection.Selection.GetEventMapForElement<never>,
+    // $ExpectType HTMLElementEventMap | GlobalEventHandlersEventMap | SVGElementEventMap | (ElementEventMap & GlobalEventHandlersEventMap) | WindowEventMap | DocumentEventMap
+    d3Selection.Selection.GetEventMapForElement<any>,
+    // $ExpectType GlobalEventHandlersEventMap
+    d3Selection.Selection.GetEventMapForElement<unknown>,
+];
+
+let test_EventNameToInterface: [
+    // $ExpectType MouseEvent
+    d3Selection.Selection.EventNameToInterface<"mousedown", HTMLDialogElement>,
+    // $ExpectType CustomEvent<any>
+    d3Selection.Selection.EventNameToInterface<"visibilitychange", HTMLDialogElement>,
+    // $ExpectType Event
+    d3Selection.Selection.EventNameToInterface<"visibilitychange", Document>,
+    // $ExpectType never
+    d3Selection.Selection.EventNameToInterface<never, never>,
+    // $ExpectType any
+    d3Selection.Selection.EventNameToInterface<any, any>,
+    // $ExpectType CustomEvent<any>
+    d3Selection.Selection.EventNameToInterface<string, unknown>,
+];
+
+// Events --------------------------------------------
+
+// inferred from a trivial typename
+body.on("drop", (event) => {
+    // $ExpectType DragEvent
+    event;
+});
+
+// inferred from a typename with a label
+body.on("drop.label", (event) => {
+    // $ExpectType DragEvent
+    event;
+});
+
+// inferred from multiple typenames with labels
+body.on("drop.label keydown mousedown.otherLabel", (event) => {
+    // $ExpectType DragEvent | KeyboardEvent | MouseEvent
+    event;
+});
+
+// invalid
+body.on("", (event) => {
+    // $ExpectType never
+    event;
+});
+
+// invalid value
+body.on("invalidddd", (event) => {
+    // $ExpectType CustomEvent<any>
+    event;
+});
+
+// generic string
+body.on("" as string, (event) => {
+    // $ExpectType any
+    event;
+});
+
+// type-annotations are still allowed (exactly correct)
+body.on("drop", (event: DragEvent) => {});
+
+// type-annotations are still allowed (exactly correct)
+body.on("drop keydown", (event: DragEvent | KeyboardEvent) => {});
+
+// type-annotations are still allowed (wider type)
+body.on("drop", (event: Event) => {});
+
+// type-annotations are still allowed (union with excessive members)
+body.on("drop", (event: DragEvent | KeyboardEvent) => {});
+
+// @ts-expect-error -- incorrect type-annotations are not allowed (missing union member)
+body.on("drop keydown", (event: DragEvent) => {});
+
+// @ts-expect-error -- incorrect type-annotations are not allowed (mismatch)
+body.on("mousedown", (event: DragEvent) => {});
+
+// a listener may be declared with a wider event type
+body.on("drop", (event: Event) => {});
+
+// fallbacks to CustomEvent for types that are not valid for this element
+// (visibilitychange only exists on `Document`, not `HTMLElement`)
+body.on("visibilitychange", (event) => {
+    // $ExpectType CustomEvent<any>
+    event;
+});
+
+// works with non-DOM events
+d3Selection.select(document).on("visibilitychange", (event) => {
+    // $ExpectType Event
+    event;
+});
+
+// event options
+body.on("click", () => {}, { capture: true, passive: true });
+body.on("click", () => {}, true);
+body.on("click", () => {}, {
+    once: true,
+    // @ts-expect-error -- invalid property
+    invalidddd: true,
+});
+
 // dispatch(...) -------------------------------------------------------------------------
 
 const fooEventParam: d3Selection.CustomEventParameters = {
@@ -1156,6 +1302,8 @@ body = body.on("click", (event) => {
     position = d3Selection.pointer(event, event.currentTarget);
     positions = d3Selection.pointers(event);
     positions = d3Selection.pointers(event, event.currentTarget);
+
+    event.buttons; // specific to PointerEvent
 });
 
 // ---------------------------------------------------------------------------------------

--- a/types/d3-selection/index.d.ts
+++ b/types/d3-selection/index.d.ts
@@ -161,6 +161,37 @@ export function selectAll<GElement extends BaseType, OldDatum>(
     nodes: GElement[] | ArrayLike<GElement> | Iterable<GElement>,
 ): Selection<GElement, OldDatum, null, undefined>;
 
+export namespace Selection {
+    /** (helper) given a string like `a.1 b c.2`, it returns a union like `'a' | 'b' | 'c'` */
+    type ExtractEventNames<Input extends string> = Input extends "" ? never
+        : Input extends `${infer A} ${infer B}` // multiple events
+            ? ExtractEventNames<A> | ExtractEventNames<B>
+        : Input extends `${infer A}.${string}` // single event with a name
+            ? A
+        : Input; // single event with no name
+
+    /** (helper) given a `select`able element, returns the EventMap for that element */
+    type GetEventMapForElement<GElement> = GElement extends Window ? WindowEventMap
+        : GElement extends Document ? DocumentEventMap
+        : GElement extends SVGElement ? SVGElementEventMap
+        : GElement extends HTMLElement ? HTMLElementEventMap
+        : GElement extends Element ? ElementEventMap & GlobalEventHandlersEventMap
+        : GlobalEventHandlersEventMap;
+
+    /** (helper) converts an event name to the event class (e.g. `'mouseup'` -> `MouseEvent`) */
+    type EventNameToInterface<Name extends string, GElement> = Name extends keyof GetEventMapForElement<GElement>
+        ? GetEventMapForElement<GElement>[Name]
+        : CustomEvent<any>;
+
+    /**
+     * (helper) given a typenames like `mouseup.a mousedown.b`, this helper will:
+     *  1. extract the types from the string (`mouseup` | `mousedown`)
+     *  2. convert the names to type (`MouseEvent` | `MouseEvent`)
+     */
+    type EventOf<Source extends string, GElement> = string extends Source ? any
+        : EventNameToInterface<ExtractEventNames<Source>, GElement>;
+}
+
 /**
  * A D3 Selection of elements.
  *
@@ -843,7 +874,9 @@ export interface Selection<GElement extends BaseType, Datum, PElement extends Ba
      * to receive events of the same type, such as click.foo and click.bar. To specify multiple typenames, separate typenames with spaces,
      * such as "input change"" or "click.foo click.bar".
      */
-    on(typenames: string): ((this: GElement, event: any, d: Datum) => void) | undefined;
+    on<Source extends string>(
+        typenames: Source,
+    ): ((this: GElement, event: Selection.EventOf<Source, GElement>, d: Datum) => void) | undefined;
     /**
      * Remove a listener for the specified event type names. To remove all listeners for a given name,
      * pass null as the listener and ".foo" as the typename, where foo is the name; to remove all listeners with no name, specify "." as the typename.
@@ -870,9 +903,13 @@ export interface Selection<GElement extends BaseType, Datum, PElement extends Ba
      * Listeners always see the latest datum for their element.
      * Note: while you can use event.pageX and event.pageY directly,
      * it is often convenient to transform the event position to the local coordinate system of that element that received the event using d3.pointer.
-     * @param options An optional options object may specify characteristics about the event listener, such as wehether it is captures or passive; see element.addEventListener.
+     * @param options An optional options object may specify characteristics about the event listener, such as wehether it is captures or passive; see {@link AddEventListenerOptions}.
      */
-    on(typenames: string, listener: (this: GElement, event: any, d: Datum) => void, options?: any): this;
+    on<Source extends string>(
+        typenames: Source,
+        listener: (this: GElement, event: Selection.EventOf<Source, GElement>, d: Datum) => void,
+        options?: boolean | AddEventListenerOptions,
+    ): this;
 
     /**
      * Dispatches a custom event of the specified type to each selected element, in order.

--- a/types/d3-selection/package.json
+++ b/types/d3-selection/package.json
@@ -33,6 +33,10 @@
         {
             "name": "Ambar Mutha",
             "githubUsername": "ambar-arkin"
+        },
+        {
+            "name": "Kyle Hensel",
+            "githubUsername": "k-yle"
         }
     ]
 }


### PR DESCRIPTION
we did this a year ago for d3-**dispatch** (see #73197). This PR does the same for d3-**selection**.


Right now, the `event` argument is always `any`, which is not ideal. We can infer the `event` type (such as `MouseEvent`) based on the event names (such as `mouseup mousedown`). see unit tests for examples.

to avoid breaking changes, the fallback is `any` or `CustomEvent<any>`. not ideal, but for a https://github.com/DefinitelyTyped/DefinitelyTyped/labels/Critical%20package we should probably avoid breaking changes. there were some grumpy comments when we did this for d3-dispatch: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/73197#discussion_r2245075851

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://d3js.org/d3-selection/events
- [x] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.~~