### PR TITLE
node: prune codeowners

### DIFF
--- a/types/node/package.json
+++ b/types/node/package.json
@@ -61,20 +61,12 @@
             "githubUsername": "WilcoBakker"
         },
         {
-            "name": "Marcin Kopacz",
-            "githubUsername": "chyzwar"
-        },
-        {
             "name": "Trivikram Kamat",
             "githubUsername": "trivikr"
         },
         {
             "name": "Junxiao Shi",
             "githubUsername": "yoursunny"
-        },
-        {
-            "name": "Ilia Baryshnikov",
-            "githubUsername": "qwelias"
         },
         {
             "name": "ExE Boss",
@@ -87,10 +79,6 @@
         {
             "name": "Anna Henningsen",
             "githubUsername": "addaleax"
-        },
-        {
-            "name": "Victor Perin",
-            "githubUsername": "victorperin"
         },
         {
             "name": "NodeJS Contributors",

--- a/types/node/v22/package.json
+++ b/types/node/v22/package.json
@@ -58,20 +58,12 @@
             "githubUsername": "WilcoBakker"
         },
         {
-            "name": "Marcin Kopacz",
-            "githubUsername": "chyzwar"
-        },
-        {
             "name": "Trivikram Kamat",
             "githubUsername": "trivikr"
         },
         {
             "name": "Junxiao Shi",
             "githubUsername": "yoursunny"
-        },
-        {
-            "name": "Ilia Baryshnikov",
-            "githubUsername": "qwelias"
         },
         {
             "name": "ExE Boss",
@@ -84,10 +76,6 @@
         {
             "name": "Anna Henningsen",
             "githubUsername": "addaleax"
-        },
-        {
-            "name": "Victor Perin",
-            "githubUsername": "victorperin"
         },
         {
             "name": "NodeJS Contributors",

--- a/types/node/v24/package.json
+++ b/types/node/v24/package.json
@@ -61,20 +61,12 @@
             "githubUsername": "WilcoBakker"
         },
         {
-            "name": "Marcin Kopacz",
-            "githubUsername": "chyzwar"
-        },
-        {
             "name": "Trivikram Kamat",
             "githubUsername": "trivikr"
         },
         {
             "name": "Junxiao Shi",
             "githubUsername": "yoursunny"
-        },
-        {
-            "name": "Ilia Baryshnikov",
-            "githubUsername": "qwelias"
         },
         {
             "name": "ExE Boss",
@@ -87,10 +79,6 @@
         {
             "name": "Anna Henningsen",
             "githubUsername": "addaleax"
-        },
-        {
-            "name": "Victor Perin",
-            "githubUsername": "victorperin"
         },
         {
             "name": "NodeJS Contributors",

--- a/types/node/v25/package.json
+++ b/types/node/v25/package.json
@@ -61,20 +61,12 @@
             "githubUsername": "WilcoBakker"
         },
         {
-            "name": "Marcin Kopacz",
-            "githubUsername": "chyzwar"
-        },
-        {
             "name": "Trivikram Kamat",
             "githubUsername": "trivikr"
         },
         {
             "name": "Junxiao Shi",
             "githubUsername": "yoursunny"
-        },
-        {
-            "name": "Ilia Baryshnikov",
-            "githubUsername": "qwelias"
         },
         {
             "name": "ExE Boss",
@@ -87,10 +79,6 @@
         {
             "name": "Anna Henningsen",
             "githubUsername": "addaleax"
-        },
-        {
-            "name": "Victor Perin",
-            "githubUsername": "victorperin"
         },
         {
             "name": "NodeJS Contributors",


### PR DESCRIPTION
Same as last year, this removes those listed as @types/node codeowners who have not authored, reviewed or commented on issues/PRs in the last 5+ years.

If any objections, then holler.