### PR TITLE
node: v26.4

### DIFF
--- a/types/node/buffer.buffer.d.ts
+++ b/types/node/buffer.buffer.d.ts
@@ -463,4 +463,9 @@ declare module "node:buffer" {
          */
         type AllowSharedBuffer = Buffer<ArrayBufferLike>;
     }
+    /**
+     * @deprecated This is intended for internal use, and will be removed once `@types/node` no longer supports
+     * TypeScript versions earlier than 5.7.
+     */
+    type BufferView<T extends NodeJS.ArrayBufferView> = T extends NodeJS.ArrayBufferView<infer B> ? Buffer<B> : never;
 }

--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -3475,7 +3475,6 @@ declare module "node:crypto" {
      * ```
      * @since v24.7.0
      * @param algorithm Variant of Argon2, one of `"argon2d"`, `"argon2i"` or `"argon2id"`.
-     * @experimental
      */
     function argon2(
         algorithm: Argon2Algorithm,
@@ -3515,7 +3514,6 @@ declare module "node:crypto" {
      * console.log(derivedKey.toString('hex'));  // 'af91dad...9520f15'
      * ```
      * @since v24.7.0
-     * @experimental
      */
     function argon2Sync(algorithm: Argon2Algorithm, parameters: Argon2Parameters): NonSharedBuffer;
     /**

--- a/types/node/dgram.d.ts
+++ b/types/node/dgram.d.ts
@@ -15,6 +15,10 @@ declare module "node:dgram" {
         exclusive?: boolean | undefined;
         fd?: number | undefined;
     }
+    interface BindSyncOptions {
+        port?: number | undefined;
+        address?: string | undefined;
+    }
     type SocketType = "udp4" | "udp6";
     interface SocketOptions extends Abortable {
         type: SocketType;
@@ -117,10 +121,12 @@ declare module "node:dgram" {
          * messages on a named `port` and optional `address`. If `port` is not
          * specified or is `0`, the operating system will attempt to bind to a
          * random port. If `address` is not specified, the operating system will
-         * attempt to listen on all addresses. Once binding is complete, a `'listening'` event is emitted and the optional `callback` function is
+         * attempt to listen on all addresses. Once binding is complete, a
+         * `'listening'` event is emitted and the optional `callback` function is
          * called.
          *
-         * Specifying both a `'listening'` event listener and passing a `callback` to the `socket.bind()` method is not harmful but not very
+         * Specifying both a `'listening'` event listener and passing a
+         * `callback` to the `socket.bind()` method is not harmful but not very
          * useful.
          *
          * A bound datagram socket keeps the Node.js process running to receive
@@ -157,9 +163,82 @@ declare module "node:dgram" {
          * @param callback with no parameters. Called when binding is complete.
          */
         bind(port?: number, address?: string, callback?: () => void): this;
-        bind(port?: number, callback?: () => void): this;
-        bind(callback?: () => void): this;
+        bind(port: number, callback: () => void): this;
+        bind(callback: () => void): this;
+        /**
+         * For UDP sockets, causes the `dgram.Socket` to listen for datagram
+         * messages on a named `port` and optional `address` that are passed as
+         * properties of an `options` object passed as the first argument. If
+         * `port` is not specified or is `0`, the operating system will attempt
+         * to bind to a random port. If `address` is not specified, the operating
+         * system will attempt to listen on all addresses. Once binding is
+         * complete, a `'listening'` event is emitted and the optional `callback`
+         * function is called.
+         *
+         * The `options` object may contain a `fd` property. When a `fd` greater
+         * than `0` is set, it will wrap around an existing socket with the given
+         * file descriptor. In this case, the properties of `port` and `address`
+         * will be ignored.
+         *
+         * Specifying both a `'listening'` event listener and passing a
+         * `callback` to the `socket.bind()` method is not harmful but not very
+         * useful.
+         *
+         * The `options` object may contain an additional `exclusive` property that is
+         * used when using `dgram.Socket` objects with the [`cluster`](https://nodejs.org/docs/latest-v26.x/api/cluster.html) module. When
+         * `exclusive` is set to `false` (the default), cluster workers will use the same
+         * underlying socket handle allowing connection handling duties to be shared.
+         * When `exclusive` is `true`, however, the handle is not shared and attempted
+         * port sharing results in an error. Creating a `dgram.Socket` with the `reusePort`
+         * option set to `true` causes `exclusive` to always be `true` when `socket.bind()`
+         * is called.
+         *
+         * A bound datagram socket keeps the Node.js process running to receive
+         * datagram messages.
+         *
+         * If binding fails, an `'error'` event is generated. In rare case (e.g.
+         * attempting to bind with a closed socket), an `Error` may be thrown.
+         *
+         * An example socket listening on an exclusive port is shown below.
+         *
+         * ```js
+         * socket.bind({
+         *   address: 'localhost',
+         *   port: 8000,
+         *   exclusive: true,
+         * });
+         * ```
+         * @since v0.11.14
+         * @param options Required. Supports the following properties:
+         */
         bind(options: BindOptions, callback?: () => void): this;
+        /**
+         * The synchronous counterpart of `socket.bind()`. `bind(2)` is a local,
+         * non-blocking system call, so the bind is performed inline and the resolved
+         * address is returned immediately, including the operating-system-assigned
+         * ephemeral port when `port` is `0`:
+         *
+         * ```js
+         * const dgram = require('node:dgram');
+         *
+         * const socket = dgram.createSocket('udp4');
+         * const address = socket.bindSync({ address: '0.0.0.0', port: 0 });
+         * console.log(address); // e.g. { address: '0.0.0.0', family: 'IPv4', port: 53124 }
+         * ```
+         *
+         * A bind failure such as `EADDRINUSE` is thrown synchronously rather than emitted
+         * as an `'error'` event. After `bindSync()` returns, `socket.address()` is
+         * valid synchronously and the `'listening'` event is emitted on the next tick.
+         *
+         * `address` must be a numeric IP literal; `bindSync()` never performs DNS
+         * resolution (asynchronous name resolution being the only genuinely blocking part
+         * of binding). Incoming datagrams continue to be delivered asynchronously via the
+         * `'message'` event. `bindSync()` always binds the socket's own handle and
+         * does not participate in [`cluster`](https://nodejs.org/docs/latest-v26.x/api/cluster.html) handle sharing.
+         * @since v26.4.0
+         * @returns The bound address as returned by `socket.address()`.
+         */
+        bindSync(options?: BindSyncOptions): AddressInfo;
         /**
          * Close the underlying socket and stop listening for data on it. If a callback is
          * provided, it is added as a listener for the `'close'` event.

--- a/types/node/dgram.d.ts
+++ b/types/node/dgram.d.ts
@@ -262,6 +262,42 @@ declare module "node:dgram" {
         connect(port: number, address?: string, callback?: () => void): void;
         connect(port: number, callback: () => void): void;
         /**
+         * The synchronous counterpart of `socket.connect()`. For a UDP socket
+         * `connect(2)` only records the default peer address and is a local, non-blocking
+         * system call, so the association is performed inline. Any error raised by the
+         * call itself (for example `EAFNOSUPPORT` for a mismatched address family) is
+         * thrown synchronously rather than reported via the `'error'` event. Because
+         * `connect(2)` does not probe reachability, errors such as `ECONNREFUSED` are
+         * still surfaced asynchronously on a later send or receive, exactly as for
+         * `socket.connect()`:
+         *
+         * ```js
+         * const dgram = require('node:dgram');
+         *
+         * const socket = dgram.createSocket('udp4');
+         * socket.connectSync(41234, '127.0.0.1');
+         * console.log(socket.remoteAddress()); // { address: '127.0.0.1', family: 'IPv4', port: 41234 }
+         * ```
+         *
+         * If the socket is still unbound it is bound synchronously first. After
+         * `connectSync()` returns, `socket.remoteAddress()` is valid synchronously
+         * and the `'connect'` event is emitted on the next tick. Trying to call
+         * `connectSync()` on an already connected socket throws an
+         * `ERR_SOCKET_DGRAM_IS_CONNECTED` exception, and calling it while an
+         * asynchronous [`socket.bind()`][] is still in progress throws an
+         * `ERR_SOCKET_ALREADY_BOUND` exception.
+         *
+         * `address` must be a numeric IP literal; `connectSync()` never performs DNS
+         * resolution (asynchronous name resolution being the only genuinely blocking part
+         * of connecting).
+         * @since v26.4.0
+         * @param address A numeric IP address to connect to. Unlike
+         * `socket.connect()`, no DNS resolution is performed, so a host name is not
+         * accepted. If omitted, `'127.0.0.1'` (for `udp4` sockets) or `'::1'` (for
+         * `udp6` sockets) is used.
+         */
+        connectSync(port: number, address?: string): void;
+        /**
          * A synchronous function that disassociates a connected `dgram.Socket` from
          * its remote address. Trying to call `disconnect()` on an unbound or already
          * disconnected socket will result in an `ERR_SOCKET_DGRAM_NOT_CONNECTED` exception.

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -1,5 +1,5 @@
 declare module "node:fs" {
-    import { NonSharedBuffer } from "node:buffer";
+    import { BufferView, NonSharedBuffer } from "node:buffer";
     import { Abortable, EventEmitter, InternalEventEmitter } from "node:events";
     import { FileHandle } from "node:fs/promises";
     import * as stream from "node:stream";
@@ -3029,6 +3029,19 @@ declare module "node:fs" {
      * If no `options` object is specified, it will default with the above values.
      */
     function readSync(fd: number, buffer: NodeJS.ArrayBufferView, opts?: ReadOptions): number;
+    interface ReadFileOptions extends Abortable {
+        encoding?: BufferEncoding | null | undefined;
+        flag?: OpenMode | undefined;
+    }
+    interface ReadFileOptionsWithStringEncoding extends ReadFileOptions {
+        encoding: BufferEncoding;
+    }
+    interface ReadFileOptionsWithBufferEncoding extends ReadFileOptions {
+        encoding?: null | undefined;
+    }
+    interface ReadFileOptionsWithBuffer<T extends NodeJS.ArrayBufferView> extends ReadFileOptionsWithBufferEncoding {
+        buffer: T | ((size: number) => T);
+    }
     /**
      * Asynchronously reads the entire contents of a file.
      *
@@ -3046,6 +3059,11 @@ declare module "node:fs" {
      *
      * If no encoding is specified, then the raw buffer is returned.
      *
+     * If `buffer` is provided and no encoding is specified, the returned `Buffer` is
+     * a view over the supplied buffer containing only the bytes read. If the
+     * supplied buffer is too small to contain the entire file, the callback is
+     * called with an error.
+     *
      * If `options` is a string, then it specifies the encoding:
      *
      * ```js
@@ -3054,7 +3072,8 @@ declare module "node:fs" {
      * readFile('/etc/passwd', 'utf8', callback);
      * ```
      *
-     * When the path is a directory, the behavior of `fs.readFile()` and {@link readFileSync} is platform-specific. On macOS, Linux, and Windows, an
+     * When the path is a directory, the behavior of `fs.readFile()` and
+     * `fs.readFileSync()` is platform-specific. On macOS, Linux, and Windows, an
      * error will be returned. On FreeBSD, a representation of the directory's contents
      * will be returned.
      *
@@ -3092,60 +3111,56 @@ declare module "node:fs" {
      *
      * Aborting an ongoing request does not abort individual operating
      * system requests but rather the internal buffering `fs.readFile` performs.
+     *
+     * An example using the `buffer` option with a pre-allocated buffer:
+     *
+     * ```js
+     * import { Buffer } from 'node:buffer';
+     * import { readFile } from 'node:fs';
+     *
+     * const buf = Buffer.alloc(16384);
+     * readFile('/path/to/file', { buffer: buf }, (err, data) => {
+     *   if (err) throw err;
+     *   console.log(data); // A view over `buf` containing only the bytes read
+     * });
+     * ```
+     *
+     * An example using the `buffer` option with a function returning a buffer:
+     *
+     * ```js
+     * import { Buffer } from 'node:buffer';
+     * import { readFile } from 'node:fs';
+     *
+     * readFile('/path/to/file', {
+     *   buffer: (size) => Buffer.alloc(size),
+     * }, (err, data) => {
+     *   if (err) throw err;
+     *   console.log(data);
+     * });
+     * ```
      * @since v0.1.29
      * @param path filename or file descriptor
      */
+    function readFile<T extends NodeJS.ArrayBufferView>(
+        path: PathOrFileDescriptor,
+        options: ReadFileOptionsWithBuffer<T>,
+        callback: (err: NodeJS.ErrnoException | null, data: BufferView<T>) => void,
+    ): void;
     function readFile(
         path: PathOrFileDescriptor,
-        options:
-            | ({
-                encoding?: null | undefined;
-                flag?: string | undefined;
-            } & Abortable)
-            | undefined
-            | null,
+        options: ReadFileOptionsWithBufferEncoding | null | undefined,
         callback: (err: NodeJS.ErrnoException | null, data: NonSharedBuffer) => void,
     ): void;
-    /**
-     * Asynchronously reads the entire contents of a file.
-     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-     * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
-     * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
-     * If a flag is not provided, it defaults to `'r'`.
-     */
     function readFile(
         path: PathOrFileDescriptor,
-        options:
-            | ({
-                encoding: BufferEncoding;
-                flag?: string | undefined;
-            } & Abortable)
-            | BufferEncoding,
+        options: ReadFileOptionsWithStringEncoding | BufferEncoding,
         callback: (err: NodeJS.ErrnoException | null, data: string) => void,
     ): void;
-    /**
-     * Asynchronously reads the entire contents of a file.
-     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-     * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
-     * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
-     * If a flag is not provided, it defaults to `'r'`.
-     */
     function readFile(
         path: PathOrFileDescriptor,
-        options:
-            | (ObjectEncodingOptions & {
-                flag?: string | undefined;
-            } & Abortable)
-            | BufferEncoding
-            | undefined
-            | null,
+        options: ReadFileOptions | BufferEncoding | null | undefined,
         callback: (err: NodeJS.ErrnoException | null, data: string | NonSharedBuffer) => void,
     ): void;
-    /**
-     * Asynchronously reads the entire contents of a file.
-     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-     * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
-     */
     function readFile(
         path: PathOrFileDescriptor,
         callback: (err: NodeJS.ErrnoException | null, data: NonSharedBuffer) => void,
@@ -3200,16 +3215,37 @@ declare module "node:fs" {
                 | null,
         ): Promise<string | NonSharedBuffer>;
     }
+    interface ReadFileSyncOptions {
+        encoding?: BufferEncoding | null | undefined;
+        flag?: OpenMode | undefined;
+    }
+    interface ReadFileSyncOptionsWithStringEncoding extends ReadFileSyncOptions {
+        encoding: BufferEncoding;
+    }
+    interface ReadFileSyncOptionsWithBufferEncoding extends ReadFileSyncOptions {
+        encoding?: null | undefined;
+    }
+    interface ReadFileSyncOptionsWithBuffer<T extends NodeJS.ArrayBufferView>
+        extends ReadFileSyncOptionsWithBufferEncoding
+    {
+        buffer: T | ((size: number) => T);
+    }
     /**
      * Returns the contents of the `path`.
      *
      * For detailed information, see the documentation of the asynchronous version of
-     * this API: {@link readFile}.
+     * this API: `fs.readFile()`.
      *
      * If the `encoding` option is specified then this function returns a
      * string. Otherwise it returns a buffer.
      *
-     * Similar to {@link readFile}, when the path is a directory, the behavior of `fs.readFileSync()` is platform-specific.
+     * If `buffer` is provided and no encoding is specified, the returned {Buffer} is
+     * a view over the supplied buffer containing only the bytes read. If the
+     * supplied buffer is too small to contain the entire file, an error will be
+     * thrown.
+     *
+     * Similar to `fs.readFile()`, when the path is a directory, the behavior of
+     * `fs.readFileSync()` is platform-specific.
      *
      * ```js
      * import { readFileSync } from 'node:fs';
@@ -3224,45 +3260,19 @@ declare module "node:fs" {
      * @since v0.1.8
      * @param path filename or file descriptor
      */
+    function readFileSync<T extends NodeJS.ArrayBufferView>(
+        path: PathOrFileDescriptor,
+        options: ReadFileSyncOptionsWithBuffer<T>,
+    ): BufferView<T>;
     function readFileSync(
         path: PathOrFileDescriptor,
-        options?: {
-            encoding?: null | undefined;
-            flag?: string | undefined;
-        } | null,
+        options?: ReadFileSyncOptionsWithBufferEncoding | null,
     ): NonSharedBuffer;
-    /**
-     * Synchronously reads the entire contents of a file.
-     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-     * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
-     * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
-     * If a flag is not provided, it defaults to `'r'`.
-     */
     function readFileSync(
         path: PathOrFileDescriptor,
-        options:
-            | {
-                encoding: BufferEncoding;
-                flag?: string | undefined;
-            }
-            | BufferEncoding,
+        options: ReadFileSyncOptionsWithStringEncoding | BufferEncoding,
     ): string;
-    /**
-     * Synchronously reads the entire contents of a file.
-     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-     * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
-     * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
-     * If a flag is not provided, it defaults to `'r'`.
-     */
-    function readFileSync(
-        path: PathOrFileDescriptor,
-        options?:
-            | (ObjectEncodingOptions & {
-                flag?: string | undefined;
-            })
-            | BufferEncoding
-            | null,
-    ): string | NonSharedBuffer;
+    function readFileSync(path: PathOrFileDescriptor, options: ReadFileSyncOptions): string | NonSharedBuffer;
     type WriteFileOptions =
         | (
             & ObjectEncodingOptions

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -1,5 +1,5 @@
 declare module "node:fs/promises" {
-    import { NonSharedBuffer } from "node:buffer";
+    import { BufferView, NonSharedBuffer } from "node:buffer";
     import { Abortable } from "node:events";
     import { Interface as ReadlineInterface } from "node:readline";
     import {
@@ -20,6 +20,10 @@ declare module "node:fs/promises" {
         OpenDirOptions,
         OpenMode,
         PathLike,
+        ReadFileOptions,
+        ReadFileOptionsWithBuffer,
+        ReadFileOptionsWithBufferEncoding,
+        ReadFileOptionsWithStringEncoding,
         ReadOptions,
         ReadOptionsWithBuffer,
         ReadPosition,
@@ -36,7 +40,6 @@ declare module "node:fs/promises" {
         WriteStream,
         WriteVResult,
     } from "node:fs";
-    import { Stream } from "node:stream";
     import { ByteReadableStream, Transform, Writer } from "node:stream/iter";
     import { ReadableStream } from "node:stream/web";
     interface FileChangeInfo<T extends string | Buffer> {
@@ -357,39 +360,61 @@ declare module "node:fs/promises" {
          *
          * If `options` is a string, then it specifies the `encoding`.
          *
+         * If `buffer` is provided and no encoding is specified, the returned {Buffer} is
+         * a view over the supplied buffer containing only the bytes read. If the
+         * supplied buffer is too small to contain the entire file, the operation will
+         * fail.
+         *
          * The `FileHandle` has to support reading.
          *
-         * If one or more `filehandle.read()` calls are made on a file handle and then a `filehandle.readFile()` call is made, the data will be read from the current
+         * If one or more `filehandle.read()` calls are made on a file handle and then a
+         * `filehandle.readFile()` call is made, the data will be read from the current
          * position till the end of the file. It doesn't always read from the beginning
          * of the file.
+         *
+         * An example using the `buffer` option with a pre-allocated buffer:
+         *
+         * ```js
+         * import { Buffer } from 'node:buffer';
+         * import { open } from 'node:fs/promises';
+         *
+         * const file = await open('./some/file/to/read');
+         * try {
+         *   const buf = Buffer.alloc(16384);
+         *   const contents = await file.readFile({ buffer: buf });
+         *   console.log(contents); // A view over `buf` containing only the bytes read
+         * } finally {
+         *   await file.close();
+         * }
+         * ```
+         *
+         * An example using the `buffer` option with a function returning a buffer:
+         *
+         * ```js
+         * import { Buffer } from 'node:buffer';
+         * import { open } from 'node:fs/promises';
+         *
+         * const file = await open('./some/file/to/read');
+         * try {
+         *   const contents = await file.readFile({
+         *     buffer: (size) => Buffer.alloc(size),
+         *   });
+         *   console.log(contents);
+         * } finally {
+         *   await file.close();
+         * }
+         * ```
          * @since v10.0.0
-         * @return Fulfills upon a successful read with the contents of the file. If no encoding is specified (using `options.encoding`), the data is returned as a {Buffer} object. Otherwise, the
-         * data will be a string.
+         * @returns Fulfills upon a successful read with the contents of the
+         * file. If no encoding is specified (using `options.encoding`), the data is
+         * returned as a `Buffer` object. Otherwise, the data will be a string.
          */
-        readFile(
-            options?:
-                | ({ encoding?: null | undefined } & Abortable)
-                | null,
-        ): Promise<NonSharedBuffer>;
-        /**
-         * Asynchronously reads the entire contents of a file. The underlying file will _not_ be closed automatically.
-         * The `FileHandle` must have been opened for reading.
-         */
-        readFile(
-            options:
-                | ({ encoding: BufferEncoding } & Abortable)
-                | BufferEncoding,
-        ): Promise<string>;
-        /**
-         * Asynchronously reads the entire contents of a file. The underlying file will _not_ be closed automatically.
-         * The `FileHandle` must have been opened for reading.
-         */
-        readFile(
-            options?:
-                | (ObjectEncodingOptions & Abortable)
-                | BufferEncoding
-                | null,
-        ): Promise<string | NonSharedBuffer>;
+        readFile<T extends NodeJS.ArrayBufferView>(
+            options: Omit<ReadFileOptionsWithBuffer<T>, "flag">,
+        ): Promise<BufferView<T>>;
+        readFile(options?: Omit<ReadFileOptionsWithBufferEncoding, "flag"> | null): Promise<NonSharedBuffer>;
+        readFile(options: Omit<ReadFileOptionsWithStringEncoding, "flag"> | BufferEncoding): Promise<string>;
+        readFile(options: Omit<ReadFileOptions, "flag"> | BufferEncoding | null): Promise<string | NonSharedBuffer>;
         /**
          * Convenience method to create a `readline` interface and stream over the file.
          * See `filehandle.createReadStream()` for the options.
@@ -1310,50 +1335,21 @@ declare module "node:fs/promises" {
      * @param path filename or `FileHandle`
      * @return Fulfills with the contents of the file.
      */
+    function readFile<T extends NodeJS.ArrayBufferView>(
+        path: PathLike | FileHandle,
+        options: ReadFileOptionsWithBuffer<T>,
+    ): Promise<BufferView<T>>;
     function readFile(
         path: PathLike | FileHandle,
-        options?:
-            | ({
-                encoding?: null | undefined;
-                flag?: OpenMode | undefined;
-            } & Abortable)
-            | null,
+        options?: ReadFileOptionsWithBufferEncoding | null,
     ): Promise<NonSharedBuffer>;
-    /**
-     * Asynchronously reads the entire contents of a file.
-     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-     * If a `FileHandle` is provided, the underlying file will _not_ be closed automatically.
-     * @param options An object that may contain an optional flag.
-     * If a flag is not provided, it defaults to `'r'`.
-     */
     function readFile(
         path: PathLike | FileHandle,
-        options:
-            | ({
-                encoding: BufferEncoding;
-                flag?: OpenMode | undefined;
-            } & Abortable)
-            | BufferEncoding,
+        options: ReadFileOptionsWithStringEncoding | BufferEncoding,
     ): Promise<string>;
-    /**
-     * Asynchronously reads the entire contents of a file.
-     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
-     * If a `FileHandle` is provided, the underlying file will _not_ be closed automatically.
-     * @param options An object that may contain an optional flag.
-     * If a flag is not provided, it defaults to `'r'`.
-     */
     function readFile(
         path: PathLike | FileHandle,
-        options?:
-            | (
-                & ObjectEncodingOptions
-                & Abortable
-                & {
-                    flag?: OpenMode | undefined;
-                }
-            )
-            | BufferEncoding
-            | null,
+        options: ReadFileOptions | BufferEncoding | null,
     ): Promise<string | NonSharedBuffer>;
     /**
      * Asynchronously open a directory for iterative scanning. See the POSIX [`opendir(3)`](http://man7.org/linux/man-pages/man3/opendir.3.html) documentation for more detail.

--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -299,7 +299,7 @@ declare module "node:http" {
         requireHostHeader?: boolean | undefined;
         /**
          * If set to `true`, it enables keep-alive functionality on the socket immediately after a new incoming connection is received,
-         * similarly on what is done in `socket.setKeepAlive([enable][, initialDelay])`.
+         * similarly on what is done in `socket.setKeepAlive()`.
          * @default false
          * @since v16.5.0
          */

--- a/types/node/http2.d.ts
+++ b/types/node/http2.d.ts
@@ -433,7 +433,7 @@ declare module "node:http2" {
          *
          * When the `options.waitForTrailers` option is set, the `'wantTrailers'` event
          * will be emitted immediately after queuing the last chunk of payload data to be
-         * sent. The `http2stream.sendTrailers()` method can then be used to sent trailing
+         * sent. The `http2stream.sendTrailers()` method can then be used to send trailing
          * header fields to the peer.
          *
          * When `options.waitForTrailers` is set, the `Http2Stream` will not automatically
@@ -548,7 +548,7 @@ declare module "node:http2" {
          *
          * When the `options.waitForTrailers` option is set, the `'wantTrailers'` event
          * will be emitted immediately after queuing the last chunk of payload data to be
-         * sent. The `http2stream.sendTrailers()` method can then be used to sent trailing
+         * sent. The `http2stream.sendTrailers()` method can then be used to send trailing
          * header fields to the peer.
          *
          * When `options.waitForTrailers` is set, the `Http2Stream` will not automatically

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -108,6 +108,7 @@
 /// <reference path="util.d.ts" />
 /// <reference path="util/types.d.ts" />
 /// <reference path="v8.d.ts" />
+/// <reference path="vfs.d.ts" />
 /// <reference path="vm.d.ts" />
 /// <reference path="wasi.d.ts" />
 /// <reference path="worker_threads.d.ts" />

--- a/types/node/inspector.d.ts
+++ b/types/node/inspector.d.ts
@@ -43,7 +43,8 @@ declare module "node:inspector" {
      */
     function open(port?: number, host?: string, wait?: boolean): Disposable;
     /**
-     * Deactivate the inspector. Blocks until there are no active connections.
+     * Deactivates the inspector. If there are active connections, they are forcibly
+     * terminated. Blocks until the inspector server has fully stopped.
      */
     function close(): void;
     /**

--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -57,6 +57,12 @@ declare module "node:net" {
     }
     type SocketConnectOpts = TcpSocketConnectOpts | IpcSocketConnectOpts;
     type SocketReadyState = "opening" | "open" | "readOnly" | "writeOnly" | "closed";
+    interface SetKeepAliveOptions {
+        enable?: boolean | undefined;
+        initialDelay?: number | undefined;
+        interval?: number | undefined;
+        count?: number | undefined;
+    }
     interface SocketEventMap extends Omit<stream.DuplexEventMap, "close"> {
         "close": [hadError: boolean];
         "connect": [];
@@ -199,25 +205,27 @@ declare module "node:net" {
          */
         setNoDelay(noDelay?: boolean): this;
         /**
-         * Enable/disable keep-alive functionality, and optionally set the initial
-         * delay before the first keepalive probe is sent on an idle socket.
+         * Configure keep-alive using an options object. See `socket.setKeepAlive()`
+         * for a description of each property.
          *
-         * Set `initialDelay` (in milliseconds) to set the delay between the last
-         * data packet received and the first keepalive probe. Setting `0` for`initialDelay` will leave the value unchanged from the default
-         * (or previous) setting.
-         *
-         * Enabling the keep-alive functionality will set the following socket options:
-         *
-         * * `SO_KEEPALIVE=1`
-         * * `TCP_KEEPIDLE=initialDelay`
-         * * `TCP_KEEPCNT=10`
-         * * `TCP_KEEPINTVL=1`
-         * @since v0.1.92
-         * @param [enable=false]
-         * @param [initialDelay=0]
-         * @return The socket itself.
+         * ```js
+         * socket.setKeepAlive({ enable: true, initialDelay: 1000, interval: 1000, count: 10 });
+         * ```
+         * @since v26.4.0
+         * @returns The socket itself.
          */
-        setKeepAlive(enable?: boolean, initialDelay?: number): this;
+        setKeepAlive(options: SetKeepAliveOptions): this;
+        /**
+         * Configure keep-alive using positional arguments. See
+         * `socket.setKeepAlive()` for a description of each argument.
+         * @since v0.1.92
+         * @param enable **Default:** `false`
+         * @param initialDelay **Default:** `0`
+         * @param interval **Default:** `1000`
+         * @param count **Default:** `10`
+         * @returns The socket itself.
+         */
+        setKeepAlive(enable: boolean, initialDelay?: number, interval?: number, count?: number): this;
         /**
          * Returns the current Type of Service (TOS) field for IPv4 packets or Traffic
          * Class for IPv6 packets for this socket.

--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -226,7 +226,7 @@ declare module "node:net" {
          * @param count **Default:** `10`
          * @returns The socket itself.
          */
-        setKeepAlive(enable: boolean, initialDelay?: number, interval?: number, count?: number): this;
+        setKeepAlive(enable?: boolean, initialDelay?: number, interval?: number, count?: number): this;
         /**
          * Returns the current Type of Service (TOS) field for IPv4 packets or Traffic
          * Class for IPv6 packets for this socket.

--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -25,6 +25,7 @@ declare module "node:net" {
         keepAliveInitialDelay?: number | undefined;
         blockList?: BlockList | undefined;
         typeOfService?: number | undefined;
+        handle?: BoundSocket | undefined;
     }
     interface OnReadOpts {
         buffer: Uint8Array | (() => Uint8Array);
@@ -450,9 +451,92 @@ declare module "node:net" {
         removeListener(eventName: string | symbol, listener: (...args: any[]) => void): this;
         // #endregion
     }
+    interface BoundSocketOptions {
+        /**
+         * Local address to bind. Must be a numeric IP literal; no DNS
+         * resolution is performed. **Default:** `'0.0.0.0'`, or `'::'` when
+         * `ipv6Only` is `true`.
+         */
+        host?: string | undefined;
+        /**
+         * Local port. `0` requests an OS-assigned ephemeral port.
+         * **Default:** `0`.
+         */
+        port?: number | undefined;
+        /**
+         * Sets `IPV6_V6ONLY`, disabling dual-stack support so the
+         * socket binds IPv6 only. Only meaningful for IPv6 binds. **Default:**
+         * `false`.
+         */
+        ipv6Only?: boolean | undefined;
+        /**
+         * Sets `SO_REUSEPORT`, allowing multiple sockets to bind
+         * the same address and port for kernel-level load balancing. Support is
+         * platform-dependent. **Default:** `false`.
+         */
+        reusePort?: boolean | undefined;
+    }
+    /**
+     * Allows for the synchronous creation of a pre-bound socket, that can be passed
+     * to `listen()` or `new net.Socket()` later on. For `listen()` this enables
+     * synchronous port reservation, while for `new net.Socket()`, it allows control
+     * over the local egress port/IP, via `bind(2)` semantics.
+     *
+     * Adoption transfers ownership of the socket; afterwards `address()` and `close()`
+     * throw `ERR_SOCKET_HANDLE_ADOPTED`. A handle that is never adopted must be
+     * closed to avoid leaking the socket.
+     *
+     * ```js
+     * import net from 'node:net';
+     *
+     * const bound = new net.BoundSocket();
+     * const { port } = bound.address();
+     * console.log(`Reserved port ${port} for server`);
+     *
+     * const server = net.createServer();
+     * server.listen(bound); // Adopt as a server, or pass to new net.Socket() instead.
+     * ```
+     * @since v26.4.0
+     */
+    class BoundSocket {
+        /**
+         * @since v26.4.0
+         */
+        constructor(options?: BoundSocketOptions);
+        /**
+         * Returns the bound local address. When bound with `port: 0`, `port` is the
+         * OS-assigned ephemeral port.
+         * @since v26.4.0
+         * @returns An object with `address`, `family`, and `port` properties,
+         * as `server.address()` returns.
+         */
+        address(): AddressInfo;
+        /**
+         * Returns the file descriptor of the bound socket. Ownership remains with the
+         * `BoundSocket`, so the descriptor must not be closed by the caller. The
+         * descriptor is only available before the handle is adopted; afterwards it belongs
+         * to the adopting `net.Server` or `net.Socket` and `fd()` throws
+         * `ERR_SOCKET_HANDLE_ADOPTED`.
+         * @since v26.4.0
+         * @returns The underlying OS file descriptor, or `-1` on platforms
+         * that do not expose one for sockets (such as Windows).
+         */
+        fd(): number;
+        /**
+         * Releases the bound socket. Only needed when the handle is never adopted.
+         * @since v26.4.0
+         */
+        close(): void;
+        /**
+         * Closes the handle if it has not been adopted or closed; otherwise a no-op.
+         * @since v26.4.0
+         */
+        [Symbol.dispose](): void;
+    }
     interface ListenOptions extends Abortable {
         backlog?: number | undefined;
         exclusive?: boolean | undefined;
+        handle?: BoundSocket | undefined;
         host?: string | undefined;
         /**
          * @default false

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -44,6 +44,7 @@ import "./node-tests/url";
 import "./node-tests/util_types";
 import "./node-tests/util";
 import "./node-tests/v8";
+import "./node-tests/vfs";
 import "./node-tests/vm";
 import "./node-tests/wasi";
 import "./node-tests/worker_threads";

--- a/types/node/node-tests/dgram.ts
+++ b/types/node/node-tests/dgram.ts
@@ -145,6 +145,10 @@ sock.bind(8000, "192.0.2.1", () => undefined);
 sock.bind({}, () => undefined);
 sock.bind({ port: 8000, address: "192.0.2.1", exclusive: true });
 sock.bind({ fd: 7, exclusive: true });
+sock.bindSync(); // $ExpectType AddressInfo
+sock.bindSync({}); // $ExpectType AddressInfo
+sock.bindSync({ address: "192.0.2.1" }); // $ExpectType AddressInfo
+sock.bindSync({ address: "192.0.2.1", port: 8000 }); // $ExpectType AddressInfo
 sock.close();
 sock.close(() => undefined);
 sock.connect(8000);

--- a/types/node/node-tests/dgram.ts
+++ b/types/node/node-tests/dgram.ts
@@ -155,6 +155,8 @@ sock.connect(8000);
 sock.connect(8000, "192.0.2.1");
 sock.connect(8000, () => undefined);
 sock.connect(8000, "192.0.2.1", () => undefined);
+sock.connectSync(8000);
+sock.connectSync(8000, "192.0.2.1");
 sock.disconnect();
 sock.dropMembership("233.252.0.0");
 sock.dropMembership("233.252.0.0", "192.0.2.1");

--- a/types/node/node-tests/fs.ts
+++ b/types/node/node-tests/fs.ts
@@ -100,6 +100,19 @@ import { CopyOptions, CopySyncOptions, cp, cpSync, glob, globSync } from "node:f
     fs.readFile("testfile", { encoding: nullEncoding }, (err, data) => stringOrBuffer = data);
 
     fs.readFile("testfile", { flag: "r" }, (err, data) => buffer = data);
+
+    fs.readFile("testfile", { buffer: new Uint8Array(16) }, (err, data) => {
+        data; // $ExpectType Buffer || Buffer<ArrayBuffer>
+    });
+    fs.readFile("testfile", { buffer: new Uint8Array(new SharedArrayBuffer(16)) }, (err, data) => {
+        data; // $ExpectType Buffer || Buffer<SharedArrayBuffer>
+    });
+    fs.readFile("testfile", { buffer }, (err, data) => {
+        data; // $ExpectType Buffer || Buffer<ArrayBufferLike>
+    });
+    fs.readFile("testfile", { buffer: (size) => new Uint8Array(size) }, (err, data) => {
+        data; // $ExpectType Buffer || Buffer<ArrayBuffer>
+    });
 }
 
 {
@@ -1256,6 +1269,9 @@ const anyStatFs: fs.StatsFs | fs.BigIntStatsFs = fs.statfsSync(".", { bigint: Ma
     fd.readFile({ signal: new AbortSignal(), encoding: "utf-8" });
     // @ts-expect-error
     fd.readFile({ encoding: "utf-8", flag: "r" });
+
+    await fd.readFile({ buffer: new Uint8Array(256) }); // $ExpectType Buffer || Buffer<ArrayBuffer>
+    await fd.readFile({ buffer: (size) => new Uint8Array(size) }); // $ExpectType Buffer || Buffer<ArrayBuffer>
 });
 
 {

--- a/types/node/node-tests/net.ts
+++ b/types/node/node-tests/net.ts
@@ -79,7 +79,9 @@ import * as net from "node:net";
     _socket = _socket.setTimeout(500);
 
     _socket = _socket.setNoDelay(true);
-    _socket = _socket.setKeepAlive(true, 10);
+    _socket = _socket.setKeepAlive(true);
+    _socket = _socket.setKeepAlive(true, 1000, 5000, 5);
+    _socket = _socket.setKeepAlive({ enable: true, initialDelay: 500 });
     _socket = _socket.setEncoding("utf8");
     _socket = _socket.resume();
     _socket = _socket.resetAndDestroy();

--- a/types/node/node-tests/net.ts
+++ b/types/node/node-tests/net.ts
@@ -490,3 +490,16 @@ import * as net from "node:net";
     bl.toJSON(); // $ExpectType readonly string[]
     net.BlockList.isBlockList(bl); // $ExpectType boolean
 }
+
+{
+    using boundSocket = new net.BoundSocket({
+        host: "1234:5678::1",
+        port: 8080,
+        ipv6Only: false,
+        reusePort: false,
+    });
+    boundSocket.address(); // $ExpectType AddressInfo
+    boundSocket.fd(); // $ExpectType number
+
+    new net.Socket({ handle: new net.BoundSocket() });
+}

--- a/types/node/node-tests/tls.ts
+++ b/types/node/node-tests/tls.ts
@@ -11,6 +11,7 @@ import {
     DEFAULT_MIN_VERSION,
     EphemeralKeyInfo,
     getCACertificates,
+    getCertificateCompressionAlgorithms,
     getCiphers,
     PeerCertificate,
     rootCertificates,
@@ -41,6 +42,7 @@ import {
             };
         },
         requestOCSP: true,
+        certificateCompression: ["zlib"],
     };
     const tlsSocket = connect(connOpts);
 
@@ -65,6 +67,7 @@ import {
 
     const caCertificates: string[] = getCACertificates("default");
     const ciphers: string[] = getCiphers();
+    const certificateCompressionAlgorithms: string[] = getCertificateCompressionAlgorithms();
     const curve: string = DEFAULT_ECDH_CURVE;
     const maxVersion: string = DEFAULT_MAX_VERSION;
     const minVersion: string = DEFAULT_MIN_VERSION;

--- a/types/node/node-tests/vfs.ts
+++ b/types/node/node-tests/vfs.ts
@@ -1,0 +1,52 @@
+import vfs from "node:vfs";
+
+{
+    const myVfs = vfs.create();
+    myVfs.mkdirSync("/dir", { recursive: true });
+    myVfs.writeFileSync("/dir/hello.txt", "Hello, VFS!");
+
+    console.log(myVfs.readFileSync("/dir/hello.txt", "utf8")); // 'Hello, VFS!'
+}
+
+{
+    // Default in-memory provider
+    const memoryVfs: vfs.VirtualFileSystem = vfs.create();
+
+    // Explicit provider
+    const realVfs: vfs.VirtualFileSystem = vfs.create(new vfs.RealFSProvider("/tmp/sandbox"));
+}
+
+void async function(): Promise<string> {
+    const myVfs = vfs.create();
+    await myVfs.promises.writeFile("/file.txt", "hello");
+    const data = await myVfs.promises.readFile("/file.txt", "utf8");
+    return data;
+};
+
+{
+    class StaticProvider extends vfs.VirtualProvider {
+        get readonly() {
+            return true;
+        }
+
+        statSync(path: string) {/* ... */}
+        openSync(path: string, flags: string) {/* ... */}
+        readdirSync(path: string, options: object) {/* ... */}
+        // ...
+    }
+}
+
+{
+    const provider = new vfs.MemoryProvider();
+    const myVfs = vfs.create(provider);
+    myVfs.writeFileSync("/seed.txt", "initial");
+
+    provider.setReadOnly();
+
+    myVfs.writeFileSync("/x.txt", "fail"); // throws EROFS
+}
+
+{
+    const realVfs = vfs.create(new vfs.RealFSProvider("/tmp/sandbox"));
+    realVfs.writeFileSync("/file.txt", "hello"); // writes /tmp/sandbox/file.txt
+}

--- a/types/node/package.json
+++ b/types/node/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/node",
-    "version": "26.3.9999",
+    "version": "26.4.9999",
     "nonNpm": "conflict",
     "nonNpmDescription": "Node.js",
     "projects": [

--- a/types/node/quic.d.ts
+++ b/types/node/quic.d.ts
@@ -1,10 +1,10 @@
 declare module "node:quic" {
     import { NonSharedBuffer } from "node:buffer";
-    import { KeyObject } from "node:crypto";
+    import { KeyObject, X509Certificate } from "node:crypto";
     import { FileHandle } from "node:fs/promises";
     import { BlockList, SocketAddress } from "node:net";
     import { Writer } from "node:stream/iter";
-    import { EphemeralKeyInfo, PeerCertificate } from "node:tls";
+    import { EphemeralKeyInfo } from "node:tls";
     /**
      * @since v23.8.0
      */
@@ -1437,19 +1437,20 @@ declare module "node:quic" {
             encoding?: BufferEncoding,
         ): Promise<bigint>;
         /**
-         * The local certificate as an object with properties such as `subject`,
-         * `issuer`, `valid_from`, `valid_to`, `fingerprint`, etc. Returns `undefined`
-         * if the session is destroyed or no certificate is available.
+         * The local certificate as a `crypto.X509Certificate` instance. Server
+         * sessions return the certificate configured for the negotiated SNI host.
+         * Client sessions return `undefined` unless a client certificate was sent.
+         * Returns `undefined` if the session is destroyed.
          * @since v26.2.0
          */
-        readonly certificate: PeerCertificate | undefined;
+        readonly certificate: X509Certificate | undefined;
         /**
-         * The peer's certificate as an object with properties such as `subject`,
-         * `issuer`, `valid_from`, `valid_to`, `fingerprint`, etc. Returns `undefined`
-         * if the session is destroyed or the peer did not present a certificate.
+         * The peer's certificate as a `crypto.X509Certificate` instance. Returns
+         * `undefined` if the peer did not present a certificate or the session is
+         * destroyed.
          * @since v26.2.0
          */
-        readonly peerCertificate: PeerCertificate | undefined;
+        readonly peerCertificate: X509Certificate | undefined;
         /**
          * The ephemeral key information for the session, with properties such as
          * `type`, `name`, and `size`. Only available on client sessions. Returns

--- a/types/node/quic.d.ts
+++ b/types/node/quic.d.ts
@@ -608,6 +608,20 @@ declare module "node:quic" {
      * @since v23.8.0
      */
     function listen(onsession: OnSessionCallback, options?: SessionOptions): Promise<QuicEndpoint>;
+    interface ListEndpointsOptions {
+        /**
+         * If `true` (the default), only returns endpoints that are
+         * active (not destroyed, not closing, and not busy). If `false` returns all
+         * endpoints.
+         */
+        active?: boolean | undefined;
+    }
+    /**
+     * Returns the list of all `QuicEndpoint` instances. By default, only active
+     * endpoints are returned.
+     * @since v26.4.0
+     */
+    function listEndpoints(options?: ListEndpointsOptions): QuicEndpoint[];
     /**
      * The endpoint configuration options passed when constructing a new `QuicEndpoint` instance.
      * @since v23.8.0

--- a/types/node/quic.d.ts
+++ b/types/node/quic.d.ts
@@ -28,6 +28,10 @@ declare module "node:quic" {
     /**
      * @since v23.8.0
      */
+    type OnApplicationCallback = (this: QuicSession, applicationoptions: SessionApplicationOptions) => void;
+    /**
+     * @since v23.8.0
+     */
     type OnPathValidationCallback = (
         this: QuicSession,
         result: "success" | "failure" | "aborted",
@@ -235,6 +239,7 @@ declare module "node:quic" {
          */
         enableDatagrams?: boolean | undefined;
     }
+    type SessionApplicationOptions = { [K in keyof ApplicationOptions]-?: ApplicationOptions[K] & (bigint | boolean) };
     /**
      * @since v23.8.0
      */
@@ -539,6 +544,7 @@ declare module "node:quic" {
         ongoaway?: QuicSession["ongoaway"] | undefined;
         onkeylog?: QuicSession["onkeylog"] | undefined;
         onqlog?: QuicSession["onqlog"] | undefined;
+        onapplication?: QuicSession["onapplication"] | undefined;
         onheaders?: QuicStream["onheaders"] | undefined;
         ontrailers?: QuicStream["ontrailers"] | undefined;
         oninfo?: QuicStream["oninfo"] | undefined;
@@ -1186,7 +1192,7 @@ declare module "node:quic" {
          * be negotiated separately from the transport parameters. Read only.
          * @since v26.3.0
          */
-        readonly applicationOptions: { [K in keyof ApplicationOptions]-?: ApplicationOptions[K] & (bigint | boolean) };
+        readonly applicationOptions: SessionApplicationOptions;
         /**
          * Initiate a graceful close of the session. Existing streams will be allowed
          * to complete but no new streams will be opened. Once all streams have closed,
@@ -1240,6 +1246,11 @@ declare module "node:quic" {
          * @since v23.8.0
          */
         readonly endpoint: QuicEndpoint | null;
+        /**
+         * The callback to invoke when new application options, e.g. HTTP/3 settings arrived.
+         * @since v26.4
+         */
+        onapplication: OnApplicationCallback | undefined;
         /**
          * An optional callback invoked when the session is destroyed with an error.
          * This includes errors caused by user callbacks that throw or reject (see

--- a/types/node/stream/iter.d.ts
+++ b/types/node/stream/iter.d.ts
@@ -389,7 +389,7 @@ declare module "node:stream/iter" {
      *
      * Each `_write()` / `_writev()` call attempts the Writer's synchronous method
      * first (`writeSync` / `writevSync`), falling back to the async method if the
-     * sync path returns `false` or throws. Similarly, `_final()` tries `endSync()`
+     * sync path returns `false`. Similarly, `_final()` tries `endSync()`
      * before `end()`. When the sync path succeeds, the callback is deferred via
      * `queueMicrotask` to preserve the async resolution contract.
      *

--- a/types/node/stream/iter.d.ts
+++ b/types/node/stream/iter.d.ts
@@ -271,8 +271,8 @@ declare module "node:stream/iter" {
      *
      * If the object implements the `toAsyncStreamable` protocol (as
      * `stream.Readable` does), that protocol is used. Otherwise, the function
-     * duck-types on `read()` and `on()` (EventEmitter) and wraps the stream with
-     * a batched async iterator.
+     * duck-types on `read()`, `on()`, and `off()` (EventEmitter) and wraps the
+     * stream with a batched async iterator.
      *
      * The result is cached per instance -- calling `fromReadable()` twice with the
      * same stream returns the same iterable.
@@ -294,7 +294,7 @@ declare module "node:stream/iter" {
      * @since v26.1.0
      * @experimental
      * @param readable A classic Readable stream or any object
-     * with `read()` and `on()` methods.
+     * with `read()`, `on()` and `off()` methods.
      * @returns A stream/iter async iterable source.
      */
     function fromReadable(readable: NodeJS.ReadableStream): ByteReadableStream;

--- a/types/node/tls.d.ts
+++ b/types/node/tls.d.ts
@@ -746,6 +746,7 @@ declare module "node:tls" {
         // #endregion
     }
     type SecureVersion = "TLSv1.3" | "TLSv1.2" | "TLSv1.1" | "TLSv1";
+    type CertificateCompressionAlgorithm = "zlib" | "brotli" | "zstd";
     interface SecureContextOptions {
         /**
          * If set, this will be called when a client opens a connection using the ALPN extension.
@@ -782,6 +783,15 @@ declare module "node:tls" {
          *  able to validate the certificate, and the handshake will fail.
          */
         cert?: string | Buffer | Array<string | Buffer> | undefined;
+        /**
+         * An array of supported certificate
+         * compression algorithm names, in preference order. Supported values are
+         * `'zlib'`, `'brotli'`, and `'zstd'`. When set, enables TLS certificate
+         * compression ([RFC 8879](https://tools.ietf.org/html/rfc8879)) which compresses certificates during the TLS
+         * handshake, reducing handshake size. Only effective with TLSv1.3.
+         * **Default:** `[]` (disabled).
+         */
+        certificateCompression?: readonly CertificateCompressionAlgorithm[] | undefined;
         /**
          *  Colon-separated list of supported signature algorithms. The list
          *  can contain digest algorithms (SHA256, MD5 etc.), public key
@@ -1110,6 +1120,20 @@ declare module "node:tls" {
      * @since v0.10.2
      */
     function getCiphers(): string[];
+    /**
+     * Returns an array with the names of the RFC 8879 certificate compression
+     * algorithms supported by the current OpenSSL build, suitable for use in the
+     * `certificateCompression` option of `tls.createSecureContext()`. Possible
+     * values include `'zlib'`, `'brotli'`, and `'zstd'`.
+     *
+     * The array is empty when certificate compression is unavailable.
+     *
+     * ```js
+     * console.log(tls.getCertificateCompressionAlgorithms()); // ['zlib', 'brotli', 'zstd']
+     * ```
+     * @since v26.4.0
+     */
+    function getCertificateCompressionAlgorithms(): CertificateCompressionAlgorithm[];
     /**
      * Sets the default CA certificates used by Node.js TLS clients. If the provided
      * certificates are parsed successfully, they will become the default CA

--- a/types/node/ts5.6/buffer.buffer.d.ts
+++ b/types/node/ts5.6/buffer.buffer.d.ts
@@ -459,4 +459,9 @@ declare module "node:buffer" {
          */
         type AllowSharedBuffer = Buffer;
     }
+    /**
+     * @deprecated This is intended for internal use, and will be removed once `@types/node` no longer supports
+     * TypeScript versions earlier than 5.7.
+     */
+    type BufferView<T extends NodeJS.ArrayBufferView> = Buffer;
 }

--- a/types/node/ts5.6/index.d.ts
+++ b/types/node/ts5.6/index.d.ts
@@ -110,6 +110,7 @@
 /// <reference path="../util.d.ts" />
 /// <reference path="../util/types.d.ts" />
 /// <reference path="../v8.d.ts" />
+/// <reference path="../vfs.d.ts" />
 /// <reference path="../vm.d.ts" />
 /// <reference path="../wasi.d.ts" />
 /// <reference path="../worker_threads.d.ts" />

--- a/types/node/ts5.7/index.d.ts
+++ b/types/node/ts5.7/index.d.ts
@@ -110,6 +110,7 @@
 /// <reference path="../util.d.ts" />
 /// <reference path="../util/types.d.ts" />
 /// <reference path="../v8.d.ts" />
+/// <reference path="../vfs.d.ts" />
 /// <reference path="../vm.d.ts" />
 /// <reference path="../wasi.d.ts" />
 /// <reference path="../worker_threads.d.ts" />

--- a/types/node/tty.d.ts
+++ b/types/node/tty.d.ts
@@ -28,10 +28,11 @@ declare module "node:tty" {
          * Allows configuration of `tty.ReadStream` so that it operates as a raw device.
          *
          * When in raw mode, input is always available character-by-character, not
-         * including modifiers. Additionally, all special processing of characters by the
-         * terminal is disabled, including echoing input
+         * including modifiers. Additionally, all special processing of input characters
+         * by the terminal is disabled, including echoing input
          * characters. Ctrl+C will no longer cause a `SIGINT` when
-         * in this mode.
+         * in this mode. This mode does not affect terminal output processing, such as
+         * newline translation on Unix terminals.
          * @since v0.7.7
          * @param mode If `true`, configures the `tty.ReadStream` to operate as a raw device. If `false`, configures the `tty.ReadStream` to operate in its default mode. The `readStream.isRaw`
          * property will be set to the resulting mode.

--- a/types/node/vfs.d.ts
+++ b/types/node/vfs.d.ts
@@ -1,0 +1,210 @@
+declare module "node:vfs" {
+    /**
+     * Convenience factory equivalent to `new VirtualFileSystem(provider, options)`.
+     *
+     * ```js
+     * const vfs = require('node:vfs');
+     *
+     * // Default in-memory provider
+     * const memoryVfs = vfs.create();
+     *
+     * // Explicit provider
+     * const realVfs = vfs.create(new vfs.RealFSProvider('/tmp/sandbox'));
+     * ```
+     * @since v26.4.0
+     * @param provider The provider to use. **Default:** `new MemoryProvider()`.
+     */
+    function create(provider?: VirtualProvider, options?: VirtualFileSystemOptions): VirtualFileSystem;
+    function create(options: VirtualFileSystemOptions): VirtualFileSystem;
+    interface VirtualFileSystemOptions {
+        /**
+         * Whether to emit the experimental warning. **Default:** `true`.
+         */
+        emitExperimentalWarning?: boolean | undefined;
+    }
+    /**
+     * A `VirtualFileSystem` wraps a {@link VirtualProvider} and exposes a
+     * `node:fs`-like API. Each instance maintains its own file tree.
+     * @since v26.4.0
+     */
+    class VirtualFileSystem {
+        /**
+         * @param provider The provider to use. **Default:** `new MemoryProvider()`.
+         */
+        constructor(provider?: VirtualProvider, options?: VirtualFileSystemOptions);
+        constructor(options: VirtualFileSystemOptions);
+        /**
+         * The provider backing this VFS instance.
+         * @since v26.4.0
+         */
+        readonly provider: VirtualProvider;
+        /**
+         * `true` when the underlying provider is read-only.
+         * @since v26.4.0
+         */
+        readonly readonly: boolean;
+    }
+    interface VirtualFileSystem extends
+        // Synchronous API
+        Pick<
+            typeof import("node:fs"),
+            | "existsSync"
+            | "statSync"
+            | "lstatSync"
+            | "readFileSync"
+            | "writeFileSync"
+            | "appendFileSync"
+            | "readdirSync"
+            | "mkdirSync"
+            | "rmdirSync"
+            | "unlinkSync"
+            | "renameSync"
+            | "copyFileSync"
+            | "realpathSync"
+            | "readlinkSync"
+            | "symlinkSync"
+            | "accessSync"
+            | "rmSync"
+            | "truncateSync"
+            | "ftruncateSync"
+            | "linkSync"
+            | "chmodSync"
+            | "chownSync"
+            | "utimesSync"
+            | "lutimesSync"
+            | "mkdtempSync"
+            | "opendirSync"
+            | "openAsBlob"
+            | "openSync"
+            | "closeSync"
+            | "readSync"
+            | "writeSync"
+            | "fstatSync"
+            | "createReadStream"
+            | "createWriteStream"
+            | "watch"
+            | "watchFile"
+            | "unwatchFile"
+        >,
+        // Callback API
+        Pick<
+            typeof import("node:fs"),
+            | "readFile"
+            | "writeFile"
+            | "stat"
+            | "lstat"
+            | "readdir"
+            | "realpath"
+            | "readlink"
+            | "access"
+            | "open"
+            | "close"
+            | "read"
+            | "write"
+            | "rm"
+            | "fstat"
+            | "truncate"
+            | "ftruncate"
+            | "link"
+            | "mkdtemp"
+            | "opendir"
+        >
+    {
+        // Promise API
+        readonly promises: Pick<
+            typeof import("node:fs/promises"),
+            | "readFile"
+            | "writeFile"
+            | "appendFile"
+            | "stat"
+            | "lstat"
+            | "readdir"
+            | "mkdir"
+            | "rmdir"
+            | "unlink"
+            | "rename"
+            | "copyFile"
+            | "realpath"
+            | "readlink"
+            | "symlink"
+            | "access"
+            | "rm"
+            | "truncate"
+            | "link"
+            | "mkdtemp"
+            | "chmod"
+            | "chown"
+            | "lchown"
+            | "utimes"
+            | "lutimes"
+            | "open"
+            | "lchmod"
+            | "watch"
+        >;
+    }
+    /**
+     * The base class for all VFS providers. Subclasses implement the essential
+     * primitives (such as `open`, `stat`, `readdir`, `mkdir`, `rmdir`, `unlink`,
+     * `rename`, etc.) and inherit default implementations of the derived
+     * methods (such as `readFile`, `writeFile`, `exists`, `copyFile`, `access`, etc.).
+     * @since v26.4.0
+     */
+    abstract class VirtualProvider {
+        get readonly(): boolean;
+        get supportsSymlinks(): boolean;
+        get supportsWatch(): boolean;
+    }
+    /**
+     * The default in-memory provider. Stores files, directories, and symbolic
+     * links in a `Map`-backed tree, supports symlinks (`supportsSymlinks ===
+     * true`), and supports watching (`supportsWatch === true`).
+     * @since v26.4.0
+     */
+    class MemoryProvider extends VirtualProvider {
+        /**
+         * Locks the provider into read-only mode. Subsequent writes through any
+         * `VirtualFileSystem` using this provider throw `EROFS`. There is no
+         * way to revert the provider to writable.
+         *
+         * ```js
+         * const vfs = require('node:vfs');
+         *
+         * const provider = new vfs.MemoryProvider();
+         * const myVfs = vfs.create(provider);
+         * myVfs.writeFileSync('/seed.txt', 'initial');
+         *
+         * provider.setReadOnly();
+         *
+         * myVfs.writeFileSync('/x.txt', 'fail'); // throws EROFS
+         * ```
+         * @since v26.4.0
+         */
+        setReadOnly(): void;
+    }
+    /**
+     * A provider that wraps a directory (i.e. one on the actual file system) and exposes its
+     * contents through the VFS API. All VFS paths are resolved relative to
+     * the root and verified to stay inside it; symbolic links resolving
+     * outside the root are rejected.
+     * @since v26.4.0
+     */
+    class RealFSProvider extends VirtualProvider {
+        /**
+         * ```js
+         * const vfs = require('node:vfs');
+         *
+         * const realVfs = vfs.create(new vfs.RealFSProvider('/tmp/sandbox'));
+         * realVfs.writeFileSync('/file.txt', 'hello'); // writes /tmp/sandbox/file.txt
+         * ```
+         * @since v26.4.0
+         * @param rootPath The absolute file-system path to use as the root.
+         * Must be a non-empty string.
+         */
+        constructor(rootPath: string);
+        /**
+         * The resolved absolute path used as the root.
+         * @since v26.4.0
+         */
+        readonly rootPath: string;
+    }
+}

--- a/types/node/vm.d.ts
+++ b/types/node/vm.d.ts
@@ -741,7 +741,7 @@ declare module "node:vm" {
          */
         status: ModuleStatus;
         /**
-         * Evaluate the module and its depenendencies. Corresponds to the [Evaluate() concrete method](https://tc39.es/ecma262/#sec-moduleevaluation) field of
+         * Evaluate the module and its dependencies. Corresponds to the [Evaluate() concrete method](https://tc39.es/ecma262/#sec-moduleevaluation) field of
          * [Cyclic Module Record](https://tc39.es/ecma262/#sec-cyclic-module-records)s in the ECMAScript specification.
          *
          * If the module is a `vm.SourceTextModule`, `evaluate()` must be called after the module has been instantiated;


### PR DESCRIPTION
- dgram: add synchronous Socket connectSync()
- dgram: add synchronous Socket.prototype.bindSync()
- fs: support caller-supplied readFile() buffers
- net: early TCP binding via synchronous net.BoundSocket
- net: support TCP_KEEPINTVL and TCP_KEEPCNT in setKeepAlive
- quic: add listEndpoints API
- quic: expose QUIC certificates as JS X509Certificate, not raw handles
- quic: impl. cb for http/3 settings/app. options
- tls: add certificateCompression option
- vfs: add minimal node:vfs subsystem

The initial vfs implementation, and by extension its types, are fairly bare-bones. In particular, the concept of a user-provided VirtualProvider is not really fleshed out, and the interfaces (`VirtualFileHandle`) etc. that such an implementation would need to construct are currently internal-only. This should be fine for now.