### PR TITLE
[ssh2] Add missing term property to PseudoTtyInfo

### DIFF
--- a/types/ssh2/index.d.ts
+++ b/types/ssh2/index.d.ts
@@ -1487,6 +1487,8 @@ export interface Session extends ServerChannel {
 }
 
 export interface PseudoTtyInfo {
+    /** The terminal type requested by the client for the pseudo-TTY (e.g. `"vt100"`). */
+    term: string;
     /** The number of columns for the pseudo-TTY. */
     cols: number;
     /** The number of rows for the pseudo-TTY. */

--- a/types/ssh2/ssh2-tests.ts
+++ b/types/ssh2/ssh2-tests.ts
@@ -413,6 +413,8 @@ new ssh2.Server({
                 info.rows; // $ExpectType number
                 info.width; // $ExpectType number
                 info.height; // $ExpectType number
+                info.modes; // $ExpectType TerminalModes
+                info.modes.VINTR; // $ExpectType number | undefined
                 accept?.();
             });
         });

--- a/types/ssh2/ssh2-tests.ts
+++ b/types/ssh2/ssh2-tests.ts
@@ -407,6 +407,14 @@ new ssh2.Server({
                 stream.exit(0);
                 stream.end();
             });
+            session.once("pty", (accept, reject, info) => {
+                info.term; // $ExpectType string
+                info.cols; // $ExpectType number
+                info.rows; // $ExpectType number
+                info.width; // $ExpectType number
+                info.height; // $ExpectType number
+                accept?.();
+            });
         });
     }).on("end", () => {
         console.log("Client disconnected");


### PR DESCRIPTION
Picks up #75339 (closed as inactive) and addresses the outstanding review feedback there.

## Summary

`PseudoTtyInfo` — emitted on a `Session`'s `'pty'` event — was missing the `term` property. ssh2's server-side `pty-req` handler builds `{ term, cols, rows, width, height, modes }`:

https://github.com/mscdex/ssh2/blob/master/lib/protocol/handlers.misc.js#L1092-L1116

`term` is non-optional: if the string read fails, `data` is never assigned and the event is not emitted at all, so a handler that runs always has one.

## What has changed since #75339

- **Addressed the review comment.** `info.modes` had no coverage. Added `info.modes; // $ExpectType TerminalModes`, plus an assertion on a `TerminalModes` member so the test also fails if the interface is weakened, not only if `modes` is dropped outright.
- **Corrected the doc comment.** The original read *"defaults to `"vt100"` if the client did not specify one"*. That default is applied client-side when *sending* the request (`Protocol.js#pty()`, and `client.js` for `shell()`); the server reports verbatim whatever the client sent, which for a non-ssh2 client may be anything, including an empty string. Reworded to match upstream's README, which documents this field as "The terminal type for the pseudo-TTY."

## Testing

`dtslint types/ssh2` passes at each of the three commits — TypeScript 5.6 through 6.0, plus the npm and `are-the-types-wrong` checks. `dprint check` is clean.

Original work by @pckilgore, whose authorship is preserved on the first two commits.
