### PR TITLE
[chrome] update since Chrome 152

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -395,6 +395,11 @@ declare namespace chrome {
         type AlarmCreateInfo =
             & {
                 /**
+                 * Name of this alarm.
+                 * @since Chrome 152
+                 */
+                name?: string | undefined;
+                /**
                  * Whether the alarm should persist across sessions (browser restarts). In Chrome, this defaults to true to match historical behavior, but you should set this explicitly to maximize compatibility across browsers.
                  * @since Chrome 150
                  */
@@ -453,9 +458,18 @@ declare namespace chrome {
          * Can return its result via Promise in Manifest V3 or later since Chrome 111.
          */
         function create(alarmInfo: AlarmCreateInfo): Promise<void>;
-        function create(name: string | undefined, alarmInfo: AlarmCreateInfo): Promise<void>;
+        function create(name: undefined, alarmInfo: AlarmCreateInfo): Promise<void>;
+        function create<T extends AlarmCreateInfo>(
+            name: string,
+            alarmInfo: T & (T extends { name: string } ? never : unknown),
+        ): Promise<void>;
         function create(alarmInfo: AlarmCreateInfo, callback: () => void): void;
-        function create(name: string | undefined, alarmInfo: AlarmCreateInfo, callback: () => void): void;
+        function create(name: undefined, alarmInfo: AlarmCreateInfo, callback: () => void): void;
+        function create<T extends AlarmCreateInfo>(
+            name: string,
+            alarmInfo: T & (T extends { name: string } ? never : unknown),
+            callback: () => void,
+        ): void;
 
         /**
          * Gets an array of all the alarms.
@@ -3074,10 +3088,13 @@ declare namespace chrome {
             /**
              * Creates a pane within panel's sidebar.
              * @param title Text that is displayed in sidebar caption.
+             *
+             * Can return its result via Promise in Manifest V3 or later since Chrome 152.
              */
+            createSidebarPane(title: string): Promise<ExtensionSidebarPane>;
             createSidebarPane(
                 title: string,
-                callback?: (
+                callback: (
                     /** An ExtensionSidebarPane object for created sidebar pane. */
                     result: ExtensionSidebarPane,
                 ) => void,
@@ -3091,10 +3108,13 @@ declare namespace chrome {
             /**
              * Creates a pane within panel's sidebar.
              * @param title Text that is displayed in sidebar caption.
+             *
+             * Can return its result via Promise in Manifest V3 or later since Chrome 152.
              */
+            createSidebarPane(title: string): Promise<ExtensionSidebarPane>;
             createSidebarPane(
                 title: string,
-                callback?: (
+                callback: (
                     /** An ExtensionSidebarPane object for created sidebar pane. */
                     result: ExtensionSidebarPane,
                 ) => void,
@@ -3114,19 +3134,23 @@ declare namespace chrome {
              * Sets an expression that is evaluated within the inspected page. The result is displayed in the sidebar pane.
              * @param expression An expression to be evaluated in context of the inspected page. JavaScript objects and DOM nodes are displayed in an expandable tree similar to the console/watch.
              * @param rootTitle An optional title for the root of the expression tree.
+             *
+             * Can return its result via Promise in Manifest V3 or later since Chrome 152.
              */
-            setExpression(expression: string, callback?: () => void): void;
-            setExpression(expression: string, rootTitle: string | undefined, callback?: () => void): void;
+            setExpression(expression: string, rootTitle?: string): Promise<void>;
+            setExpression(expression: string, rootTitle: string | undefined, callback: () => void): void;
             /**
              * Sets a JSON-compliant object to be displayed in the sidebar pane.
              * @param jsonObject An object to be displayed in context of the inspected page. Evaluated in the context of the caller (API client).
              * @param rootTitle An optional title for the root of the expression tree.
+             *
+             * Can return its result via Promise in Manifest V3 or later since Chrome 152.
              */
-            setObject(jsonObject: { [key: string]: unknown }, callback?: () => void): void;
+            setObject(jsonObject: { [key: string]: unknown }, rootTitle?: string): Promise<void>;
             setObject(
                 jsonObject: { [key: string]: unknown },
                 rootTitle: string | undefined,
-                callback?: () => void,
+                callback: () => void,
             ): void;
             /**
              * Sets an HTML page to be displayed in the sidebar pane.
@@ -3156,12 +3180,15 @@ declare namespace chrome {
          * @param title Title that is displayed next to the extension icon in the Developer Tools toolbar.
          * @param iconPath Path of the panel's icon relative to the extension directory.
          * @param pagePath Path of the panel's HTML page relative to the extension directory.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 152.
          */
+        function create(title: string, iconPath: string, pagePath: string): Promise<ExtensionPanel>;
         function create(
             title: string,
             iconPath: string,
             pagePath: string,
-            callback?: (
+            callback: (
                 /** An ExtensionPanel object representing the created panel. */
                 panel: ExtensionPanel,
             ) => void,
@@ -3188,13 +3215,16 @@ declare namespace chrome {
          * @param url The URL of the resource to open.
          * @param lineNumber Specifies the line number to scroll to when the resource is loaded.
          * @param columnNumber Specifies the column number to scroll to when the resource is loaded.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 152.
          */
-        function openResource(url: string, lineNumber: number, callback?: () => void): void;
+        function openResource(url: string, lineNumber: number, columnNumber?: number): Promise<void>;
+        function openResource(url: string, lineNumber: number, callback: () => void): void;
         function openResource(
             url: string,
             lineNumber: number,
             columnNumber: number | undefined,
-            callback?: () => void,
+            callback: () => void,
         ): void;
 
         /**

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1903,40 +1903,76 @@ function testDevtoolsPanels() {
     const title = "title";
     const iconPath = "iconPath";
     const pagePath = "pagePath";
+    const expression = "expression";
+    const rootTitle = "rootTitle";
 
     chrome.devtools.panels.elements; // $ExpectType ElementsPanel
-    chrome.devtools.panels.elements.createSidebarPane(title); // $ExpectType void
+    chrome.devtools.panels.elements.createSidebarPane(title); // $ExpectType Promise<ExtensionSidebarPane>
     chrome.devtools.panels.elements.createSidebarPane(title, result => { // $ExpectType void
         result; // $ExpectType ExtensionSidebarPane
+
+        checkChromeEvent(result.onHidden, () => void 0);
+        checkChromeEvent(result.onShown, () => void 0);
+
+        result.setExpression(expression); // $ExpectType Promise<void>
+        // @ts-expect-error Uncaught DataCloneError: Failed to execute 'postMessage' on 'MessagePort'
+        result.setExpression(expression, () => void 0);
+        result.setExpression(expression, undefined, () => void 0); // $ExpectType void
+        result.setExpression(expression, rootTitle); // $ExpectType Promise<void>
+        result.setExpression(expression, rootTitle, () => void 0); // $ExpectType void
+        // @ts-expect-error
+        result.setExpression(expression, rootTitle, () => {}).then(() => {});
+
+        result.setHeight("100px"); // $ExpectType void
+
+        result.setObject({}); // $ExpectType Promise<void>
+        // @ts-expect-error Uncaught DataCloneError: Failed to execute 'postMessage' on 'MessagePort'
+        result.setObject({}, () => void 0);
+        result.setObject({}, undefined, () => void 0); // $ExpectType void
+        result.setObject({}, rootTitle); // $ExpectType Promise<void>
+        result.setObject({}, rootTitle, () => void 0); // $ExpectType void
+        // @ts-expect-error
+        result.setObject({}, rootTitle, () => {}).then(() => {});
+
+        result.setPage("path"); // $ExpectType void
     });
+    // @ts-expect-error
+    chrome.devtools.panels.elements.createSidebarPane(title, () => {}).then(() => {});
     checkChromeEvent(chrome.devtools.panels.elements.onSelectionChanged, () => void 0);
 
     chrome.devtools.panels.sources; // $ExpectType SourcesPanel
-    chrome.devtools.panels.sources.createSidebarPane(title); // $ExpectType void
+    chrome.devtools.panels.sources.createSidebarPane(title); // $ExpectType Promise<ExtensionSidebarPane>
     chrome.devtools.panels.sources.createSidebarPane(title, result => { // $ExpectType void
         result; // $ExpectType ExtensionSidebarPane
     });
+    // @ts-expect-error
+    chrome.devtools.panels.sources.createSidebarPane(title, () => {}).then(() => {});
     checkChromeEvent(chrome.devtools.panels.sources.onSelectionChanged, () => void 0);
 
     chrome.devtools.panels.themeName; // $ExpectType Theme
 
-    chrome.devtools.panels.create(title, iconPath, pagePath); // $ExpectType void
+    chrome.devtools.panels.create(title, iconPath, pagePath); // $ExpectType Promise<ExtensionPanel>
     chrome.devtools.panels.create(title, iconPath, pagePath, panel => { // $ExpectType void
+        panel; // ExpectType ExtensionPanel
         checkChromeEvent(panel.onHidden, () => void 0);
         checkChromeEvent(panel.onSearch, () => void 0);
         checkChromeEvent(panel.onShown, () => void 0);
         panel.createStatusBarButton("iconPath", "tooltipText", true); // $ExpectType Button
         panel.show(); // $ExpectType void
     });
+    // @ts-expect-error
+    chrome.devtools.panels.create(title, iconPath, pagePath, () => {}).then(() => {});
 
     const url = "url";
     const lineNumber = 10;
     const columnNumber = 10;
 
-    chrome.devtools.panels.openResource(url, lineNumber); // $ExpectType void
-    chrome.devtools.panels.openResource(url, lineNumber, columnNumber); // $ExpectType void
+    chrome.devtools.panels.openResource(url, lineNumber); // $ExpectType Promise<void>
+    chrome.devtools.panels.openResource(url, lineNumber, columnNumber); // $ExpectType Promise<void>
     chrome.devtools.panels.openResource(url, lineNumber, columnNumber, () => void 0); // $ExpectType void
     chrome.devtools.panels.openResource(url, lineNumber, () => void 0); // $ExpectType void
+    // @ts-expect-error
+    chrome.devtools.panels.openResource(url, lineNumber, () => {}).then(() => {});
 
     chrome.devtools.panels.setOpenResourceHandler(); // $ExpectType void
     chrome.devtools.panels.setOpenResourceHandler((resource, lineNumber) => { // $ExpectType void
@@ -2708,6 +2744,8 @@ async function testAlarms() {
     chrome.alarms.create("name", { persistAcrossSessions: true }, () => {});
     // @ts-expect-error Cannot set both when and delayInMinutes.
     chrome.alarms.create("name", { when: 1, delayInMinutes: 1, periodInMinutes: 1 }, () => {});
+    // @ts-expect-error Cannot set alarm name in both separate argument and object form.
+    chrome.alarms.create("name", { delayInMinutes: 1, name: "name" }, () => {});
     // @ts-expect-error
     chrome.alarms.create("name", alarmCreateInfo, () => {}).then(() => {});
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://developer.chrome.com/docs/extensions/reference/api/alarms#type-AlarmCreateInfo
  - https://developer.chrome.com/docs/extensions/reference/api/devtools/panels
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Notes:
- update `chrome.alarms.create()`: can define `name` in option
  
  <img width="826" height="332" alt="image" src="https://github.com/user-attachments/assets/0b7a7115-b96c-4ea4-bdfb-e591bb250056" />

- update `chrome.devtools.panels.sources.createSidebarPane()`: can return a promise

  <img width="645" height="117" alt="image" src="https://github.com/user-attachments/assets/0d09cfb5-6fe5-4bf6-90c0-ed0dfbf61282" />

- update `chrome.devtools.panels.elements.createSidebarPane()`: can return a promise

  <img width="637" height="111" alt="image" src="https://github.com/user-attachments/assets/779015df-ea72-4a73-8343-fd5a872f5a64" />

- update `chrome.devtools.panels.ExtensionSidebarPane.setExpression()`: can return a promise

  <img width="962" height="374" alt="image" src="https://github.com/user-attachments/assets/85243526-b73f-483e-998a-cb147b2755a7" />

- update `chrome.devtools.panels.ExtensionSidebarPane.setObject()`: can return a promise

  <img width="955" height="327" alt="image" src="https://github.com/user-attachments/assets/12226a6f-f153-4d2a-9837-d080aec14710" />

- update `chrome.devtools.panels.create()`: can return a promise

  <img width="671" height="141" alt="image" src="https://github.com/user-attachments/assets/3003ca5b-6f2a-4a2b-97c5-42a5e235fde3" />
  
- update `chrome.devtools.panels.openResource()`: can return a promise
  
   <img width="592" height="112" alt="image" src="https://github.com/user-attachments/assets/801c798d-4e06-4104-9e38-914538e8ea0e" />
