### PR TITLE
[oidc-provider] add release declaration handoff

### DIFF
--- a/types/oidc-provider/scripts/README.md
+++ b/types/oidc-provider/scripts/README.md
@@ -1,0 +1,144 @@
+# oidc-provider declaration mirror
+
+`update-types.mjs` copies the declaration artifact produced by oidc-provider
+into fixed generated regions in `index.d.ts` and the generated
+`lib/helpers/grants.d.ts` file. Configuration structure, extension methods,
+events, interaction policy declarations, errors, and unstable grant helpers
+therefore share a canonical upstream source.
+
+Run it from `types/oidc-provider` and pass an explicit oidc-provider checkout:
+
+```sh
+node scripts/update-types.mjs /path/to/oidc-provider
+```
+
+Alternatively, consume a previously generated artifact without a provider
+checkout:
+
+```sh
+node scripts/update-types.mjs --artifact /path/to/oidc-provider-types.json
+```
+
+Use `--check` to verify that the committed declarations are current without
+writing them:
+
+```sh
+node scripts/update-types.mjs --check /path/to/oidc-provider
+```
+
+`--check` also accepts `--artifact`. It intentionally compares the exact
+mirror, including artifact provenance, and requires matching provider and DT
+major/minor version lines.
+
+Use `--status` to decide whether a release warrants a DT pull request:
+
+```sh
+node scripts/update-types.mjs --status --artifact /path/to/oidc-provider-types.json
+```
+
+It writes deterministic JSON to stdout. The comparison formats current and
+prospective declarations and ignores only artifact provenance. Declaration or
+generated JSDoc changes require an update, as does a new provider major.
+Patch-only and minor-only releases do not. A required update advances the DT
+package to the provider's `X.Y.9999`; artifacts older than DT's tracked
+major/minor line are reported and skipped. Normal update mode follows this
+policy, while exact `--check` may still reject provenance drift that does not
+warrant a pull request.
+
+The script invokes `node docs/update-configuration.js --types-json` in the
+provider checkout. It validates the artifact schema, exact provider version,
+and SHA-256 content hash before changing any declaration. That provenance is
+persisted in the generated contracts region, so `--check` also detects an
+upstream patch release or source change whose formatted declarations happen to
+be identical.
+
+The script uses only Node.js built-ins. It formats `index.d.ts` with the dprint
+installation from the DefinitelyTyped repository and copies the grant-helper
+declaration byte-for-byte, so that repository's dependencies must be installed.
+Generated regions and files must not be edited by hand.
+
+### One-time legacy bootstrap
+
+The automation can be merged while `@types/oidc-provider` still describes the
+currently released provider. When the three generated regions and
+`lib/helpers/grants.d.ts` are all absent, the updater recognizes the exact DT
+baseline present when this automation was introduced. The first substantive
+provider artifact then performs a hash-gated migration that:
+
+- reorganizes the provider-owned declarations into the generated regions;
+- applies the grant-helper model and token-endpoint context declarations;
+- creates `lib/helpers/grants.d.ts`; and
+- updates the accompanying DT acceptance tests.
+
+The migration inputs beside the updater do not alter the declarations published
+by the bootstrap DT release. A partial generated layout, an existing helper
+combined with a markerless index, or an unrecognized baseline is rejected
+instead of being guessed at. Once the first release update has landed, the
+generated markers permanently select the normal update path; the legacy
+migration files can then be removed in a follow-up.
+
+The updater integration checks accept the same provider checkout:
+
+```sh
+node scripts/update-types.test.mjs /path/to/oidc-provider
+```
+
+Release handoffs can run the same checks without provider source:
+
+```sh
+node scripts/update-types.test.mjs --artifact /path/to/oidc-provider-types.json
+```
+
+## Release synchronization
+
+`sync-release.mjs` turns a provider release artifact into an isolated,
+validated DefinitelyTyped commit. Run it from any directory in this checkout
+with a stable provider tag and exactly one artifact source:
+
+```sh
+node types/oidc-provider/scripts/sync-release.mjs \
+  --tag v9.12.0 \
+  --run-id 123456789
+
+node types/oidc-provider/scripts/sync-release.mjs \
+  --tag v9.12.0 \
+  --artifact /path/to/oidc-provider-types.json
+```
+
+The run ID form downloads the `oidc-provider-types-v9.12.0` artifact from
+`panva/node-oidc-provider` and requires its sole top-level file to be
+`oidc-provider-types.json`. Before changing anything, the script verifies the
+GitHub CLI login, the `origin` fork and official `upstream` remote, Git author
+identity, Node.js, and pnpm. The authenticated GitHub user must own `origin`.
+
+The script fetches `upstream/master`, creates a temporary Git worktree, installs
+only the root tooling and `@types/oidc-provider` dependency closure with a
+no-lockfile workspace install, and asks `update-types.mjs --status` whether the
+release needs a declaration update. When it does, the script applies the
+artifact and runs:
+
+- the updater's exact `--check` mode;
+- the updater artifact/status integration checks;
+- dprint over `types/oidc-provider`;
+- `pnpm test oidc-provider`.
+
+The updater's reported file list must exactly match Git, and every change must
+remain below `types/oidc-provider`. A successful preparation leaves the local
+branch `oidc-provider-v9.12.0` containing one commit titled
+`[oidc-provider] sync declarations for v9.12.0`; the temporary worktree is then
+removed. Inspect and submit that retained branch using the commands printed by
+the script. The submission instruction reruns the helper with the same artifact
+source so it can validate and reuse the prepared branch before pushing.
+
+Pass `--submit` to push the branch without force and open the deterministic PR
+against `DefinitelyTyped/DefinitelyTyped:master`. Existing open or merged PRs
+for the release branch are successful no-ops. A closed, unmerged PR or a remote
+branch without a PR requires manual recovery and is never overwritten or
+adopted. A matching prepared local branch can be reused safely.
+
+Temporary state is preserved on every failure. Pass `--keep-temp` to preserve
+it after success as well. The focused orchestration tests are run separately:
+
+```sh
+node --test types/oidc-provider/scripts/sync-release.test.mjs
+```

--- a/types/oidc-provider/scripts/legacy-bootstrap.mjs
+++ b/types/oidc-provider/scripts/legacy-bootstrap.mjs
@@ -1,0 +1,367 @@
+import { createHash } from "node:crypto";
+
+export const LEGACY_INDEX_HASH = "a325aa77fce6dd7a8126143dc9456140ba530043c1d6f75d4e88e9520c5419f6";
+export const LEGACY_TESTS_HASH = "dd5f211e4b13e0bd3cc47772aac74ad32c7b259aee11b142c333d670137e7b1e";
+export const MIGRATED_TESTS_HASH = "9dcb3c8c321b634bd1b16ff0c3c3c2341197091426e7371f1e920824040aac07";
+
+const CONTRACTS_START = "// BEGIN GENERATED OIDC-PROVIDER CONTRACTS";
+const CONTRACTS_END = "// END GENERATED OIDC-PROVIDER CONTRACTS";
+const PROVIDER_MEMBERS_START = "    // BEGIN GENERATED OIDC-PROVIDER MEMBERS";
+const PROVIDER_MEMBERS_END = "    // END GENERATED OIDC-PROVIDER MEMBERS";
+const RELATED_CONTRACTS_START = "// BEGIN GENERATED OIDC-PROVIDER RELATED CONTRACTS";
+const RELATED_CONTRACTS_END = "// END GENERATED OIDC-PROVIDER RELATED CONTRACTS";
+
+function hash(value) {
+    return createHash("sha256").update(value).digest("hex");
+}
+
+function replaceOnce(source, before, after, label) {
+    const index = source.indexOf(before);
+    if (index === -1 || source.indexOf(before, index + before.length) !== -1) {
+        throw new TypeError(`legacy oidc-provider index has an unexpected ${label}`);
+    }
+    return `${source.slice(0, index)}${after}${source.slice(index + before.length)}`;
+}
+
+function replaceRange(source, start, end, replacement, label, searchFrom = 0) {
+    const startIndex = source.indexOf(start, searchFrom);
+    if (startIndex === -1 || source.indexOf(start, startIndex + start.length) !== -1) {
+        throw new TypeError(`legacy oidc-provider index has an unexpected ${label} start`);
+    }
+    const endIndex = source.indexOf(end, startIndex + start.length);
+    if (endIndex === -1) {
+        throw new TypeError(`legacy oidc-provider index has an unexpected ${label} end`);
+    }
+    return `${source.slice(0, startIndex)}${replacement}${source.slice(endIndex)}`;
+}
+
+function assertHash(source, expectedHash, label) {
+    const actualHash = hash(source);
+    if (actualHash !== expectedHash) {
+        throw new TypeError(`${label} is not the supported bootstrap baseline (sha256 ${actualHash})`);
+    }
+}
+
+export function generatedRegionState(source) {
+    const markers = [
+        CONTRACTS_START,
+        CONTRACTS_END,
+        PROVIDER_MEMBERS_START,
+        PROVIDER_MEMBERS_END,
+        RELATED_CONTRACTS_START,
+        RELATED_CONTRACTS_END,
+    ];
+    const counts = markers.map((marker) => source.split(marker).length - 1);
+    if (counts.every((count) => count === 0)) return "legacy";
+    if (counts.every((count) => count === 1)) return "generated";
+    throw new TypeError("oidc-provider index has a partial or duplicated generated-region layout");
+}
+
+export function migrateLegacyIndex(source, expectedHash = LEGACY_INDEX_HASH) {
+    assertHash(source, expectedHash, "oidc-provider index");
+    if (generatedRegionState(source) !== "legacy") {
+        throw new TypeError("oidc-provider index bootstrap requires a markerless declaration");
+    }
+
+    source = replaceOnce(
+        source,
+        `        deviceInfo: UnknownObject;
+        [key: string]: unknown;`,
+        `        deviceInfo: UnknownObject;
+        rar?: AuthorizationDetail[] | undefined;
+        [key: string]: unknown;`,
+        "DeviceCode constructor",
+    );
+    source = replaceOnce(
+        source,
+        `    grantId: string;
+    attestationJkt?: string | undefined;
+    consumed: unknown;`,
+        `    grantId: string;
+    rar?: AuthorizationDetail[] | undefined;
+    attestationJkt?: string | undefined;
+    consumed: unknown;`,
+        "DeviceCode properties",
+    );
+    source = replaceOnce(
+        source,
+        `declare class ClientCredentials extends BaseToken {
+    constructor(properties: {
+        client: Client;
+        resourceServer?: ResourceServerInstance | undefined;
+        scope: string;
+        [key: string]: unknown;
+    });
+    readonly kind: "ClientCredentials";
+    scope?: string | undefined;
+    extra?: UnknownObject | undefined;
+    aud: string | string[];
+    readonly tokenType: string;
+    "x5t#S256"?: string | undefined;
+    jkt?: string | undefined;
+    resourceServer?: ResourceServerInstance | undefined;
+
+    isSenderConstrained(): boolean;
+}`,
+        `declare class ClientCredentials extends BaseToken {
+    constructor(properties: {
+        client: Client;
+        resourceServer?: ResourceServerInstance | undefined;
+        aud?: string | string[] | undefined;
+        scope?: string | undefined;
+        rar?: AuthorizationDetail[] | undefined;
+        [key: string]: unknown;
+    });
+    readonly kind: "ClientCredentials";
+    scope?: string | undefined;
+    extra?: UnknownObject | undefined;
+    aud?: string | string[] | undefined;
+    readonly tokenType: string;
+    "x5t#S256"?: string | undefined;
+    jkt?: string | undefined;
+    resourceServer?: ResourceServerInstance | undefined;
+    rar?: AuthorizationDetail[] | undefined;
+
+    setAudience(audience: string | string[]): void;
+    setThumbprint(prop: "x5t", input: string | crypto.X509Certificate): void;
+    setThumbprint(prop: "jkt", input: string): void;
+    isSenderConstrained(): boolean;
+}`,
+        "ClientCredentials declaration",
+    );
+    source = replaceOnce(
+        source,
+        `declare class AccessToken extends BaseToken {
+    constructor(properties: {
+        client: Client;
+        accountId: string;
+        resourceServer?: ResourceServerInstance | undefined;
+        claims?: ClaimsParameter | undefined;
+        aud?: string | string[] | undefined;
+        scope: string;
+        sid?: string | undefined;
+        sessionUid?: string | undefined;
+        expiresWithSession?: boolean | undefined;
+        "x5t#S256"?: string | undefined;
+        jkt?: string | undefined;
+        grantId: string;
+        gty: string;
+        rar?: AuthorizationDetail[] | undefined;
+        [key: string]: unknown;
+    });
+    readonly kind: "AccessToken";
+    accountId: string;
+    resourceServer?: ResourceServerInstance | undefined;
+    aud: string | string[];
+    claims?: ClaimsParameter | undefined;
+    extra?: UnknownObject | undefined;
+    grantId: string;
+    scope?: string | undefined;
+    gty: string;
+    rar?: AuthorizationDetail[] | undefined;
+    sid?: string | undefined;
+    sessionUid?: string | undefined;
+    expiresWithSession?: boolean | undefined;
+    readonly tokenType: string;
+    "x5t#S256"?: string | undefined;
+    jkt?: string | undefined;
+
+    isSenderConstrained(): boolean;
+
+    static revokeByGrantId(grantId: string): Promise<void>;
+}`,
+        `declare class AccessToken extends BaseToken {
+    constructor(properties: {
+        client: Client;
+        accountId: string;
+        resourceServer?: ResourceServerInstance | undefined;
+        claims?: ClaimsParameter | undefined;
+        aud?: string | string[] | undefined;
+        scope?: string | undefined;
+        sid?: string | undefined;
+        sessionUid?: string | undefined;
+        expiresWithSession?: boolean | undefined;
+        "x5t#S256"?: string | undefined;
+        jkt?: string | undefined;
+        grantId: string;
+        gty: string;
+        rar?: AuthorizationDetail[] | undefined;
+        [key: string]: unknown;
+    });
+    readonly kind: "AccessToken";
+    accountId: string;
+    resourceServer?: ResourceServerInstance | undefined;
+    aud?: string | string[] | undefined;
+    claims?: ClaimsParameter | undefined;
+    extra?: UnknownObject | undefined;
+    grantId: string;
+    scope?: string | undefined;
+    gty: string;
+    rar?: AuthorizationDetail[] | undefined;
+    sid?: string | undefined;
+    sessionUid?: string | undefined;
+    expiresWithSession?: boolean | undefined;
+    readonly tokenType: string;
+    "x5t#S256"?: string | undefined;
+    jkt?: string | undefined;
+
+    setAudience(audience: string | string[]): void;
+    setThumbprint(prop: "x5t", input: string | crypto.X509Certificate): void;
+    setThumbprint(prop: "jkt", input: string): void;
+    isSenderConstrained(): boolean;
+
+    static revokeByGrantId(grantId: string): Promise<void>;
+}`,
+        "AccessToken declaration",
+    );
+
+    source = replaceRange(
+        source,
+        "export type FindAccount = (",
+        "export interface UnknownObject {",
+        "\n",
+        "initial provider-owned contracts",
+    );
+    source = replaceRange(
+        source,
+        "export interface AuthorizationDetail extends UnknownObject {",
+        "export interface AllClientMetadata {",
+        "",
+        "metadata provider-owned contracts",
+    );
+    source = replaceRange(
+        source,
+        "export interface ResourceServer {",
+        "declare class OIDCContext {",
+        "",
+        "resource-server provider-owned contracts",
+    );
+    source = replaceRange(
+        source,
+        "export type TLSClientAuthProperty =",
+        "export interface HttpOptions {",
+        `export interface TokenEndpointGrantParameters extends UnknownObject {
+    grant_type: string;
+    scope?: string | undefined;
+    resource?: string | string[] | undefined;
+    authorization_details?: string | undefined;
+}
+
+/** Context passed to a handler registered with \`Provider.registerGrantType()\`. */
+export type TokenEndpointGrantContext<Params extends object = UnknownObject> = KoaContextWithOIDC & {
+    oidc: OIDCContext & {
+        readonly provider: Provider;
+        readonly client: Client;
+        readonly params: TokenEndpointGrantParameters & Params;
+        readonly resourceServers: { [identifier: string]: ResourceServerInstance };
+    };
+};
+
+/* eslint-disable @typescript-eslint/no-invalid-void-type */
+${CONTRACTS_START}
+${CONTRACTS_END}
+/* eslint-enable @typescript-eslint/no-invalid-void-type */
+
+`,
+        "configuration provider-owned contracts",
+    );
+    source = replaceRange(
+        source,
+        "interface ProviderAdditionalEventMap {",
+        "export default class Provider extends Koa {",
+        "",
+        "provider event contracts",
+    );
+
+    const providerIndex = source.indexOf("export default class Provider extends Koa {");
+    if (providerIndex === -1) {
+        throw new TypeError("legacy oidc-provider index has no Provider declaration");
+    }
+    source = replaceRange(
+        source,
+        "    urlFor(name: string, options?: UnknownObject): string;",
+        "    readonly Grant: typeof Grant;",
+        `${PROVIDER_MEMBERS_START}
+${PROVIDER_MEMBERS_END}
+
+`,
+        "Provider members",
+        providerIndex,
+    );
+    source = replaceRange(
+        source,
+        "declare class Checks extends Array<interactionPolicy.Check> {",
+        "export { Provider };",
+        `${RELATED_CONTRACTS_START}
+${RELATED_CONTRACTS_END}
+
+`,
+        "related provider-owned contracts",
+    );
+
+    if (generatedRegionState(source) !== "generated") {
+        throw new TypeError("legacy oidc-provider index migration did not create every generated region");
+    }
+    return source;
+}
+
+export function applyUnifiedPatch(source, patch, label = "file") {
+    const sourceLines = source.split("\n");
+    const patchLines = patch.replace(/\n$/, "").split("\n");
+    const output = [];
+    let sourceIndex = 0;
+    let patchIndex = patchLines.findIndex((line) => line.startsWith("@@ "));
+    if (patchIndex === -1) throw new TypeError(`${label} bootstrap patch has no hunks`);
+
+    while (patchIndex < patchLines.length && patchLines[patchIndex].startsWith("@@ ")) {
+        const header = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/.exec(patchLines[patchIndex]);
+        if (!header) throw new TypeError(`${label} bootstrap patch has an invalid hunk header`);
+        const oldCount = Number(header[2] ?? 1);
+        const oldStart = Number(header[1]) - (oldCount === 0 ? 0 : 1);
+        const newCount = Number(header[4] ?? 1);
+        if (oldStart < sourceIndex) throw new TypeError(`${label} bootstrap patch has overlapping hunks`);
+        output.push(...sourceLines.slice(sourceIndex, oldStart));
+        sourceIndex = oldStart;
+        patchIndex += 1;
+        let removed = 0;
+        let added = 0;
+
+        while (patchIndex < patchLines.length && !patchLines[patchIndex].startsWith("@@ ")) {
+            const line = patchLines[patchIndex];
+            if (line.startsWith("\\ No newline at end of file")) {
+                patchIndex += 1;
+                continue;
+            }
+            const operation = line[0];
+            const contents = line.slice(1);
+            if (operation === " " || operation === "-") {
+                if (sourceLines[sourceIndex] !== contents) {
+                    throw new TypeError(`${label} bootstrap patch does not match line ${sourceIndex + 1}`);
+                }
+                sourceIndex += 1;
+                removed += 1;
+            }
+            if (operation === " " || operation === "+") {
+                output.push(contents);
+                added += 1;
+            }
+            if (operation !== " " && operation !== "-" && operation !== "+") {
+                throw new TypeError(`${label} bootstrap patch has an invalid hunk line`);
+            }
+            patchIndex += 1;
+        }
+        if (removed !== oldCount || added !== newCount) {
+            throw new TypeError(`${label} bootstrap patch hunk counts do not match its header`);
+        }
+    }
+
+    output.push(...sourceLines.slice(sourceIndex));
+    return output.join("\n");
+}
+
+export function migrateLegacyTests(source, patch, expectedHash = LEGACY_TESTS_HASH) {
+    assertHash(source, expectedHash, "oidc-provider tests");
+    const migrated = applyUnifiedPatch(source, patch, "oidc-provider tests");
+    assertHash(migrated, MIGRATED_TESTS_HASH, "migrated oidc-provider tests");
+    return migrated;
+}

--- a/types/oidc-provider/scripts/legacy-tests.patch
+++ b/types/oidc-provider/scripts/legacy-tests.patch
@@ -1,0 +1,636 @@
+diff --git a/types/oidc-provider/oidc-provider-tests.ts b/types/oidc-provider/oidc-provider-tests.ts
+index 8fc2ad052d..c015f4a202 100644
+--- a/types/oidc-provider/oidc-provider-tests.ts
++++ b/types/oidc-provider/oidc-provider-tests.ts
+@@ -7,0 +8 @@ import * as oidc from "oidc-provider";
++import * as grantHelpers from "oidc-provider/lib/helpers/grants.js";
+@@ -21,0 +23,314 @@ new Provider("https://op.example.com", {
++new Provider("https://op.example.com", {
++    cookies: {
++        long: {
++            // @ts-expect-error Cookie priority has a finite set of supported values.
++            priority: "urgent",
++        },
++    },
++});
++
++const getAttestationSignaturePublicKey: oidc.AttestationSignaturePublicKey = async () =>
++    crypto.generateKeyPairSync(
++        "ec",
++        { namedCurve: "P-256" },
++    ).publicKey;
++const issueCredential: oidc.OpenID4VCIIssueCredential = async () => ({ credentials: ["credential"] });
++const authorizationDetailsForGrantSource: oidc.AuthorizationDetailsForGrantSource = async () => undefined;
++const authorizationDetailsForAccessToken: oidc.AuthorizationDetailsForAccessToken = async () => undefined;
++const authorizationDetailsForIntrospection: oidc.AuthorizationDetailsForIntrospection = async () => undefined;
++const paymentAuthorizationDetail: oidc.RichAuthorizationRequestType = {
++    validate(_ctx: oidc.KoaContextWithOIDC, detail: oidc.AuthorizationDetail) {
++        detail.type.substring(0);
++    },
++};
++const optionalAuthorizationDetailTypes = undefined as
++    | Readonly<Record<string, oidc.RichAuthorizationRequestType>>
++    | undefined;
++const dynamicallyEnabled: boolean = true;
++
++new Provider("https://op.example.com", {
++    features: {
++        attestClientAuth: {
++            enabled: true,
++            challengeSecret: Buffer.alloc(32),
++            getAttestationSignaturePublicKey,
++        },
++        ciba: {
++            enabled: true,
++            triggerAuthenticationDevice() {},
++            validateRequestContext() {},
++            verifyUserCode() {},
++        },
++        fapi: {
++            enabled: true,
++            profile: "2.0",
++        },
++        mTLS: {
++            enabled: true,
++            tlsClientAuth: true,
++            getCertificate: () => undefined,
++            certificateAuthorized: () => true,
++            certificateSubjectMatches: () => true,
++        },
++        openid4vci: {
++            enabled: true,
++            nonceSecret: Buffer.alloc(32),
++            credentialConfigurationsSupported: {
++                credential: { format: "example" },
++            },
++            issueCredential,
++        },
++        introspection: { enabled: true },
++        richAuthorizationRequests: {
++            enabled: true,
++            types: { payment: paymentAuthorizationDetail },
++            authorizationDetailsForGrantSource,
++            authorizationDetailsForAccessToken,
++            authorizationDetailsForIntrospection,
++        },
++    },
++});
++
++new Provider("https://op.example.com", {
++    features: {
++        attestClientAuth: {
++            enabled: dynamicallyEnabled,
++            challengeSecret: Buffer.alloc(32),
++            getAttestationSignaturePublicKey,
++        },
++        ciba: {
++            enabled: dynamicallyEnabled,
++            triggerAuthenticationDevice() {},
++            validateRequestContext() {},
++            verifyUserCode() {},
++        },
++        fapi: {
++            enabled: dynamicallyEnabled,
++            profile: () => undefined,
++        },
++        mTLS: {
++            enabled: dynamicallyEnabled,
++            tlsClientAuth: dynamicallyEnabled,
++            getCertificate: () => undefined,
++            certificateAuthorized: () => true,
++            certificateSubjectMatches: () => true,
++        },
++        openid4vci: {
++            enabled: dynamicallyEnabled,
++            nonceSecret: Buffer.alloc(32),
++            credentialConfigurationsSupported: {
++                credential: { format: "example" },
++            },
++            issueCredential,
++        },
++    },
++});
++
++new Provider("https://op.example.com", {
++    features: {
++        mTLS: {
++            enabled: true,
++            certificateBoundAccessTokens: true,
++            getCertificate: () => undefined,
++        },
++        richAuthorizationRequests: {
++            enabled: true,
++            types: {},
++        },
++    },
++});
++
++new Provider("https://op.example.com", {
++    features: {
++        mTLS: { enabled: true },
++    },
++});
++
++new Provider("https://op.example.com", {
++    features: {
++        mTLS: {
++            enabled: dynamicallyEnabled,
++            certificateBoundAccessTokens: dynamicallyEnabled,
++            getCertificate: () => undefined,
++        },
++    },
++});
++
++new Provider("https://op.example.com", {
++    features: {
++        openid4vci: {
++            enabled: true,
++            nonceSecret: Buffer.alloc(32),
++            credentialConfigurationsSupported: {
++                credential: { format: "example" },
++            },
++            issueCredential,
++        },
++        richAuthorizationRequests: {
++            enabled: true,
++            types: {},
++            authorizationDetailsForGrantSource,
++            authorizationDetailsForAccessToken,
++        },
++    },
++});
++
++new Provider("https://op.example.com", {
++    features: {
++        openid4vci: {
++            enabled: true,
++            nonceSecret: Buffer.alloc(32),
++            credentialConfigurationsSupported: {
++                credential: { format: "example" },
++            },
++            issueCredential,
++        },
++        richAuthorizationRequests: {
++            enabled: true,
++            types: optionalAuthorizationDetailTypes,
++            authorizationDetailsForGrantSource,
++            authorizationDetailsForAccessToken,
++        },
++    },
++});
++
++new Provider("https://op.example.com", {
++    features: {
++        // @ts-expect-error enabled attestClientAuth requires its challenge secret and key resolver
++        attestClientAuth: { enabled: true },
++    },
++});
++
++new Provider("https://op.example.com", {
++    features: {
++        // @ts-expect-error the challenge secret does not make the attestation key resolver optional
++        attestClientAuth: { enabled: true, challengeSecret: Buffer.alloc(32) },
++    },
++});
++
++new Provider("https://op.example.com", {
++    features: {
++        // @ts-expect-error active RAR with introspection requires an introspection projection policy
++        introspection: { enabled: true },
++        richAuthorizationRequests: {
++            enabled: true,
++            types: { payment: paymentAuthorizationDetail },
++            authorizationDetailsForGrantSource,
++            authorizationDetailsForAccessToken,
++        },
++    },
++});
++
++new Provider("https://op.example.com", {
++    features: {
++        openid4vci: {
++            // @ts-expect-error OpenID4VCI activates an otherwise empty enabled RAR configuration
++            enabled: true,
++            nonceSecret: Buffer.alloc(32),
++            credentialConfigurationsSupported: {
++                credential: { format: "example" },
++            },
++            issueCredential,
++        },
++        richAuthorizationRequests: {
++            enabled: true,
++            types: {},
++        },
++    },
++});
++
++new Provider("https://op.example.com", {
++    features: {
++        // @ts-expect-error enabled CIBA requires its always-invoked application callbacks
++        ciba: { enabled: true },
++    },
++});
++
++new Provider("https://op.example.com", {
++    features: {
++        // @ts-expect-error verifyUserCode remains mandatory when the other CIBA callbacks are configured
++        ciba: {
++            enabled: true,
++            triggerAuthenticationDevice() {},
++            validateRequestContext() {},
++        },
++    },
++});
++
++new Provider("https://op.example.com", {
++    features: {
++        // @ts-expect-error enabled FAPI requires a profile
++        fapi: { enabled: true },
++    },
++});
++
++new Provider("https://op.example.com", {
++    features: {
++        // @ts-expect-error enabled OpenID4VCI requires a nonce secret, configurations, and issuance callback
++        openid4vci: { enabled: true },
++    },
++});
++
++new Provider("https://op.example.com", {
++    features: {
++        openid4vci: {
++            // @ts-expect-error issueCredential remains mandatory when the other OpenID4VCI values are configured
++            enabled: true,
++            nonceSecret: Buffer.alloc(32),
++            credentialConfigurationsSupported: { credential: { format: "example" } },
++        },
++    },
++});
++
++new Provider("https://op.example.com", {
++    features: {
++        // @ts-expect-error certificate-bound access tokens require a certificate resolver
++        mTLS: { enabled: true, certificateBoundAccessTokens: true },
++    },
++});
++
++new Provider("https://op.example.com", {
++    features: {
++        // @ts-expect-error self-signed TLS client authentication requires a certificate resolver
++        mTLS: { enabled: true, selfSignedTlsClientAuth: true },
++    },
++});
++
++new Provider("https://op.example.com", {
++    features: {
++        // @ts-expect-error tls_client_auth requires all three certificate callbacks
++        mTLS: { enabled: true, tlsClientAuth: true, getCertificate: () => undefined },
++    },
++});
++
++new Provider("https://op.example.com", {
++    features: {
++        // @ts-expect-error a dynamic certificate-bound flag still requires a certificate resolver
++        mTLS: {
++            enabled: dynamicallyEnabled,
++            certificateBoundAccessTokens: dynamicallyEnabled,
++        },
++    },
++});
++
++new Provider("https://op.example.com", {
++    features: {
++        // @ts-expect-error a dynamic tls_client_auth flag still requires all three certificate callbacks
++        mTLS: {
++            enabled: dynamicallyEnabled,
++            tlsClientAuth: dynamicallyEnabled,
++            getCertificate: () => undefined,
++        },
++    },
++});
++
++new Provider("https://op.example.com", {
++    features: {
++        // @ts-expect-error a non-empty RAR type map requires grant-source and access-token policies
++        richAuthorizationRequests: {
++            enabled: true,
++            types: { payment: paymentAuthorizationDetail },
++        },
++    },
++});
++
+@@ -44 +358,0 @@ new oidc.Provider("https://op.example.com", {
+-                return parts;
+@@ -49,0 +364,4 @@ new oidc.Provider("https://op.example.com", {
++const findAccountRefreshToken = null as unknown as oidc.RefreshToken;
++const findAccountToken: Parameters<oidc.FindAccount>[2] = findAccountRefreshToken;
++findAccountToken?.iat.toFixed();
++
+@@ -207,0 +526,4 @@ const provider = new oidc.Provider("https://op.example.com", {
++        address: {
++            formatted: null,
++            country: null,
++        },
+@@ -231,0 +554,2 @@ const provider = new oidc.Provider("https://op.example.com", {
++            // @ts-expect-error `state` is not a configurable cookie name.
++            state: "_state",
+@@ -233,0 +558,2 @@ const provider = new oidc.Provider("https://op.example.com", {
++            partitioned: true,
++            priority: "high",
+@@ -239 +565,2 @@ const provider = new oidc.Provider("https://op.example.com", {
+-            sameSite: "lax",
++            priority: "low",
++            sameSite: true,
+@@ -264 +590,0 @@ const provider = new oidc.Provider("https://op.example.com", {
+-                return parts;
+@@ -360 +686,3 @@ const provider = new oidc.Provider("https://op.example.com", {
+-        validator(ctx: oidc.KoaContextWithOIDC, key, value, metadata: oidc.ClientMetadata) {
++        validator(ctx, key, value, metadata: oidc.ClientMetadata) {
++            const optionalContext: oidc.KoaContextWithOIDC | undefined = ctx;
++            // @ts-expect-error The validator context may be undefined.
+@@ -361,0 +690 @@ const provider = new oidc.Provider("https://op.example.com", {
++            optionalContext?.oidc.issuer.substring(0);
+@@ -625,0 +955,41 @@ const provider = new oidc.Provider("https://op.example.com", {
++const firstInteractionCheck = new oidc.interactionPolicy.Check("first", "first check", () => false);
++const secondInteractionCheck = new oidc.interactionPolicy.Check("second", "second check", () => false);
++const thirdInteractionCheck = new oidc.interactionPolicy.Check("third", "third check", () => false);
++const fourthInteractionCheck = new oidc.interactionPolicy.Check("fourth", "fourth check", () => false);
++const replacementInteractionCheck = new oidc.interactionPolicy.Check("replacement", "replacement check", () => false);
++const interactionPrompt = new oidc.interactionPolicy.Prompt(
++    { name: "step-up" },
++    () => ({ method: "webauthn" }),
++    firstInteractionCheck,
++);
++const selectAccountPrompt = new oidc.interactionPolicy.Prompt({ name: "select_account" });
++const reauthenticationPrompt = new oidc.interactionPolicy.Prompt({ name: "reauthenticate" });
++const replacementPrompt = new oidc.interactionPolicy.Prompt({ name: "step-up-replacement" });
++const configuredInteractionPolicy = oidc.interactionPolicy.base();
++const interactionPolicyContext = null as unknown as oidc.KoaContextWithOIDC;
++
++firstInteractionCheck.error?.substring(0);
++configuredInteractionPolicy.get("login")?.name.substring(0);
++configuredInteractionPolicy.remove("missing");
++configuredInteractionPolicy.insertBefore("consent", interactionPrompt);
++configuredInteractionPolicy.insertAfter("login", selectAccountPrompt);
++configuredInteractionPolicy.replace("step-up", reauthenticationPrompt);
++configuredInteractionPolicy.add(interactionPrompt);
++configuredInteractionPolicy.replace("step-up", replacementPrompt);
++configuredInteractionPolicy.clear();
++
++interactionPrompt.checks.get("first")?.description.substring(0);
++interactionPrompt.checks.remove("missing");
++interactionPrompt.checks.add(secondInteractionCheck);
++interactionPrompt.checks.insertBefore("second", thirdInteractionCheck);
++interactionPrompt.checks.insertAfter("third", fourthInteractionCheck);
++interactionPrompt.checks.replace("first", replacementInteractionCheck);
++interactionPrompt.checks.clear();
++Promise.resolve(interactionPrompt.details(interactionPolicyContext)).then(details => details?.method);
++Promise.resolve(selectAccountPrompt.details(interactionPolicyContext)).then(details => details?.method);
++
++// @ts-expect-error policy collections only accept Prompt instances
++configuredInteractionPolicy.add(firstInteractionCheck);
++// @ts-expect-error check collections only accept Check instances
++interactionPrompt.checks.add(interactionPrompt);
++
+@@ -632 +1002 @@ provider.registerGrantType(
+-    async (ctx: oidc.KoaContextWithOIDC, next) => {
++    async (ctx: oidc.TokenEndpointGrantContext) => {
+@@ -634 +1003,0 @@ provider.registerGrantType(
+-        return next();
+@@ -648,0 +1018,15 @@ provider.on("authorization.accepted", (ctx: oidc.KoaContextWithOIDC) => {
++const authorizationSuccessListener = (ctx: oidc.KoaContextWithOIDC, response?: oidc.UnknownObject) => {
++    ctx.oidc.route.substring(0);
++    response?.state;
++};
++
++provider.on("authorization.success", (ctx, response) => {
++    ctx.oidc.route.substring(0);
++    const optionalResponse: oidc.UnknownObject | undefined = response;
++    optionalResponse?.state;
++});
++provider.addListener("authorization.success", authorizationSuccessListener);
++provider.once("authorization.success", authorizationSuccessListener);
++provider.prependListener("authorization.success", authorizationSuccessListener);
++provider.prependOnceListener("authorization.success", authorizationSuccessListener);
++
+@@ -718 +1102,6 @@ provider.OIDCContext.prototype.clientJwtAuthExpectedAudience = function clientJw
+-            externalSigningSupport: { enabled: true, ack: "" },
++            externalSigningSupport: {
++                enabled: true,
++                ack: "",
++                // @ts-expect-error externalSigningSupport has a finite configuration schema.
++                custom: true,
++            },
+@@ -870,0 +1260,17 @@ provider.PreAuthorizedCode.revokeByGrantId("grant").then(console.log);
++const deviceCode = new provider.DeviceCode({
++    client: null as unknown as oidc.Client,
++    deviceInfo: {},
++    grantId: "grant",
++    params: {},
++    userCode: "ABCD-EFGH",
++    rar: [{ type: "payment", actions: ["initiate"] }],
++});
++deviceCode.rar?.[0].type.substring(0);
++
++const clientCredentials = new provider.ClientCredentials({
++    client: null as unknown as oidc.Client,
++    scope: "api:read",
++    rar: [{ type: "payment", actions: ["read"] }],
++});
++clientCredentials.rar?.[0].type.substring(0);
++
+@@ -906,0 +1313,4 @@ const immutableConfiguration = {
++        address: {
++            formatted: null,
++            country: null,
++        },
+@@ -1101,11 +1511,8 @@ new Provider("https://op.example.com", {
+-            rarForAuthorizationCode(ctx) {
+-                return ctx.oidc.grant?.rar;
+-            },
+-            rarForBackchannelResponse(ctx, resourceServer) {
+-                resourceServer.identifier().substring(0);
+-                resourceServer.scopes.has("api:read");
+-                return ctx.oidc.grant?.rar;
+-            },
+-            rarForCodeResponse(ctx, resourceServer) {
+-                resourceServer.identifier().substring(0);
+-                return ctx.oidc.grant?.rar;
++            authorizationDetailsForGrantSource(ctx, source) {
++                ctx.oidc.issuer.substring(0);
++                if (source.kind === "DeviceCode") {
++                    source.userCode.substring(0);
++                } else {
++                    source.redirectUri?.substring(0);
++                }
++                return source.rar;
+@@ -1113 +1520,2 @@ new Provider("https://op.example.com", {
+-            rarForIntrospectionResponse(ctx, token) {
++            authorizationDetailsForAccessToken(ctx, token, source, grantType) {
++                ctx.oidc.issuer.substring(0);
+@@ -1115 +1523,3 @@ new Provider("https://op.example.com", {
+-                return ctx.oidc.grant?.rar;
++                source?.jti.substring(0);
++                grantType.substring(0);
++                return token.rar;
+@@ -1117,3 +1527,4 @@ new Provider("https://op.example.com", {
+-            rarForRefreshTokenResponse(ctx, resourceServer) {
+-                resourceServer.identifier().substring(0);
+-                return ctx.oidc.grant?.rar;
++            authorizationDetailsForIntrospection(ctx, token) {
++                ctx.oidc.issuer.substring(0);
++                token.jti.substring(0);
++                return token.rar;
+@@ -1141,0 +1553,152 @@ provider.registerGrantType(
++interface TokenExchangeParameters {
++    subject_token: string;
++    subject_token_type: string;
++    actor_token?: string | undefined;
++    actor_token_type?: string | undefined;
++    audience?: string | string[] | undefined;
++}
++
++provider.registerGrantType<TokenExchangeParameters>(
++    "urn:ietf:params:oauth:grant-type:token-exchange",
++    async ctx => {
++        ctx.oidc.provider.issuer.substring(0);
++        ctx.oidc.client.clientId.substring(0);
++        ctx.oidc.params.grant_type.substring(0);
++        ctx.oidc.params.subject_token.substring(0);
++        ctx.oidc.params.subject_token_type.substring(0);
++        ctx.oidc.params.actor_token?.substring(0);
++        ctx.oidc.params.audience?.valueOf();
++        Object.values(ctx.oidc.resourceServers).map(resource => resource.identifier());
++
++        const source = await grantHelpers.findGrantSource<oidc.AccessToken>(
++            provider,
++            ctx,
++            provider.AccessToken,
++            ctx.oidc.params.subject_token,
++            "subject token",
++        );
++        const clientBoundSource: grantHelpers.ClientBoundGrantSource = source;
++        clientBoundSource.clientId?.substring(0);
++        const sourceModel: grantHelpers.GrantSourceModel<oidc.AccessToken> = provider.AccessToken;
++        sourceModel.find("access-token", { ignoreExpiration: true }).then(found => found?.jti.substring(0));
++        const code = await grantHelpers.findGrantSource<oidc.AuthorizationCode>(
++            provider,
++            ctx,
++            provider.AuthorizationCode,
++            "authorization-code",
++            "authorization code",
++        );
++        const consumableSource: grantHelpers.ConsumableGrantSource = code;
++        consumableSource.grantId?.substring(0);
++        await grantHelpers.consumeGrantSource(provider, ctx, code, "authorization code");
++
++        const grant = await grantHelpers.validateGrant(provider, ctx, source.grantId);
++        const account = await grantHelpers.findAccount(provider, ctx, source.accountId, source);
++        account?.accountId.substring(0);
++
++        const scopes = grantHelpers.validateClientScope(provider, ctx);
++        grantHelpers.validateClientScope(provider, ctx, "api:read api:write");
++        grantHelpers.validateClientScope(provider, ctx, ["api:read"]);
++        const resources = await grantHelpers.resolveRequestedResources(provider, ctx);
++        resources.map(resource => resource.identifier());
++
++        const accessToken = new provider.AccessToken({
++            accountId: source.accountId,
++            client: ctx.oidc.client,
++            grantId: source.grantId,
++            gty: ctx.oidc.params.grant_type,
++        });
++        accessToken.setAudience("https://api.example.com");
++        accessToken.setAudience(["https://api.example.com"]);
++        accessToken.setThumbprint("jkt", "thumbprint");
++        accessToken.setThumbprint("x5t", "certificate");
++        accessToken.setThumbprint("x5t", new crypto.X509Certificate(Buffer.alloc(0)));
++
++        const resource = await grantHelpers.resolveAndApplyResource(
++            provider,
++            ctx,
++            source,
++            accessToken,
++            grant,
++            scopes,
++        );
++        resource?.substring(0);
++        const resourceSource: grantHelpers.ResourceGrantSource = source;
++        resourceSource.scopes.has("api:read");
++        const authorizationDetailsSource: grantHelpers.AuthorizationDetailsSource = source;
++        authorizationDetailsSource.rar?.[0].type.substring(0);
++
++        const constraints: grantHelpers.SenderConstraints = await grantHelpers.validateSenderConstraints(
++            provider,
++            ctx,
++            oidc.errors.InvalidGrant,
++        );
++        constraints.dPoP?.thumbprint.substring(0);
++        constraints.dPoP?.jti.substring(0);
++        constraints.dPoP?.iat.toFixed();
++        await grantHelpers.applySenderConstraints(provider, ctx, accessToken, constraints, oidc.errors.InvalidRequest);
++        await grantHelpers.applyAuthorizationDetails(provider, ctx, accessToken, source);
++
++        const refreshToken = new provider.RefreshToken({
++            accountId: source.accountId,
++            client: ctx.oidc.client,
++            grantId: source.grantId,
++            gty: ctx.oidc.params.grant_type,
++            scope: accessToken.scope || "",
++        });
++        if (await grantHelpers.shouldIssueRefreshToken(provider, ctx, source)) {
++            await grantHelpers.applyRefreshTokenBindings(provider, ctx, accessToken, refreshToken);
++        }
++
++        const responseInput: grantHelpers.TokenResponseInput<{ transaction_id: string }> = {
++            accessToken: "serialized-access-token",
++            expiresIn: accessToken.expiration,
++            issuedTokenType: "urn:ietf:params:oauth:token-type:access_token",
++            parameters: {
++                transaction_id: "transaction-id",
++            },
++            scope: accessToken.scope,
++            tokenType: accessToken.tokenType,
++        };
++        const response = grantHelpers.buildTokenResponse(provider, responseInput);
++        response.access_token.substring(0);
++        response.token_type.substring(0);
++        response.transaction_id.substring(0);
++        const standardResponse: grantHelpers.TokenResponse = response;
++        standardResponse.issued_token_type?.substring(0);
++        const reservedMember: grantHelpers.ReservedTokenResponseParameter = "access_token";
++        reservedMember.substring(0);
++
++        const clientCredentials = new provider.ClientCredentials({ client: ctx.oidc.client });
++        clientCredentials.setAudience("https://api.example.com");
++        clientCredentials.setThumbprint("jkt", "thumbprint");
++        await grantHelpers.applyAuthorizationDetails(provider, ctx, clientCredentials);
++
++        const errorConstructor: grantHelpers.OIDCProviderErrorConstructor = oidc.errors.InvalidGrant;
++        errorConstructor.name.substring(0);
++        const dpopResult: grantHelpers.DPoPValidationResult | undefined = constraints.dPoP;
++        dpopResult?.thumbprint.substring(0);
++
++        // @ts-expect-error The provider argument must be an oidc-provider instance.
++        grantHelpers.validateClientScope({}, ctx);
++        grantHelpers.buildTokenResponse(provider, {
++            accessToken: "serialized-access-token",
++            tokenType: "Bearer",
++            // @ts-expect-error Extension parameters cannot override reserved response members.
++            parameters: {
++                access_token: "replacement",
++            },
++        });
++        // @ts-expect-error tokenType is required.
++        grantHelpers.buildTokenResponse(provider, { accessToken: "serialized-access-token" });
++    },
++    [
++        "subject_token",
++        "subject_token_type",
++        "actor_token",
++        "actor_token_type",
++        "audience",
++    ],
++    ["audience"],
++);
++

--- a/types/oidc-provider/scripts/sync-release.mjs
+++ b/types/oidc-provider/scripts/sync-release.mjs
@@ -1,0 +1,837 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { lstatSync, mkdirSync, mkdtempSync, readdirSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, posix, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const STATUS_SCHEMA_VERSION = 1;
+const UPSTREAM_REPOSITORY = "DefinitelyTyped/DefinitelyTyped";
+const PROVIDER_REPOSITORY = "panva/node-oidc-provider";
+const PACKAGE_PATH = "types/oidc-provider";
+const HASH_PATTERN = /^[a-f0-9]{64}$/;
+const VERSION_PATTERN = /^(\d+)\.(\d+)\.(\d+)$/;
+const TAG_PATTERN = /^v(\d+\.\d+\.\d+)$/;
+const STATUS_REASONS = new Set(["declarations", "major-version"]);
+function usage() {
+    return "usage: node scripts/sync-release.mjs --tag vX.Y.Z (--run-id <id> | --artifact <path>) [--submit] [--keep-temp]";
+}
+
+function fail(message) {
+    throw new Error(message);
+}
+
+function optionValue(argv, index, option) {
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) fail(`${option} requires a value`);
+    return value;
+}
+
+export function parseArguments(argv, cwd = process.cwd()) {
+    const parsed = {
+        artifact: undefined,
+        keepTemp: false,
+        runId: undefined,
+        submit: false,
+        tag: undefined,
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const argument = argv[index];
+        switch (argument) {
+            case "--artifact": {
+                if (parsed.artifact !== undefined) fail("--artifact may only be specified once");
+                parsed.artifact = resolve(cwd, optionValue(argv, index, argument));
+                index += 1;
+                break;
+            }
+            case "--keep-temp":
+                if (parsed.keepTemp) fail("--keep-temp may only be specified once");
+                parsed.keepTemp = true;
+                break;
+            case "--run-id":
+                if (parsed.runId !== undefined) fail("--run-id may only be specified once");
+                parsed.runId = optionValue(argv, index, argument);
+                index += 1;
+                break;
+            case "--submit":
+                if (parsed.submit) fail("--submit may only be specified once");
+                parsed.submit = true;
+                break;
+            case "--tag":
+                if (parsed.tag !== undefined) fail("--tag may only be specified once");
+                parsed.tag = optionValue(argv, index, argument);
+                index += 1;
+                break;
+            default:
+                fail(`unknown argument ${JSON.stringify(argument)}\n${usage()}`);
+        }
+    }
+
+    if (!parsed.tag) fail(`--tag is required\n${usage()}`);
+    if (!TAG_PATTERN.test(parsed.tag)) fail("--tag must have the form vX.Y.Z");
+    if ((parsed.artifact === undefined) === (parsed.runId === undefined)) {
+        fail(`exactly one of --run-id or --artifact is required\n${usage()}`);
+    }
+    if (parsed.runId !== undefined && !/^[1-9]\d*$/.test(parsed.runId)) {
+        fail("--run-id must be a positive GitHub Actions run ID");
+    }
+
+    return parsed;
+}
+
+export function releasePlan(tag) {
+    const match = TAG_PATTERN.exec(tag);
+    if (!match) fail("tag must have the form vX.Y.Z");
+    const version = match[1];
+    return {
+        artifactName: `oidc-provider-types-${tag}`,
+        branch: `oidc-provider-${tag}`,
+        commitTitle: `[oidc-provider] sync declarations for ${tag}`,
+        tag,
+        version,
+    };
+}
+
+function commandDescription(command, args) {
+    return [command, ...args].map((part) => JSON.stringify(part)).join(" ");
+}
+
+function shellQuote(value) {
+    if (/^[A-Za-z0-9_./:@%+=,-]+$/.test(value)) return value;
+    return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+export function shellCommand(command, args) {
+    return [command, ...args].map(shellQuote).join(" ");
+}
+
+export function runCommand(command, args, {
+    allowStatuses = [0],
+    capture = true,
+    cwd,
+} = {}) {
+    const result = spawnSync(command, args, {
+        cwd,
+        encoding: "utf8",
+        maxBuffer: 32 * 1024 * 1024,
+        stdio: capture ? ["ignore", "pipe", "pipe"] : "inherit",
+    });
+    if (result.error) {
+        fail(`could not run ${commandDescription(command, args)}: ${result.error.message}`);
+    }
+    if (!allowStatuses.includes(result.status)) {
+        const diagnostic = capture ? (result.stderr || result.stdout || "").trim() : "";
+        fail(
+            `${commandDescription(command, args)} exited with status ${result.status}${
+                diagnostic ? `: ${diagnostic}` : ""
+            }`,
+        );
+    }
+    return {
+        status: result.status,
+        stderr: result.stderr || "",
+        stdout: result.stdout || "",
+    };
+}
+
+function output(execute, command, args, options) {
+    return execute(command, args, options).stdout.trim();
+}
+
+export function githubRepository(remote) {
+    const patterns = [
+        /^git@github\.com:([^/\s:]+)\/([^/\s?#:]+?)(?:\.git)?\/?$/,
+        /^ssh:\/\/git@github\.com\/([^/\s:]+)\/([^/\s?#:]+?)(?:\.git)?\/?$/,
+        /^https:\/\/github\.com\/([^/\s:]+)\/([^/\s?#:]+?)(?:\.git)?\/?$/,
+    ];
+    for (const pattern of patterns) {
+        const match = pattern.exec(remote);
+        if (match) return { owner: match[1], repository: match[2] };
+    }
+    fail("remote must use an exact github.com HTTPS or SSH URL");
+}
+
+function assertNodeVersion(version) {
+    const match = VERSION_PATTERN.exec(version);
+    if (!match) fail(`could not parse Node.js version ${JSON.stringify(version)}`);
+    const major = Number(match[1]);
+    const minor = Number(match[2]);
+    if (major < 20 || (major === 20 && minor < 17)) {
+        fail(`Node.js 20.17.0 or newer is required, found ${version}`);
+    }
+}
+
+function preflight(packageDirectory, execute) {
+    assertNodeVersion(process.versions.node);
+
+    const repositoryDirectory = output(
+        execute,
+        "git",
+        ["-C", packageDirectory, "rev-parse", "--show-toplevel"],
+    );
+    const packageRelative = relative(repositoryDirectory, packageDirectory).split(sep).join("/");
+    if (packageRelative !== PACKAGE_PATH) {
+        fail(`sync-release must be run from ${PACKAGE_PATH} in a DefinitelyTyped checkout`);
+    }
+
+    output(execute, "git", ["--version"]);
+    output(execute, "gh", ["--version"]);
+    execute("gh", ["auth", "status", "--hostname", "github.com"], { capture: true });
+    const githubLogin = output(execute, "gh", ["api", "user", "--jq", ".login"]);
+    const pnpmVersion = output(execute, "pnpm", ["--version"]);
+    if (!VERSION_PATTERN.test(pnpmVersion)) fail(`could not parse pnpm version ${JSON.stringify(pnpmVersion)}`);
+
+    const userName = output(execute, "git", ["-C", repositoryDirectory, "config", "--get", "user.name"]);
+    const userEmail = output(execute, "git", ["-C", repositoryDirectory, "config", "--get", "user.email"]);
+    if (!userName || !userEmail) fail("git user.name and user.email must both be configured");
+
+    const upstreamUrl = output(
+        execute,
+        "git",
+        ["-C", repositoryDirectory, "remote", "get-url", "upstream"],
+    );
+    const originUrl = output(
+        execute,
+        "git",
+        ["-C", repositoryDirectory, "remote", "get-url", "origin"],
+    );
+    const originPushUrls = parseLines(output(
+        execute,
+        "git",
+        ["-C", repositoryDirectory, "remote", "get-url", "--push", "--all", "origin"],
+    ));
+    const upstream = githubRepository(upstreamUrl);
+    const origin = githubRepository(originUrl);
+    if (`${upstream.owner}/${upstream.repository}`.toLowerCase() !== UPSTREAM_REPOSITORY.toLowerCase()) {
+        fail(`upstream must point to ${UPSTREAM_REPOSITORY}, found ${upstream.owner}/${upstream.repository}`);
+    }
+    if (origin.repository.toLowerCase() !== "definitelytyped") {
+        fail(`origin must point to a DefinitelyTyped fork, found ${origin.owner}/${origin.repository}`);
+    }
+    if (origin.owner.toLowerCase() !== githubLogin.toLowerCase()) {
+        fail(`origin fork owner ${origin.owner} does not match authenticated GitHub user ${githubLogin}`);
+    }
+    if (
+        !originPushUrls.length || originPushUrls.some((url) => {
+            const push = githubRepository(url);
+            return push.owner.toLowerCase() !== origin.owner.toLowerCase()
+                || push.repository.toLowerCase() !== origin.repository.toLowerCase();
+        })
+    ) {
+        fail("every origin push URL must point to the authenticated DefinitelyTyped fork");
+    }
+
+    return { originOwner: origin.owner, repositoryDirectory };
+}
+
+function regularFile(path, label, rejectSymlink = false) {
+    let stats;
+    try {
+        stats = rejectSymlink ? lstatSync(path) : statSync(path);
+    } catch (error) {
+        fail(`${label} is not readable at ${path}: ${error.message}`);
+    }
+    if (!stats.isFile()) fail(`${label} must be a regular file: ${path}`);
+    return path;
+}
+
+function acquireArtifact(options, plan, temporaryDirectory, execute) {
+    if (options.artifact !== undefined) {
+        return regularFile(options.artifact, "provider types artifact");
+    }
+
+    const downloadDirectory = join(temporaryDirectory, "artifact");
+    mkdirSync(downloadDirectory);
+    execute("gh", [
+        "run",
+        "download",
+        options.runId,
+        "--repo",
+        PROVIDER_REPOSITORY,
+        "--name",
+        plan.artifactName,
+        "--dir",
+        downloadDirectory,
+    ], { capture: false });
+
+    const entries = readdirSync(downloadDirectory);
+    if (entries.length !== 1 || entries[0] !== "oidc-provider-types.json") {
+        fail(
+            `${plan.artifactName} must contain exactly one top-level file named oidc-provider-types.json`,
+        );
+    }
+    return regularFile(
+        join(downloadDirectory, "oidc-provider-types.json"),
+        "downloaded provider types artifact",
+        true,
+    );
+}
+
+function exactObjectKeys(value, required, optional, label) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) fail(`${label} must be an object`);
+    const allowed = new Set([...required, ...optional]);
+    const keys = Object.keys(value);
+    const missing = required.filter((key) => !Object.hasOwn(value, key));
+    const extra = keys.filter((key) => !allowed.has(key));
+    if (missing.length || extra.length) {
+        fail(
+            `${label} has invalid keys${missing.length ? `; missing ${missing.join(", ")}` : ""}${
+                extra.length ? `; unexpected ${extra.join(", ")}` : ""
+            }`,
+        );
+    }
+}
+
+function safePackagePath(path) {
+    return typeof path === "string"
+        && path.length > 0
+        && path !== "."
+        && !path.includes("\\")
+        && path === posix.normalize(path)
+        && !posix.isAbsolute(path)
+        && path !== ".."
+        && !path.startsWith("../");
+}
+
+export function validateStatus(stdout, expectedVersion) {
+    let status;
+    try {
+        status = typeof stdout === "string" ? JSON.parse(stdout) : stdout;
+    } catch (error) {
+        fail(`update-types --status returned invalid JSON: ${error.message}`);
+    }
+    exactObjectKeys(
+        status,
+        [
+            "schemaVersion",
+            "updateRequired",
+            "reasons",
+            "providerVersion",
+            "typesVersion",
+            "currentHash",
+            "candidateHash",
+            "changedFiles",
+        ],
+        ["warning"],
+        "update-types status",
+    );
+    if (status.schemaVersion !== STATUS_SCHEMA_VERSION) {
+        fail(`unsupported update-types status schema ${JSON.stringify(status.schemaVersion)}`);
+    }
+    if (typeof status.updateRequired !== "boolean") fail("update-types status updateRequired must be a Boolean");
+    if (!Array.isArray(status.reasons) || status.reasons.some((reason) => !STATUS_REASONS.has(reason))) {
+        fail("update-types status reasons contains an unsupported value");
+    }
+    if (new Set(status.reasons).size !== status.reasons.length) {
+        fail("update-types status reasons must not contain duplicates");
+    }
+    if (status.updateRequired !== (status.reasons.length > 0)) {
+        fail("update-types status updateRequired must agree with reasons");
+    }
+    if (status.providerVersion !== expectedVersion) {
+        fail(
+            `provider artifact version ${
+                JSON.stringify(status.providerVersion)
+            } does not match release ${expectedVersion}`,
+        );
+    }
+    if (typeof status.typesVersion !== "string" || !VERSION_PATTERN.test(status.typesVersion)) {
+        fail("update-types status typesVersion must be an X.Y.Z version");
+    }
+    if (!HASH_PATTERN.test(status.currentHash) || !HASH_PATTERN.test(status.candidateHash)) {
+        fail("update-types status hashes must be lowercase hexadecimal SHA-256 digests");
+    }
+    if (!Array.isArray(status.changedFiles) || status.changedFiles.some((path) => !safePackagePath(path))) {
+        fail("update-types status changedFiles must contain safe package-relative paths");
+    }
+    if (new Set(status.changedFiles).size !== status.changedFiles.length) {
+        fail("update-types status changedFiles must not contain duplicates");
+    }
+    if (status.updateRequired !== (status.changedFiles.length > 0)) {
+        fail("update-types status updateRequired must agree with changedFiles");
+    }
+    if (status.warning !== undefined && (typeof status.warning !== "string" || !status.warning)) {
+        fail("update-types status warning must be a non-empty string");
+    }
+    return status;
+}
+
+function parseLines(value) {
+    return value.split("\n").map((line) => line.trim()).filter(Boolean);
+}
+
+export function assertPackageChanges(repositoryPaths, expectedPackagePaths) {
+    const actual = [...new Set(repositoryPaths)].sort();
+    for (const path of actual) {
+        if (path !== PACKAGE_PATH && !path.startsWith(`${PACKAGE_PATH}/`)) {
+            fail(`unexpected change outside ${PACKAGE_PATH}: ${path}`);
+        }
+    }
+    if (expectedPackagePaths !== undefined) {
+        const expected = expectedPackagePaths.map((path) => `${PACKAGE_PATH}/${path}`).sort();
+        if (actual.length !== expected.length || actual.some((path, index) => path !== expected[index])) {
+            fail(
+                `updated files do not match update-types status; expected ${expected.join(", ")}, found ${
+                    actual.join(", ") || "none"
+                }`,
+            );
+        }
+    }
+    return actual;
+}
+
+function workingChanges(repositoryDirectory, execute) {
+    const commands = [
+        ["diff", "--name-only", "--no-ext-diff"],
+        ["diff", "--cached", "--name-only", "--no-ext-diff"],
+        ["ls-files", "--others", "--exclude-standard"],
+    ];
+    return commands.flatMap((args) =>
+        parseLines(output(
+            execute,
+            "git",
+            ["-C", repositoryDirectory, ...args],
+        ))
+    );
+}
+
+function installDependencies(worktreeDirectory, execute) {
+    execute(
+        "pnpm",
+        [
+            "install",
+            "--no-frozen-lockfile",
+            "--ignore-scripts",
+            "--filter",
+            ".",
+            "--filter",
+            "@types/oidc-provider...",
+        ],
+        { capture: false, cwd: worktreeDirectory },
+    );
+}
+
+function updaterStatus(packageDirectory, artifactPath, expectedVersion, execute) {
+    const result = execute(
+        "node",
+        ["scripts/update-types.mjs", "--status", "--artifact", artifactPath],
+        { capture: true, cwd: packageDirectory },
+    );
+    if (result.stderr) process.stderr.write(result.stderr);
+    return validateStatus(result.stdout, expectedVersion);
+}
+
+function runChecks(worktreeDirectory, artifactPath, execute) {
+    const packageDirectory = join(worktreeDirectory, PACKAGE_PATH);
+    execute(
+        "node",
+        ["scripts/update-types.mjs", "--check", "--artifact", artifactPath],
+        { capture: false, cwd: packageDirectory },
+    );
+    execute(
+        "node",
+        ["scripts/update-types.test.mjs", "--artifact", artifactPath],
+        { capture: false, cwd: packageDirectory },
+    );
+    execute(
+        "pnpm",
+        ["exec", "dprint", "check", PACKAGE_PATH],
+        { capture: false, cwd: worktreeDirectory },
+    );
+    execute(
+        "pnpm",
+        ["test", "oidc-provider"],
+        { capture: false, cwd: worktreeDirectory },
+    );
+}
+
+function matchingPullRequest(plan, originOwner, execute) {
+    const result = execute("gh", [
+        "pr",
+        "list",
+        "--repo",
+        UPSTREAM_REPOSITORY,
+        "--state",
+        "all",
+        "--head",
+        plan.branch,
+        "--json",
+        "number,url,state,mergedAt,headRefName,headRepositoryOwner",
+        "--limit",
+        "100",
+    ], { capture: true });
+    let pullRequests;
+    try {
+        pullRequests = JSON.parse(result.stdout);
+    } catch (error) {
+        fail(`gh pr list returned invalid JSON: ${error.message}`);
+    }
+    if (!Array.isArray(pullRequests)) fail("gh pr list did not return an array");
+    const matching = pullRequests.filter(({ headRefName, headRepositoryOwner }) =>
+        headRefName === plan.branch
+        && headRepositoryOwner?.login?.toLowerCase() === originOwner.toLowerCase()
+    );
+    if (matching.length > 1) fail(`multiple pull requests use ${originOwner}:${plan.branch}`);
+    if (!matching.length) return undefined;
+    const [{ mergedAt, number, state, url }] = matching;
+    if (
+        !Number.isSafeInteger(number)
+        || number <= 0
+        || typeof url !== "string"
+        || !url
+        || !["OPEN", "CLOSED", "MERGED"].includes(state)
+        || (mergedAt !== null && typeof mergedAt !== "string")
+    ) {
+        fail("gh pr list returned invalid pull request metadata");
+    }
+    return { merged: state === "MERGED" || mergedAt !== null, number, state, url };
+}
+
+function successfulPullRequest(pullRequest, plan) {
+    if (!pullRequest) return undefined;
+    if (pullRequest.state === "OPEN" || pullRequest.merged) return pullRequest;
+    fail(
+        `${pullRequest.url} for ${plan.branch} was closed without merging; recover or remove the branch before retrying`,
+    );
+}
+
+function remoteBranchHead(repositoryDirectory, branch, execute) {
+    const remote = output(
+        execute,
+        "git",
+        ["-C", repositoryDirectory, "ls-remote", "--heads", "origin", `refs/heads/${branch}`],
+    );
+    if (!remote) return undefined;
+    const rows = parseLines(remote);
+    if (rows.length !== 1 || !/^[a-f0-9]{40,64}\s+refs\/heads\//.test(rows[0])) {
+        fail(`could not determine the state of origin/${branch}`);
+    }
+    return rows[0].split(/\s+/)[0];
+}
+
+export function pullRequestBody(plan, status) {
+    return [
+        `Synchronizes the generated oidc-provider declaration mirrors with oidc-provider ${plan.tag}.`,
+        "",
+        `Rendered declaration hash: \`${status.candidateHash}\`.`,
+    ].join("\n");
+}
+
+export function submitPreparedBranch({
+    execute = runCommand,
+    originOwner,
+    plan,
+    repositoryDirectory,
+    status,
+    worktreeDirectory,
+}) {
+    const existing = successfulPullRequest(matchingPullRequest(plan, originOwner, execute), plan);
+    if (existing) return { created: false, ...existing };
+
+    if (remoteBranchHead(repositoryDirectory, plan.branch, execute)) {
+        fail(
+            `origin/${plan.branch} exists without a pull request; refusing to overwrite or adopt the orphaned branch`,
+        );
+    }
+    execute(
+        "git",
+        ["-C", worktreeDirectory, "push", "--set-upstream", "origin", plan.branch],
+        { capture: false },
+    );
+
+    const raced = successfulPullRequest(matchingPullRequest(plan, originOwner, execute), plan);
+    if (raced) return { created: false, ...raced };
+
+    const result = execute("gh", [
+        "pr",
+        "create",
+        "--repo",
+        UPSTREAM_REPOSITORY,
+        "--base",
+        "master",
+        "--head",
+        `${originOwner}:${plan.branch}`,
+        "--title",
+        plan.commitTitle,
+        "--body",
+        pullRequestBody(plan, status),
+    ], { capture: true, cwd: worktreeDirectory });
+    const url = result.stdout.trim();
+    if (!url) fail("gh pr create did not return a pull request URL");
+    return { created: true, url };
+}
+
+function localBranchExists(repositoryDirectory, branch, execute) {
+    const result = execute(
+        "git",
+        ["-C", repositoryDirectory, "show-ref", "--verify", "--quiet", `refs/heads/${branch}`],
+        { allowStatuses: [0, 1], capture: true },
+    );
+    return result.status === 0;
+}
+
+function verifyPreparedBranch(worktreeDirectory, plan, expectedPackagePaths, execute) {
+    const ancestry = execute(
+        "git",
+        ["-C", worktreeDirectory, "merge-base", "--is-ancestor", "upstream/master", plan.branch],
+        { allowStatuses: [0, 1], capture: true },
+    );
+    if (ancestry.status !== 0) {
+        fail(
+            `${plan.branch} is not based on the fetched upstream/master; inspect and delete or rename it before retrying`,
+        );
+    }
+    const commitCount = output(
+        execute,
+        "git",
+        ["-C", worktreeDirectory, "rev-list", "--count", `upstream/master..${plan.branch}`],
+    );
+    const subject = output(
+        execute,
+        "git",
+        ["-C", worktreeDirectory, "log", "-1", "--format=%s", plan.branch],
+    );
+    if (commitCount !== "1" || subject !== plan.commitTitle) {
+        fail(
+            `${plan.branch} exists but is not the expected single prepared commit; inspect and delete or rename it before retrying`,
+        );
+    }
+    const changes = parseLines(output(
+        execute,
+        "git",
+        ["-C", worktreeDirectory, "diff", "--name-only", `upstream/master...${plan.branch}`],
+    ));
+    if (!changes.length) fail(`${plan.branch} does not contain any package changes`);
+    assertPackageChanges(changes, expectedPackagePaths);
+    const comparison = execute(
+        "git",
+        ["-C", worktreeDirectory, "diff", "--quiet", plan.branch, "--", PACKAGE_PATH],
+        { allowStatuses: [0, 1], capture: true },
+    );
+    if (comparison.status !== 0) {
+        fail(`${plan.branch} does not contain the exact declaration update for ${plan.tag}`);
+    }
+}
+
+function cleanupTemporaryWorktree(repositoryDirectory, worktreeDirectory, temporaryDirectory, execute) {
+    if (worktreeDirectory !== undefined) {
+        execute(
+            "git",
+            ["-C", repositoryDirectory, "worktree", "remove", worktreeDirectory],
+            { capture: true },
+        );
+    }
+    rmSync(temporaryDirectory, { force: true, recursive: true });
+}
+
+export function synchronize(options, execute = runCommand) {
+    const packageDirectory = resolve(fileURLToPath(new URL("..", import.meta.url)));
+    const plan = releasePlan(options.tag);
+    const preflightResult = preflight(packageDirectory, execute);
+    const temporaryDirectory = mkdtempSync(join(tmpdir(), "oidc-provider-sync-"));
+    let worktreeDirectory;
+    let succeeded = false;
+
+    try {
+        const artifactPath = acquireArtifact(options, plan, temporaryDirectory, execute);
+        execute(
+            "git",
+            [
+                "-C",
+                preflightResult.repositoryDirectory,
+                "fetch",
+                "--no-tags",
+                "upstream",
+                "refs/heads/master:refs/remotes/upstream/master",
+            ],
+            { capture: false },
+        );
+
+        const branchExists = localBranchExists(
+            preflightResult.repositoryDirectory,
+            plan.branch,
+            execute,
+        );
+        worktreeDirectory = join(temporaryDirectory, "worktree");
+        execute(
+            "git",
+            [
+                "-C",
+                preflightResult.repositoryDirectory,
+                "worktree",
+                "add",
+                "--detach",
+                worktreeDirectory,
+                "upstream/master",
+            ],
+            { capture: false },
+        );
+        installDependencies(worktreeDirectory, execute);
+
+        const worktreePackage = join(worktreeDirectory, PACKAGE_PATH);
+        const status = updaterStatus(worktreePackage, artifactPath, plan.version, execute);
+        if (status.warning) console.warn(`sync-release: ${status.warning}`);
+
+        const existing = successfulPullRequest(
+            matchingPullRequest(plan, preflightResult.originOwner, execute),
+            plan,
+        );
+        if (existing) {
+            console.log(`${existing.merged ? "Merged" : "Open"} pull request already exists: ${existing.url}`);
+            succeeded = true;
+            return { branch: plan.branch, pullRequest: existing.url, reused: true };
+        }
+        if (remoteBranchHead(preflightResult.repositoryDirectory, plan.branch, execute)) {
+            fail(
+                `origin/${plan.branch} exists without a pull request; recover or remove the orphaned branch before retrying`,
+            );
+        }
+
+        if (!status.updateRequired) {
+            if (branchExists) {
+                fail(
+                    `${plan.branch} exists even though ${plan.tag} requires no update; inspect and delete or rename it before retrying`,
+                );
+            }
+            console.log(`No declaration update is required for oidc-provider ${plan.tag}.`);
+            succeeded = true;
+            return { branch: undefined, updated: false };
+        }
+
+        execute(
+            "node",
+            ["scripts/update-types.mjs", "--artifact", artifactPath],
+            { capture: false, cwd: worktreePackage },
+        );
+        assertPackageChanges(
+            workingChanges(worktreeDirectory, execute),
+            status.changedFiles,
+        );
+        runChecks(worktreeDirectory, artifactPath, execute);
+        assertPackageChanges(
+            workingChanges(worktreeDirectory, execute),
+            status.changedFiles,
+        );
+
+        if (branchExists) {
+            verifyPreparedBranch(worktreeDirectory, plan, status.changedFiles, execute);
+            execute(
+                "git",
+                ["-C", worktreeDirectory, "restore", "--source=HEAD", "--staged", "--worktree", "--", PACKAGE_PATH],
+                { capture: true },
+            );
+            if (workingChanges(worktreeDirectory, execute).length) {
+                fail("the temporary validation worktree could not be restored");
+            }
+        } else {
+            execute(
+                "git",
+                ["-C", worktreeDirectory, "switch", "-c", plan.branch],
+                { capture: false },
+            );
+            execute(
+                "git",
+                ["-C", worktreeDirectory, "add", "--", PACKAGE_PATH],
+                { capture: true },
+            );
+            const staged = parseLines(output(
+                execute,
+                "git",
+                ["-C", worktreeDirectory, "diff", "--cached", "--name-only"],
+            ));
+            assertPackageChanges(staged, status.changedFiles);
+            const preparedTree = output(
+                execute,
+                "git",
+                ["-C", worktreeDirectory, "write-tree"],
+            );
+            execute(
+                "git",
+                ["-C", worktreeDirectory, "commit", "-m", plan.commitTitle],
+                { capture: false },
+            );
+            const committedTree = output(
+                execute,
+                "git",
+                ["-C", worktreeDirectory, "rev-parse", "HEAD^{tree}"],
+            );
+            if (committedTree !== preparedTree) {
+                fail("commit hooks changed the prepared declaration update");
+            }
+            execute(
+                "node",
+                ["scripts/update-types.mjs", "--check", "--artifact", artifactPath],
+                { capture: false, cwd: worktreePackage },
+            );
+            const committed = parseLines(output(
+                execute,
+                "git",
+                ["-C", worktreeDirectory, "diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD"],
+            ));
+            assertPackageChanges(committed, status.changedFiles);
+            if (workingChanges(worktreeDirectory, execute).length) {
+                fail("the prepared branch is not clean after committing");
+            }
+        }
+
+        let pullRequest;
+        if (options.submit) {
+            const submitted = submitPreparedBranch({
+                execute,
+                originOwner: preflightResult.originOwner,
+                plan,
+                repositoryDirectory: preflightResult.repositoryDirectory,
+                status,
+                worktreeDirectory,
+            });
+            pullRequest = submitted.url;
+            console.log(`${submitted.created ? "Created" : "Reused"} pull request: ${submitted.url}`);
+        } else {
+            console.log(`Prepared local branch ${plan.branch}.`);
+            console.log(`Inspect it with: git show --stat ${plan.branch}`);
+            const source = options.artifact === undefined
+                ? ["--run-id", options.runId]
+                : ["--artifact", options.artifact];
+            console.log(
+                `Submit it with: ${
+                    shellCommand("node", [
+                        fileURLToPath(import.meta.url),
+                        "--tag",
+                        plan.tag,
+                        ...source,
+                        "--submit",
+                    ])
+                }`,
+            );
+        }
+
+        succeeded = true;
+        return { branch: plan.branch, pullRequest, updated: true };
+    } catch (error) {
+        error.temporaryDirectory = temporaryDirectory;
+        throw error;
+    } finally {
+        if (succeeded && !options.keepTemp) {
+            cleanupTemporaryWorktree(
+                preflightResult.repositoryDirectory,
+                worktreeDirectory,
+                temporaryDirectory,
+                execute,
+            );
+        } else if (temporaryDirectory) {
+            console.error(`sync-release: preserved temporary state at ${temporaryDirectory}`);
+        }
+    }
+}
+
+const isMain = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+    try {
+        synchronize(parseArguments(process.argv.slice(2)));
+    } catch (error) {
+        console.error(`sync-release: ${error.message}`);
+        process.exitCode = 1;
+    }
+}

--- a/types/oidc-provider/scripts/sync-release.test.mjs
+++ b/types/oidc-provider/scripts/sync-release.test.mjs
@@ -1,0 +1,609 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+    assertPackageChanges,
+    githubRepository,
+    parseArguments,
+    pullRequestBody,
+    releasePlan,
+    shellCommand,
+    submitPreparedBranch,
+    synchronize,
+    validateStatus,
+} from "./sync-release.mjs";
+
+const hash = "a".repeat(64);
+const candidateHash = "b".repeat(64);
+const packageDirectory = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const repositoryDirectory = resolve(packageDirectory, "..", "..");
+
+function status(overrides = {}) {
+    return {
+        schemaVersion: 1,
+        updateRequired: true,
+        reasons: ["declarations"],
+        providerVersion: "9.12.3",
+        typesVersion: "9.11.9999",
+        currentHash: hash,
+        candidateHash,
+        changedFiles: ["index.d.ts"],
+        ...overrides,
+    };
+}
+
+describe("sync-release argument and status validation", () => {
+    it("accepts exactly one artifact source and resolves local paths", () => {
+        assert.deepEqual(
+            parseArguments(["--tag", "v9.12.3", "--artifact", "artifact.json"], "/fixture"),
+            {
+                artifact: "/fixture/artifact.json",
+                keepTemp: false,
+                runId: undefined,
+                submit: false,
+                tag: "v9.12.3",
+            },
+        );
+        assert.deepEqual(
+            parseArguments([
+                "--run-id",
+                "12345",
+                "--keep-temp",
+                "--submit",
+                "--tag",
+                "v9.12.3",
+            ]),
+            {
+                artifact: undefined,
+                keepTemp: true,
+                runId: "12345",
+                submit: true,
+                tag: "v9.12.3",
+            },
+        );
+    });
+
+    for (
+        const [label, argv, pattern] of [
+            ["missing tag", ["--artifact", "a.json"], /--tag is required/],
+            ["invalid tag", ["--tag", "9.12.3", "--artifact", "a.json"], /form vX\.Y\.Z/],
+            ["missing source", ["--tag", "v9.12.3"], /exactly one/],
+            [
+                "both sources",
+                ["--tag", "v9.12.3", "--artifact", "a.json", "--run-id", "123"],
+                /exactly one/,
+            ],
+            ["invalid run", ["--tag", "v9.12.3", "--run-id", "latest"], /positive GitHub Actions/],
+            ["unknown option", ["--tag", "v9.12.3", "--artifact", "a.json", "--force"], /unknown/],
+            [
+                "duplicate option",
+                ["--tag", "v9.12.3", "--tag", "v9.12.4", "--artifact", "a.json"],
+                /only be specified once/,
+            ],
+        ]
+    ) {
+        it(`rejects ${label}`, () => {
+            assert.throws(() => parseArguments(argv), pattern);
+        });
+    }
+
+    it("derives stable artifact, branch, commit, and pull request metadata", () => {
+        const plan = releasePlan("v9.12.3");
+        assert.deepEqual(plan, {
+            artifactName: "oidc-provider-types-v9.12.3",
+            branch: "oidc-provider-v9.12.3",
+            commitTitle: "[oidc-provider] sync declarations for v9.12.3",
+            tag: "v9.12.3",
+            version: "9.12.3",
+        });
+        assert.equal(
+            pullRequestBody(plan, status()),
+            [
+                "Synchronizes the generated oidc-provider declaration mirrors with oidc-provider v9.12.3.",
+                "",
+                `Rendered declaration hash: \`${candidateHash}\`.`,
+            ].join("\n"),
+        );
+    });
+
+    it("prints copyable shell commands without evaluating artifact paths", () => {
+        assert.equal(
+            shellCommand("node", ["script.mjs", "--artifact", "/tmp/a$(touch pwned)'types.json"]),
+            `node script.mjs --artifact '/tmp/a$(touch pwned)'"'"'types.json'`,
+        );
+    });
+
+    it("accepts the updater status contract and enforces the release tag", () => {
+        assert.deepEqual(validateStatus(`${JSON.stringify(status())}\n`, "9.12.3"), status());
+        assert.throws(() => validateStatus(status(), "9.12.4"), /does not match release/);
+    });
+
+    for (
+        const [label, value, pattern] of [
+            ["invalid JSON", "not-json", /invalid JSON/],
+            ["schema", status({ schemaVersion: 2 }), /unsupported.*schema/],
+            ["reason", status({ reasons: ["unknown"] }), /unsupported value/],
+            ["duplicate reason", status({ reasons: ["declarations", "declarations"] }), /duplicates/],
+            ["reason invariant", status({ reasons: [] }), /agree with reasons/],
+            ["hash", status({ candidateHash: "bad" }), /SHA-256/],
+            ["unsafe path", status({ changedFiles: ["../package.json"] }), /safe package-relative/],
+            ["duplicate path", status({ changedFiles: ["index.d.ts", "index.d.ts"] }), /duplicates/],
+            [
+                "file invariant",
+                status({ updateRequired: false, reasons: [], changedFiles: ["index.d.ts"] }),
+                /agree with changedFiles/,
+            ],
+            ["empty warning", status({ warning: "" }), /non-empty string/],
+            ["extra property", { ...status(), extra: true }, /unexpected extra/],
+        ]
+    ) {
+        it(`rejects ${label} status`, () => {
+            assert.throws(() => validateStatus(value, "9.12.3"), pattern);
+        });
+    }
+
+    it("allows a warning-bearing no-update status", () => {
+        const value = status({
+            changedFiles: [],
+            reasons: [],
+            updateRequired: false,
+            warning: "older release",
+        });
+        assert.deepEqual(validateStatus(value, "9.12.3"), value);
+    });
+
+    it("allows only the exact package-relative changes reported by the updater", () => {
+        assert.deepEqual(
+            assertPackageChanges(
+                ["types/oidc-provider/lib/helpers/grants.d.ts", "types/oidc-provider/index.d.ts"],
+                ["index.d.ts", "lib/helpers/grants.d.ts"],
+            ),
+            ["types/oidc-provider/index.d.ts", "types/oidc-provider/lib/helpers/grants.d.ts"],
+        );
+        assert.throws(
+            () => assertPackageChanges(["pnpm-lock.yaml"], ["index.d.ts"]),
+            /outside types\/oidc-provider/,
+        );
+        assert.throws(
+            () => assertPackageChanges(["types/oidc-provider/index.d.ts"], ["package.json"]),
+            /do not match/,
+        );
+    });
+
+    it("parses SSH and HTTPS GitHub remotes", () => {
+        assert.deepEqual(githubRepository("git@github.com:panva/DefinitelyTyped.git"), {
+            owner: "panva",
+            repository: "DefinitelyTyped",
+        });
+        assert.deepEqual(githubRepository("ssh://git@github.com/panva/DefinitelyTyped.git"), {
+            owner: "panva",
+            repository: "DefinitelyTyped",
+        });
+        assert.deepEqual(githubRepository("https://github.com/DefinitelyTyped/DefinitelyTyped.git"), {
+            owner: "DefinitelyTyped",
+            repository: "DefinitelyTyped",
+        });
+    });
+
+    for (
+        const remote of [
+            "https://evilgithub.com/DefinitelyTyped/DefinitelyTyped.git",
+            "git@evilgithub.com:DefinitelyTyped/DefinitelyTyped.git",
+            "https://github.com.evil.example/DefinitelyTyped/DefinitelyTyped.git",
+            "https://token@github.com/DefinitelyTyped/DefinitelyTyped.git",
+        ]
+    ) {
+        it(`rejects the lookalike or credential-bearing remote ${remote}`, () => {
+            assert.throws(() => githubRepository(remote), /exact github\.com/);
+        });
+    }
+});
+
+function submissionFixture(responses) {
+    const calls = [];
+    const execute = (command, args, options = {}) => {
+        calls.push({ args, command, options });
+        const response = responses.shift();
+        assert.ok(response, `unexpected command: ${command} ${args.join(" ")}`);
+        if (response.error) throw response.error;
+        return { status: 0, stderr: "", stdout: response.stdout || "" };
+    };
+    const plan = releasePlan("v9.12.3");
+    const invoke = () =>
+        submitPreparedBranch({
+            execute,
+            originOwner: "panva",
+            plan,
+            repositoryDirectory: "/repo",
+            status: status(),
+            worktreeDirectory: "/worktree",
+        });
+    return { calls, invoke, plan };
+}
+
+describe("sync-release submission safety", () => {
+    it("reuses an existing open pull request without pushing or creating another", () => {
+        const fixture = submissionFixture([
+            {
+                stdout:
+                    "[{\"headRefName\":\"oidc-provider-v9.12.3\",\"headRepositoryOwner\":{\"login\":\"panva\"},\"mergedAt\":null,\"number\":123,\"state\":\"OPEN\",\"url\":\"https://github.com/DefinitelyTyped/DefinitelyTyped/pull/123\"}]\n",
+            },
+        ]);
+        assert.deepEqual(fixture.invoke(), {
+            created: false,
+            merged: false,
+            number: 123,
+            state: "OPEN",
+            url: "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/123",
+        });
+        assert.equal(fixture.calls.length, 1);
+        assert.deepEqual(fixture.calls[0].args.slice(0, 2), ["pr", "list"]);
+    });
+
+    it("pushes a new branch without force and creates the deterministic pull request", () => {
+        const fixture = submissionFixture([
+            { stdout: "[]\n" },
+            { stdout: "" },
+            { stdout: "" },
+            { stdout: "[]\n" },
+            { stdout: "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/456\n" },
+        ]);
+        assert.deepEqual(fixture.invoke(), {
+            created: true,
+            url: "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/456",
+        });
+        const push = fixture.calls.find(({ args }) => args.includes("push"));
+        assert.ok(push);
+        assert.deepEqual(push.args, [
+            "-C",
+            "/worktree",
+            "push",
+            "--set-upstream",
+            "origin",
+            fixture.plan.branch,
+        ]);
+        assert.equal(push.args.some((argument) => argument === "-f" || argument.startsWith("--force")), false);
+        const create = fixture.calls.at(-1);
+        assert.deepEqual(create.args.slice(0, 2), ["pr", "create"]);
+        assert.ok(create.args.includes(fixture.plan.commitTitle));
+    });
+
+    it("refuses to overwrite or adopt an orphaned remote branch", () => {
+        const fixture = submissionFixture([
+            { stdout: "[]\n" },
+            { stdout: `${"d".repeat(40)}\trefs/heads/oidc-provider-v9.12.3\n` },
+        ]);
+        assert.throws(fixture.invoke, /orphaned branch/);
+        assert.equal(fixture.calls.some(({ args }) => args.includes("push")), false);
+        assert.equal(fixture.calls.some(({ args }) => args.includes("create")), false);
+    });
+
+    it("treats a merged pull request as a successful no-op", () => {
+        const fixture = submissionFixture([
+            {
+                stdout:
+                    "[{\"headRefName\":\"oidc-provider-v9.12.3\",\"headRepositoryOwner\":{\"login\":\"panva\"},\"mergedAt\":\"2026-08-26T10:00:00Z\",\"number\":789,\"state\":\"MERGED\",\"url\":\"https://github.com/DefinitelyTyped/DefinitelyTyped/pull/789\"}]\n",
+            },
+        ]);
+        assert.deepEqual(fixture.invoke(), {
+            created: false,
+            merged: true,
+            number: 789,
+            state: "MERGED",
+            url: "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/789",
+        });
+        assert.equal(fixture.calls.some(({ args }) => args.includes("push")), false);
+    });
+
+    it("requires recovery for a pull request closed without merging", () => {
+        const fixture = submissionFixture([
+            {
+                stdout:
+                    "[{\"headRefName\":\"oidc-provider-v9.12.3\",\"headRepositoryOwner\":{\"login\":\"panva\"},\"mergedAt\":null,\"number\":987,\"state\":\"CLOSED\",\"url\":\"https://github.com/DefinitelyTyped/DefinitelyTyped/pull/987\"}]\n",
+            },
+        ]);
+        assert.throws(fixture.invoke, /closed without merging/);
+        assert.equal(fixture.calls.length, 1);
+    });
+});
+
+function orchestrationFixture({
+    branchExists = false,
+    downloadLayout = "valid",
+    failApply = false,
+    failStatus = false,
+    keepTemp = false,
+    mutateCommit = false,
+    pullRequest,
+    runId = false,
+} = {}) {
+    const fixtureDirectory = mkdtempSync(join(tmpdir(), "sync-release-test-"));
+    const artifactPath = join(fixtureDirectory, "oidc-provider-types.json");
+    writeFileSync(artifactPath, "{}\n");
+
+    const calls = [];
+    let applied = false;
+    let committed = false;
+    let staged = false;
+    let downloadDirectory;
+    let worktreeDirectory;
+    const updatedStatus = status();
+
+    const result = (stdout = "", statusCode = 0) => ({ status: statusCode, stderr: "", stdout });
+    const execute = (command, args, options = {}) => {
+        calls.push({ args, command, options });
+        if (command === "gh") {
+            if (args[0] === "--version") return result("gh version 2.98.0\n");
+            if (args[0] === "auth") return result();
+            if (args[0] === "api") return result("panva\n");
+            if (args[0] === "pr" && args[1] === "list") {
+                return result(`${JSON.stringify(pullRequest ? [pullRequest] : [])}\n`);
+            }
+            if (args[0] === "run" && args[1] === "download") {
+                downloadDirectory = args[args.indexOf("--dir") + 1];
+                if (downloadLayout !== "missing") {
+                    writeFileSync(join(downloadDirectory, "oidc-provider-types.json"), "{}\n");
+                }
+                if (downloadLayout === "extra") {
+                    writeFileSync(join(downloadDirectory, "unexpected.json"), "{}\n");
+                }
+                return result();
+            }
+        }
+        if (command === "pnpm") {
+            if (args[0] === "--version") return result("10.30.1\n");
+            return result();
+        }
+        if (command === "node") {
+            if (args.includes("--status")) {
+                if (failStatus) throw new Error("injected artifact validation failure");
+                return result(`${JSON.stringify(updatedStatus)}\n`);
+            }
+            if (args[0] === "scripts/update-types.mjs" && args.includes("--artifact") && !args.includes("--check")) {
+                if (failApply) throw new Error("injected updater failure");
+                applied = true;
+            }
+            return result();
+        }
+        if (command !== "git") throw new Error(`unexpected command ${command}`);
+
+        if (args[0] === "--version") return result("git version 2.51.0\n");
+        if (args.includes("rev-parse") && args.includes("--show-toplevel")) {
+            return result(`${repositoryDirectory}\n`);
+        }
+        if (args.includes("rev-parse") && args.includes("HEAD^{tree}")) {
+            return result(`${mutateCommit ? "changed-tree" : "prepared-tree"}\n`);
+        }
+        if (args.includes("config")) {
+            return result(`${args.at(-1) === "user.name" ? "Test User" : "test@example.com"}\n`);
+        }
+        if (args.includes("remote") && args.includes("get-url")) {
+            return result(
+                args.at(-1) === "upstream"
+                    ? "git@github.com:DefinitelyTyped/DefinitelyTyped.git\n"
+                    : "git@github.com:panva/DefinitelyTyped.git\n",
+            );
+        }
+        if (args.includes("fetch") || args.includes("switch")) return result();
+        if (args.includes("ls-remote")) return result();
+        if (args.includes("show-ref")) return result("", branchExists ? 0 : 1);
+        if (args.includes("worktree") && args.includes("add")) {
+            const addIndex = args.indexOf("add");
+            worktreeDirectory = args[addIndex + (args[addIndex + 1] === "--detach" ? 2 : 1)];
+            mkdirSync(join(worktreeDirectory, "types", "oidc-provider"), { recursive: true });
+            return result();
+        }
+        if (args.includes("worktree") && args.includes("remove")) return result();
+        if (args.includes("merge-base")) return result();
+        if (args.includes("rev-list")) return result("1\n");
+        if (args.includes("log")) return result("[oidc-provider] sync declarations for v9.12.3\n");
+        if (args.includes("diff-tree")) return result("types/oidc-provider/index.d.ts\n");
+        if (args.includes("diff") && args.some((argument) => argument.startsWith("upstream/master..."))) {
+            return result("types/oidc-provider/index.d.ts\n");
+        }
+        if (args.includes("diff") && args.includes("--quiet")) return result();
+        if (args.includes("diff") && args.includes("--cached")) {
+            return result(staged && !committed ? "types/oidc-provider/index.d.ts\n" : "");
+        }
+        if (args.includes("write-tree")) return result("prepared-tree\n");
+        if (args.includes("diff")) {
+            return result(applied && !staged && !committed ? "types/oidc-provider/index.d.ts\n" : "");
+        }
+        if (args.includes("ls-files")) return result();
+        if (args.includes("add")) {
+            staged = true;
+            return result();
+        }
+        if (args.includes("commit")) {
+            committed = true;
+            return result();
+        }
+        if (args.includes("restore")) {
+            applied = false;
+            staged = false;
+            return result();
+        }
+        throw new Error(`unexpected git command: ${args.join(" ")}`);
+    };
+
+    const options = parseArguments([
+        "--tag",
+        "v9.12.3",
+        ...(runId ? ["--run-id", "123456789"] : ["--artifact", artifactPath]),
+        ...(keepTemp ? ["--keep-temp"] : []),
+    ]);
+    return {
+        calls,
+        cleanup() {
+            rmSync(fixtureDirectory, { force: true, recursive: true });
+            if (worktreeDirectory) rmSync(dirname(worktreeDirectory), { force: true, recursive: true });
+        },
+        execute,
+        get temporaryDirectory() {
+            return worktreeDirectory
+                ? dirname(worktreeDirectory)
+                : downloadDirectory
+                ? dirname(downloadDirectory)
+                : undefined;
+        },
+        options,
+    };
+}
+
+describe("sync-release worktree lifecycle", () => {
+    it("removes the temporary worktree after preparing a local branch", (t) => {
+        t.mock.method(console, "log", () => {});
+        const fixture = orchestrationFixture();
+        try {
+            assert.deepEqual(synchronize(fixture.options, fixture.execute), {
+                branch: "oidc-provider-v9.12.3",
+                pullRequest: undefined,
+                updated: true,
+            });
+            assert.equal(existsSync(fixture.temporaryDirectory), false);
+            assert.ok(fixture.calls.some(({ args }) => args.includes("commit")));
+            assert.ok(fixture.calls.some(({ args }) => args.includes("remove")));
+            const install = fixture.calls.find(({ args, command }) => command === "pnpm" && args[0] === "install");
+            assert.ok(install.args.includes("--no-frozen-lockfile"));
+            assert.ok(install.args.includes("--ignore-scripts"));
+        } finally {
+            fixture.cleanup();
+        }
+    });
+
+    it("preserves the temporary worktree after success with --keep-temp", (t) => {
+        t.mock.method(console, "log", () => {});
+        t.mock.method(console, "error", () => {});
+        const fixture = orchestrationFixture({ keepTemp: true });
+        try {
+            synchronize(fixture.options, fixture.execute);
+            assert.equal(existsSync(fixture.temporaryDirectory), true);
+            assert.equal(fixture.calls.some(({ args }) => args.includes("remove")), false);
+        } finally {
+            fixture.cleanup();
+        }
+    });
+
+    it("preserves the temporary worktree after a failure", (t) => {
+        t.mock.method(console, "error", () => {});
+        const fixture = orchestrationFixture({ failApply: true });
+        try {
+            assert.throws(
+                () => synchronize(fixture.options, fixture.execute),
+                /injected updater failure/,
+            );
+            assert.equal(existsSync(fixture.temporaryDirectory), true);
+            assert.equal(fixture.calls.some(({ args }) => args.includes("remove")), false);
+        } finally {
+            fixture.cleanup();
+        }
+    });
+
+    it("validates the artifact before reusing an existing pull request", (t) => {
+        t.mock.method(console, "error", () => {});
+        const fixture = orchestrationFixture({
+            failStatus: true,
+            pullRequest: {
+                headRefName: "oidc-provider-v9.12.3",
+                headRepositoryOwner: { login: "panva" },
+                mergedAt: null,
+                number: 123,
+                state: "OPEN",
+                url: "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/123",
+            },
+        });
+        try {
+            assert.throws(
+                () => synchronize(fixture.options, fixture.execute),
+                /injected artifact validation failure/,
+            );
+            assert.equal(
+                fixture.calls.some(({ args, command }) => command === "gh" && args[0] === "pr" && args[1] === "list"),
+                false,
+            );
+        } finally {
+            fixture.cleanup();
+        }
+    });
+
+    it("revalidates the committed files after commit hooks run", (t) => {
+        t.mock.method(console, "error", () => {});
+        const fixture = orchestrationFixture({ mutateCommit: true });
+        try {
+            assert.throws(
+                () => synchronize(fixture.options, fixture.execute),
+                /commit hooks changed the prepared declaration update/,
+            );
+            const exactChecks = fixture.calls.filter(({ args, command }) =>
+                command === "node" && args.includes("--check")
+            );
+            assert.equal(exactChecks.length, 1);
+            assert.equal(fixture.calls.some(({ args }) => args.includes("push")), false);
+        } finally {
+            fixture.cleanup();
+        }
+    });
+
+    it("reuses an existing matching prepared local branch", (t) => {
+        t.mock.method(console, "log", () => {});
+        const fixture = orchestrationFixture({ branchExists: true });
+        try {
+            const result = synchronize(fixture.options, fixture.execute);
+            assert.equal(result.branch, "oidc-provider-v9.12.3");
+            assert.equal(fixture.calls.some(({ args }) => args.includes("switch")), false);
+            assert.equal(fixture.calls.some(({ args }) => args.includes("commit")), false);
+            assert.ok(
+                fixture.calls.some(({ args }) =>
+                    args.some((argument) => argument === "upstream/master...oidc-provider-v9.12.3")
+                ),
+            );
+            assert.equal(existsSync(fixture.temporaryDirectory), false);
+        } finally {
+            fixture.cleanup();
+        }
+    });
+
+    it("downloads the exact release artifact and consumes its sole JSON file", (t) => {
+        t.mock.method(console, "log", () => {});
+        const fixture = orchestrationFixture({ runId: true });
+        try {
+            synchronize(fixture.options, fixture.execute);
+            const download = fixture.calls.find(({ args, command }) => command === "gh" && args[0] === "run");
+            assert.deepEqual(download.args, [
+                "run",
+                "download",
+                "123456789",
+                "--repo",
+                "panva/node-oidc-provider",
+                "--name",
+                "oidc-provider-types-v9.12.3",
+                "--dir",
+                download.args.at(-1),
+            ]);
+            assert.equal(existsSync(fixture.temporaryDirectory), false);
+        } finally {
+            fixture.cleanup();
+        }
+    });
+
+    for (const downloadLayout of ["missing", "extra"]) {
+        it(`rejects a downloaded artifact with a ${downloadLayout} top-level entry`, (t) => {
+            t.mock.method(console, "error", () => {});
+            const fixture = orchestrationFixture({ downloadLayout, runId: true });
+            try {
+                assert.throws(
+                    () => synchronize(fixture.options, fixture.execute),
+                    /exactly one top-level file named oidc-provider-types\.json/,
+                );
+                assert.equal(existsSync(fixture.temporaryDirectory), true);
+                assert.equal(fixture.calls.some(({ args }) => args.includes("fetch")), false);
+            } finally {
+                fixture.cleanup();
+            }
+        });
+    }
+});

--- a/types/oidc-provider/scripts/update-types.mjs
+++ b/types/oidc-provider/scripts/update-types.mjs
@@ -1,0 +1,408 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { generatedRegionState, migrateLegacyIndex, migrateLegacyTests } from "./legacy-bootstrap.mjs";
+
+const SCHEMA_VERSION = 1;
+const STATUS_SCHEMA_VERSION = 1;
+const GRANTS_PATH = "lib/helpers/grants.d.ts";
+const TESTS_PATH = "oidc-provider-tests.ts";
+const FRAGMENT_NAMES = ["contracts", "providerMembers", "relatedContracts"];
+const REGIONS = {
+    contracts: {
+        start: "// BEGIN GENERATED OIDC-PROVIDER CONTRACTS",
+        end: "// END GENERATED OIDC-PROVIDER CONTRACTS",
+    },
+    providerMembers: {
+        start: "    // BEGIN GENERATED OIDC-PROVIDER MEMBERS",
+        end: "    // END GENERATED OIDC-PROVIDER MEMBERS",
+    },
+    relatedContracts: {
+        start: "// BEGIN GENERATED OIDC-PROVIDER RELATED CONTRACTS",
+        end: "// END GENERATED OIDC-PROVIDER RELATED CONTRACTS",
+    },
+};
+const PROVENANCE_PATTERN = /^\/\/ oidc-provider types artifact .*; schema \d+; sha256 [a-f0-9]{64}\n?/m;
+
+function fail(message) {
+    console.error(`update-types: ${message}`);
+    process.exit(1);
+}
+
+function usage() {
+    return "usage: node scripts/update-types.mjs [--check | --status] (--artifact <path> | <provider-checkout>)";
+}
+
+function parseArguments(argv) {
+    let mode = "update";
+    let artifactPath;
+    const positional = [];
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const argument = argv[index];
+        if (argument === "--check" || argument === "--status") {
+            if (mode !== "update") fail("--check and --status cannot be combined");
+            mode = argument.slice(2);
+        } else if (argument === "--artifact") {
+            if (artifactPath !== undefined) fail("--artifact may only be specified once");
+            artifactPath = argv[index + 1];
+            if (!artifactPath || artifactPath.startsWith("-")) fail("--artifact requires a path");
+            index += 1;
+        } else if (argument.startsWith("-")) {
+            fail(`unknown option ${JSON.stringify(argument)}`);
+        } else {
+            positional.push(argument);
+        }
+    }
+
+    if ((artifactPath === undefined && positional.length !== 1) || (artifactPath !== undefined && positional.length)) {
+        fail(usage());
+    }
+
+    return {
+        artifactPath: artifactPath === undefined ? undefined : resolve(artifactPath),
+        mode,
+        providerDirectory: artifactPath === undefined ? resolve(positional[0]) : undefined,
+    };
+}
+
+function readJson(path, label) {
+    try {
+        return JSON.parse(readFileSync(path, "utf8"));
+    } catch (error) {
+        fail(`could not read ${label} at ${path}: ${error.message}`);
+    }
+}
+
+function readIfPresent(path) {
+    return existsSync(path) ? readFileSync(path, "utf8") : "";
+}
+
+function versionLine(version, label) {
+    if (typeof version !== "string") {
+        fail(`${label} has an invalid version: ${JSON.stringify(version)}`);
+    }
+    const match = /^(\d+)\.(\d+)(?:\.|$)/.exec(version);
+    if (!match) {
+        fail(`${label} has an invalid version: ${JSON.stringify(version)}`);
+    }
+    return { major: Number(match[1]), minor: Number(match[2]) };
+}
+
+function compareVersionLines(left, right) {
+    return left.major - right.major || left.minor - right.minor;
+}
+
+function targetTypesVersion(providerLine) {
+    return `${providerLine.major}.${providerLine.minor}.9999`;
+}
+
+function exactKeys(value, expected, label) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+        fail(`${label} must be an object`);
+    }
+
+    const actual = Object.keys(value).sort();
+    const sortedExpected = [...expected].sort();
+    if (actual.length !== sortedExpected.length || actual.some((key, index) => key !== sortedExpected[index])) {
+        fail(`${label} must have exactly these keys: ${sortedExpected.join(", ")}`);
+    }
+}
+
+function declarationText(value, label) {
+    if (typeof value !== "string" || !value.trim()) {
+        fail(`${label} must be a non-empty string`);
+    }
+    if (value.includes("\r")) {
+        fail(`${label} must use LF line endings`);
+    }
+    return value;
+}
+
+function canonicalContent(indexFragments, files) {
+    return JSON.stringify({
+        indexFragments: {
+            contracts: indexFragments.contracts,
+            providerMembers: indexFragments.providerMembers,
+            relatedContracts: indexFragments.relatedContracts,
+        },
+        files: {
+            [GRANTS_PATH]: files[GRANTS_PATH],
+        },
+    });
+}
+
+function validateArtifact(payload, expectedProviderVersion) {
+    exactKeys(
+        payload,
+        ["schemaVersion", "providerVersion", "hash", "indexFragments", "files"],
+        "provider types artifact",
+    );
+    if (payload.schemaVersion !== SCHEMA_VERSION) {
+        fail(`unsupported provider types schema version ${JSON.stringify(payload.schemaVersion)}`);
+    }
+    versionLine(payload.providerVersion, "provider types artifact");
+    if (expectedProviderVersion !== undefined && payload.providerVersion !== expectedProviderVersion) {
+        fail(
+            `provider types artifact is for ${
+                JSON.stringify(payload.providerVersion)
+            }, expected ${expectedProviderVersion}`,
+        );
+    }
+    if (typeof payload.hash !== "string" || !/^[a-f0-9]{64}$/.test(payload.hash)) {
+        fail("provider types artifact hash must be a lowercase hexadecimal SHA-256 digest");
+    }
+
+    exactKeys(payload.indexFragments, FRAGMENT_NAMES, "provider types indexFragments");
+    exactKeys(payload.files, [GRANTS_PATH], "provider types files");
+    for (const name of FRAGMENT_NAMES) {
+        declarationText(payload.indexFragments[name], `provider types indexFragments.${name}`);
+    }
+    declarationText(payload.files[GRANTS_PATH], `provider types files.${GRANTS_PATH}`);
+
+    const actualHash = createHash("sha256")
+        .update(canonicalContent(payload.indexFragments, payload.files))
+        .digest("hex");
+    if (actualHash !== payload.hash) {
+        fail(`provider types artifact hash mismatch: expected ${payload.hash}, calculated ${actualHash}`);
+    }
+
+    return payload;
+}
+
+function artifactMetadata(payload) {
+    return `// oidc-provider types artifact ${
+        JSON.stringify(payload.providerVersion)
+    }; schema ${payload.schemaVersion}; sha256 ${payload.hash}`;
+}
+
+function replaceRegion(source, fragment, { start, end }, label) {
+    const startIndex = source.indexOf(start);
+    const endIndex = source.indexOf(end);
+    if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) {
+        fail(`index.d.ts does not contain the generated ${label} region`);
+    }
+    if (
+        source.indexOf(start, startIndex + start.length) !== -1
+        || source.indexOf(end, endIndex + end.length) !== -1
+    ) {
+        fail(`index.d.ts must contain exactly one generated ${label} region`);
+    }
+    if (fragment.includes(start) || fragment.includes(end)) {
+        fail(`provider ${label} fragment contains a generated-region marker`);
+    }
+
+    const normalized = fragment.replace(/^\n+|\n+$/g, "");
+    return `${source.slice(0, startIndex + start.length)}\n${normalized}\n${source.slice(endIndex)}`;
+}
+
+function formatDeclaration(source, packageDirectory, declarationPath) {
+    const repositoryDirectory = resolve(packageDirectory, "..", "..");
+    const executable = resolve(repositoryDirectory, "node_modules", "dprint", "bin.js");
+    const result = spawnSync(process.execPath, [executable, "fmt", "--stdin", declarationPath], {
+        cwd: repositoryDirectory,
+        encoding: "utf8",
+        input: source,
+        maxBuffer: 16 * 1024 * 1024,
+    });
+    if (result.error) {
+        fail(
+            `could not run DefinitelyTyped's dprint executable at ${executable}: ${result.error.message}. Install the repository dependencies first`,
+        );
+    }
+    if (result.status !== 0) {
+        if (result.stderr) process.stderr.write(result.stderr);
+        fail(`dprint exited with status ${result.status}`);
+    }
+    return result.stdout;
+}
+
+function generateArtifact(providerDirectory) {
+    const result = spawnSync(process.execPath, ["docs/update-configuration.js", "--types-json"], {
+        cwd: providerDirectory,
+        encoding: "utf8",
+        maxBuffer: 16 * 1024 * 1024,
+    });
+    if (result.error) {
+        fail(`could not run the provider types generator: ${result.error.message}`);
+    }
+    if (result.status !== 0) {
+        if (result.stderr) process.stderr.write(result.stderr);
+        fail(`provider types generator exited with status ${result.status}`);
+    }
+
+    try {
+        return JSON.parse(result.stdout);
+    } catch (error) {
+        fail(`provider types generator returned invalid JSON: ${error.message}`);
+    }
+}
+
+function renderedHash(outputs) {
+    return createHash("sha256").update(JSON.stringify({
+        "index.d.ts": outputs.get("index.d.ts"),
+        [GRANTS_PATH]: outputs.get(GRANTS_PATH),
+    })).digest("hex");
+}
+
+function renderedOutputs(index, grants, packageDirectory, indexPath, grantsPath) {
+    return new Map([
+        ["index.d.ts", formatDeclaration(index.replace(PROVENANCE_PATTERN, ""), packageDirectory, indexPath)],
+        [GRANTS_PATH, formatDeclaration(grants, packageDirectory, grantsPath)],
+    ]);
+}
+
+const { artifactPath, mode, providerDirectory } = parseArguments(process.argv.slice(2));
+const packageDirectory = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const indexPath = resolve(packageDirectory, "index.d.ts");
+const grantsPath = resolve(packageDirectory, GRANTS_PATH);
+const grantsFormatPath = existsSync(grantsPath) ? grantsPath : indexPath;
+const testsPath = resolve(packageDirectory, TESTS_PATH);
+const packagePath = resolve(packageDirectory, "package.json");
+const typesPackage = readJson(packagePath, "@types package.json");
+
+if (typesPackage.name !== "@types/oidc-provider") {
+    fail(`expected @types/oidc-provider, found ${JSON.stringify(typesPackage.name)}`);
+}
+
+let artifactPayload;
+let expectedProviderVersion;
+if (artifactPath === undefined) {
+    const providerPackage = readJson(resolve(providerDirectory, "package.json"), "provider package.json");
+    if (providerPackage.name !== "oidc-provider") {
+        fail(`expected oidc-provider, found ${JSON.stringify(providerPackage.name)}`);
+    }
+    expectedProviderVersion = providerPackage.version;
+    artifactPayload = generateArtifact(providerDirectory);
+} else {
+    artifactPayload = readJson(artifactPath, "provider types artifact");
+}
+const artifact = validateArtifact(artifactPayload, expectedProviderVersion);
+
+const typesLine = versionLine(typesPackage.version, "@types/oidc-provider");
+const providerLine = versionLine(artifact.providerVersion, "oidc-provider");
+const lineComparison = compareVersionLines(providerLine, typesLine);
+if (mode === "check" && lineComparison !== 0) {
+    fail(
+        `version mismatch: @types/oidc-provider is ${typesLine.major}.${typesLine.minor}.x but oidc-provider is ${providerLine.major}.${providerLine.minor}.x`,
+    );
+}
+
+const currentIndex = readFileSync(indexPath, "utf8");
+const currentGrants = readIfPresent(grantsPath);
+let indexState;
+try {
+    indexState = generatedRegionState(currentIndex);
+} catch (error) {
+    fail(error.message);
+}
+if (indexState === "legacy" && existsSync(grantsPath)) {
+    fail("markerless oidc-provider declarations cannot be bootstrapped with an existing grant-helper declaration");
+}
+
+let generatedIndex = currentIndex;
+let generatedTests;
+if (indexState === "legacy") {
+    try {
+        generatedIndex = migrateLegacyIndex(currentIndex);
+        generatedTests = migrateLegacyTests(
+            readFileSync(testsPath, "utf8"),
+            readFileSync(new URL("./legacy-tests.patch", import.meta.url), "utf8"),
+        );
+    } catch (error) {
+        fail(error.message);
+    }
+}
+for (const name of FRAGMENT_NAMES) {
+    const fragment = name === "contracts"
+        ? `${artifactMetadata(artifact)}\n${artifact.indexFragments[name]}`
+        : artifact.indexFragments[name];
+    generatedIndex = replaceRegion(generatedIndex, fragment, REGIONS[name], name);
+}
+const generatedGrants = artifact.files[GRANTS_PATH];
+const exactOutputs = new Map([
+    [indexPath, formatDeclaration(generatedIndex, packageDirectory, indexPath)],
+    [grantsPath, generatedGrants],
+]);
+if (generatedTests !== undefined) exactOutputs.set(testsPath, generatedTests);
+
+const currentRendered = renderedOutputs(currentIndex, currentGrants, packageDirectory, indexPath, grantsFormatPath);
+const candidateRendered = renderedOutputs(
+    generatedIndex,
+    generatedGrants,
+    packageDirectory,
+    indexPath,
+    grantsFormatPath,
+);
+const declarationChanges = [...candidateRendered]
+    .filter(([path, contents]) => currentRendered.get(path) !== contents)
+    .map(([path]) => path);
+const reasons = [];
+if (declarationChanges.length) reasons.push("declarations");
+if (providerLine.major > typesLine.major) reasons.push("major-version");
+
+const olderTrackedLine = lineComparison < 0;
+const updateRequired = !olderTrackedLine && reasons.length > 0;
+const warning = olderTrackedLine
+    ? `oidc-provider ${artifact.providerVersion} is older than the tracked @types/oidc-provider ${typesLine.major}.${typesLine.minor}.x line; skipping`
+    : undefined;
+
+if (updateRequired) {
+    const candidateVersion = targetTypesVersion(providerLine);
+    if (typesPackage.version !== candidateVersion) {
+        exactOutputs.set(packagePath, `${JSON.stringify({ ...typesPackage, version: candidateVersion }, null, 4)}\n`);
+    }
+}
+const changedFiles = updateRequired
+    ? [...exactOutputs]
+        .filter(([path, contents]) => readIfPresent(path) !== contents)
+        .map(([path]) => path.slice(packageDirectory.length + 1))
+    : [];
+
+if (mode === "status") {
+    const status = {
+        schemaVersion: STATUS_SCHEMA_VERSION,
+        updateRequired,
+        reasons: updateRequired ? reasons : [],
+        providerVersion: artifact.providerVersion,
+        typesVersion: typesPackage.version,
+        currentHash: renderedHash(currentRendered),
+        candidateHash: renderedHash(candidateRendered),
+        changedFiles,
+    };
+    if (warning !== undefined) status.warning = warning;
+    process.stdout.write(`${JSON.stringify(status)}\n`);
+} else if (olderTrackedLine) {
+    console.warn(`update-types: ${warning}`);
+} else {
+    if (mode === "update" && !updateRequired) {
+        console.log("No declaration update is required for this oidc-provider release.");
+        process.exit(0);
+    }
+
+    const changed = [...exactOutputs].filter(([path, contents]) => readIfPresent(path) !== contents);
+    if (!changed.length) {
+        console.log("oidc-provider declaration mirrors are up to date.");
+    } else if (mode === "check") {
+        fail(
+            `declaration mirrors are not up to date: ${
+                changed.map(([path]) => path.slice(packageDirectory.length + 1)).join(", ")
+            }`,
+        );
+    } else {
+        for (const [path, contents] of changed) {
+            mkdirSync(dirname(path), { recursive: true });
+            writeFileSync(path, contents);
+        }
+        console.log(
+            `Updated oidc-provider declaration mirrors: ${
+                changed.map(([path]) => path.slice(packageDirectory.length + 1)).join(", ")
+            }.`,
+        );
+    }
+}

--- a/types/oidc-provider/scripts/update-types.test.mjs
+++ b/types/oidc-provider/scripts/update-types.test.mjs
@@ -1,0 +1,497 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+    copyFileSync,
+    existsSync,
+    mkdirSync,
+    mkdtempSync,
+    readFileSync,
+    rmSync,
+    symlinkSync,
+    writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const arguments_ = process.argv.slice(2);
+let providerDirectory;
+let baselineArtifact;
+if (arguments_.length === 1 && arguments_[0] !== "--artifact") {
+    providerDirectory = resolve(arguments_[0]);
+} else if (arguments_.length === 2 && arguments_[0] === "--artifact") {
+    baselineArtifact = JSON.parse(readFileSync(resolve(arguments_[1]), "utf8"));
+} else {
+    throw new TypeError(
+        "usage: node scripts/update-types.test.mjs (<provider-checkout> | --artifact <types-json-path>)",
+    );
+}
+
+const packageDirectory = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const repositoryDirectory = resolve(packageDirectory, "..", "..");
+
+function run(command, args, cwd) {
+    return spawnSync(command, args, {
+        cwd,
+        encoding: "utf8",
+        maxBuffer: 16 * 1024 * 1024,
+    });
+}
+
+if (providerDirectory !== undefined) {
+    const generated = run(
+        process.execPath,
+        ["docs/update-configuration.js", "--types-json"],
+        providerDirectory,
+    );
+    assert.equal(generated.status, 0, generated.stderr);
+    baselineArtifact = JSON.parse(generated.stdout);
+}
+
+function canonicalContent(artifact) {
+    return JSON.stringify({
+        indexFragments: {
+            contracts: artifact.indexFragments.contracts,
+            providerMembers: artifact.indexFragments.providerMembers,
+            relatedContracts: artifact.indexFragments.relatedContracts,
+        },
+        files: {
+            "lib/helpers/grants.d.ts": artifact.files["lib/helpers/grants.d.ts"],
+        },
+    });
+}
+
+function updateHash(artifact) {
+    artifact.hash = createHash("sha256").update(canonicalContent(artifact)).digest("hex");
+    return artifact;
+}
+
+function parseVersion(version) {
+    const match = /^(\d+)\.(\d+)\.(\d+)/.exec(version);
+    assert.ok(match, `expected a stable provider version, received ${version}`);
+    return { major: Number(match[1]), minor: Number(match[2]), patch: Number(match[3]) };
+}
+
+function version(major, minor, patch = 0) {
+    return `${major}.${minor}.${patch}`;
+}
+
+const baselineVersion = parseVersion(baselineArtifact.providerVersion);
+const patchVersion = version(baselineVersion.major, baselineVersion.minor, baselineVersion.patch + 1);
+const minorVersion = version(baselineVersion.major, baselineVersion.minor + 1);
+const majorVersion = version(baselineVersion.major + 1, 0);
+const olderVersion = baselineVersion.minor > 0
+    ? version(baselineVersion.major, baselineVersion.minor - 1, 999)
+    : version(baselineVersion.major - 1, 999, 999);
+
+const temporaryDirectory = mkdtempSync(join(tmpdir(), "oidc-provider-types-"));
+
+try {
+    const temporaryRepository = join(temporaryDirectory, "DefinitelyTyped");
+    const temporaryPackage = join(temporaryRepository, "types", "oidc-provider");
+    const temporaryScripts = join(temporaryPackage, "scripts");
+    const temporaryGrants = join(temporaryPackage, "lib", "helpers");
+    const fakeProvider = join(temporaryDirectory, "provider");
+    const fakeProviderDocs = join(fakeProvider, "docs");
+    const artifactPath = join(temporaryDirectory, "types.json");
+    const indexPath = join(temporaryPackage, "index.d.ts");
+    const packagePath = join(temporaryPackage, "package.json");
+    const grantsPath = join(temporaryGrants, "grants.d.ts");
+    const testsPath = join(temporaryPackage, "oidc-provider-tests.ts");
+
+    mkdirSync(temporaryScripts, { recursive: true });
+    mkdirSync(fakeProviderDocs, { recursive: true });
+    mkdirSync(join(temporaryRepository, "node_modules"), { recursive: true });
+
+    for (const path of ["index.d.ts", "oidc-provider-tests.ts", "package.json"]) {
+        copyFileSync(join(packageDirectory, path), join(temporaryPackage, path));
+    }
+    copyFileSync(join(repositoryDirectory, ".dprint.jsonc"), join(temporaryRepository, ".dprint.jsonc"));
+    const sourceGrants = join(packageDirectory, "lib", "helpers", "grants.d.ts");
+    if (existsSync(sourceGrants)) {
+        mkdirSync(temporaryGrants, { recursive: true });
+        copyFileSync(sourceGrants, grantsPath);
+    }
+    for (const path of ["legacy-bootstrap.mjs", "legacy-tests.patch", "update-types.mjs"]) {
+        copyFileSync(join(packageDirectory, "scripts", path), join(temporaryScripts, path));
+    }
+    symlinkSync(
+        join(repositoryDirectory, "node_modules", "dprint"),
+        join(temporaryRepository, "node_modules", "dprint"),
+        "dir",
+    );
+
+    let baselineFiles;
+    function captureBaseline() {
+        baselineFiles = new Map([
+            [indexPath, readFileSync(indexPath, "utf8")],
+            [packagePath, readFileSync(packagePath, "utf8")],
+            [testsPath, readFileSync(testsPath, "utf8")],
+            [grantsPath, existsSync(grantsPath) ? readFileSync(grantsPath, "utf8") : undefined],
+        ]);
+    }
+    function restorePackage() {
+        for (const [path, contents] of baselineFiles) {
+            if (contents === undefined) {
+                rmSync(path, { force: true });
+            } else {
+                mkdirSync(dirname(path), { recursive: true });
+                writeFileSync(path, contents);
+            }
+        }
+    }
+
+    function writeProvider(artifact, providerVersion = artifact.providerVersion) {
+        writeFileSync(
+            join(fakeProvider, "package.json"),
+            `${JSON.stringify({ name: "oidc-provider", version: providerVersion })}\n`,
+        );
+        writeFileSync(
+            join(fakeProviderDocs, "update-configuration.js"),
+            `process.stdout.write(${JSON.stringify(`${JSON.stringify(artifact)}\n`)});\n`,
+        );
+    }
+
+    function writeArtifact(artifact) {
+        writeFileSync(artifactPath, `${JSON.stringify(artifact)}\n`);
+    }
+
+    function updater(args) {
+        return run(process.execPath, ["scripts/update-types.mjs", ...args], temporaryPackage);
+    }
+
+    function check(args = [fakeProvider]) {
+        return updater(["--check", ...args]);
+    }
+
+    function status(artifact) {
+        writeArtifact(artifact);
+        const result = updater(["--status", "--artifact", artifactPath]);
+        assert.equal(result.status, 0, result.stderr);
+        assert.equal(result.stderr, "", "status diagnostics must not pollute stderr on success");
+        assert.doesNotThrow(() => JSON.parse(result.stdout), "status stdout must be JSON only");
+        return JSON.parse(result.stdout);
+    }
+
+    function expectFailure(label, args, pattern) {
+        const result = updater(args);
+        assert.notEqual(result.status, 0, `${label} unexpectedly passed`);
+        assert.match(`${result.stdout}\n${result.stderr}`, pattern, label);
+    }
+
+    function withProviderVersion(artifact, providerVersion) {
+        const result = structuredClone(artifact);
+        result.providerVersion = providerVersion;
+        return result;
+    }
+
+    function contractsChange(artifact, text = "export interface StatusOnlyContract { value: string; }") {
+        const result = structuredClone(artifact);
+        result.indexFragments.contracts += `\n${text}\n`;
+        return updateHash(result);
+    }
+
+    writeProvider(baselineArtifact);
+    writeArtifact(baselineArtifact);
+    const sourceIsLegacy = !readFileSync(indexPath, "utf8").includes("// BEGIN GENERATED OIDC-PROVIDER CONTRACTS");
+    if (sourceIsLegacy) {
+        const legacyIndex = readFileSync(indexPath, "utf8");
+        const legacyTests = readFileSync(testsPath, "utf8");
+        const legacyPackage = readFileSync(packagePath, "utf8");
+        assert.equal(existsSync(grantsPath), false);
+
+        const legacyStatus = status(baselineArtifact);
+        assert.equal(legacyStatus.updateRequired, true);
+        assert.deepEqual(legacyStatus.reasons, ["declarations"]);
+        assert.deepEqual(legacyStatus.changedFiles, [
+            "index.d.ts",
+            "lib/helpers/grants.d.ts",
+            "oidc-provider-tests.ts",
+        ]);
+        assert.notEqual(legacyStatus.currentHash, legacyStatus.candidateHash);
+        assert.equal(readFileSync(indexPath, "utf8"), legacyIndex);
+        assert.equal(readFileSync(testsPath, "utf8"), legacyTests);
+        assert.equal(readFileSync(packagePath, "utf8"), legacyPackage);
+        assert.equal(existsSync(grantsPath), false);
+
+        expectFailure(
+            "legacy exact check",
+            ["--check", "--artifact", artifactPath],
+            /declaration mirrors are not up to date/,
+        );
+        assert.equal(readFileSync(indexPath, "utf8"), legacyIndex);
+        assert.equal(readFileSync(testsPath, "utf8"), legacyTests);
+        assert.equal(readFileSync(packagePath, "utf8"), legacyPackage);
+        assert.equal(existsSync(grantsPath), false);
+
+        const migrate = updater(["--artifact", artifactPath]);
+        assert.equal(migrate.status, 0, migrate.stderr);
+        assert.match(migrate.stdout, /index\.d\.ts, lib\/helpers\/grants\.d\.ts, oidc-provider-tests\.ts/);
+        const migratedIndex = readFileSync(indexPath, "utf8");
+        for (
+            const marker of [
+                "// BEGIN GENERATED OIDC-PROVIDER CONTRACTS",
+                "// END GENERATED OIDC-PROVIDER CONTRACTS",
+                "    // BEGIN GENERATED OIDC-PROVIDER MEMBERS",
+                "    // END GENERATED OIDC-PROVIDER MEMBERS",
+                "// BEGIN GENERATED OIDC-PROVIDER RELATED CONTRACTS",
+                "// END GENERATED OIDC-PROVIDER RELATED CONTRACTS",
+            ]
+        ) {
+            assert.equal(migratedIndex.split(marker).length - 1, 1, marker);
+        }
+        assert.equal(readFileSync(grantsPath, "utf8"), baselineArtifact.files["lib/helpers/grants.d.ts"]);
+        assert.notEqual(readFileSync(testsPath, "utf8"), legacyTests);
+        assert.equal(readFileSync(packagePath, "utf8"), legacyPackage);
+        const migratedCheck = check(["--artifact", artifactPath]);
+        assert.equal(migratedCheck.status, 0, migratedCheck.stderr);
+        const migratedStatus = status(baselineArtifact);
+        assert.equal(migratedStatus.updateRequired, false);
+        assert.equal(migratedStatus.currentHash, migratedStatus.candidateHash);
+        assert.deepEqual(migratedStatus.changedFiles, []);
+    }
+    captureBaseline();
+
+    const baselineCheckoutCheck = check();
+    assert.equal(
+        baselineCheckoutCheck.status,
+        0,
+        `the baseline checkout must pass --check\n${baselineCheckoutCheck.stdout}\n${baselineCheckoutCheck.stderr}`,
+    );
+    const baselineArtifactCheck = check(["--artifact", artifactPath]);
+    assert.equal(baselineArtifactCheck.status, 0, baselineArtifactCheck.stderr);
+    const baselineStatus = status(baselineArtifact);
+    const baselineCheckoutStatus = updater(["--status", fakeProvider]);
+    assert.equal(baselineCheckoutStatus.status, 0, baselineCheckoutStatus.stderr);
+    assert.deepEqual(JSON.parse(baselineCheckoutStatus.stdout), baselineStatus);
+    assert.deepEqual(baselineStatus, {
+        schemaVersion: 1,
+        updateRequired: false,
+        reasons: [],
+        providerVersion: baselineArtifact.providerVersion,
+        typesVersion: JSON.parse(readFileSync(packagePath, "utf8")).version,
+        currentHash: baselineStatus.currentHash,
+        candidateHash: baselineStatus.currentHash,
+        changedFiles: [],
+    });
+
+    rmSync(grantsPath, { force: true });
+    const missingGrantStatus = status(baselineArtifact);
+    assert.equal(missingGrantStatus.updateRequired, true);
+    assert.deepEqual(missingGrantStatus.reasons, ["declarations"]);
+    assert.deepEqual(missingGrantStatus.changedFiles, ["lib/helpers/grants.d.ts"]);
+    const restoreGrant = updater(["--artifact", artifactPath]);
+    assert.equal(restoreGrant.status, 0, restoreGrant.stderr);
+    assert.equal(readFileSync(grantsPath, "utf8"), baselineArtifact.files["lib/helpers/grants.d.ts"]);
+    const restoredGrantCheck = check(["--artifact", artifactPath]);
+    assert.equal(restoredGrantCheck.status, 0, restoredGrantCheck.stderr);
+    restorePackage();
+
+    const schemaMismatch = structuredClone(baselineArtifact);
+    schemaMismatch.schemaVersion += 1;
+    writeArtifact(schemaMismatch);
+    expectFailure(
+        "schema mismatch",
+        ["--status", "--artifact", artifactPath],
+        /unsupported provider types schema version/,
+    );
+
+    const versionMismatch = withProviderVersion(baselineArtifact, patchVersion);
+    writeProvider(versionMismatch, baselineArtifact.providerVersion);
+    expectFailure("artifact/package version mismatch", ["--check", fakeProvider], /provider types artifact is for/);
+
+    const hashMismatch = structuredClone(baselineArtifact);
+    hashMismatch.hash = `${hashMismatch.hash.slice(0, -1)}${hashMismatch.hash.endsWith("0") ? "1" : "0"}`;
+    writeArtifact(hashMismatch);
+    expectFailure(
+        "content hash mismatch",
+        ["--status", "--artifact", artifactPath],
+        /provider types artifact hash mismatch/,
+    );
+
+    const missingFragment = structuredClone(baselineArtifact);
+    delete missingFragment.indexFragments.providerMembers;
+    writeArtifact(missingFragment);
+    expectFailure(
+        "missing fragment",
+        ["--status", "--artifact", artifactPath],
+        /indexFragments must have exactly these keys/,
+    );
+
+    writeFileSync(artifactPath, "not json\n");
+    expectFailure(
+        "malformed artifact",
+        ["--status", "--artifact", artifactPath],
+        /could not read provider types artifact/,
+    );
+
+    const patchDrift = withProviderVersion(baselineArtifact, patchVersion);
+    const patchStatus = status(patchDrift);
+    assert.equal(patchStatus.updateRequired, false);
+    assert.deepEqual(patchStatus.reasons, []);
+    assert.equal(patchStatus.currentHash, patchStatus.candidateHash);
+    assert.deepEqual(patchStatus.changedFiles, []);
+    writeArtifact(patchDrift);
+    expectFailure(
+        "provider patch provenance drift",
+        ["--check", "--artifact", artifactPath],
+        /declaration mirrors are not up to date/,
+    );
+    const originalIndex = readFileSync(indexPath, "utf8");
+    const patchOnlyUpdate = updater(["--artifact", artifactPath]);
+    assert.equal(patchOnlyUpdate.status, 0, patchOnlyUpdate.stderr);
+    assert.match(patchOnlyUpdate.stdout, /No declaration update is required/);
+    assert.equal(readFileSync(indexPath, "utf8"), originalIndex);
+
+    const minorStatus = status(withProviderVersion(baselineArtifact, minorVersion));
+    assert.equal(minorStatus.updateRequired, false);
+    assert.deepEqual(minorStatus.reasons, []);
+    assert.equal(minorStatus.currentHash, minorStatus.candidateHash);
+
+    const majorStatus = status(withProviderVersion(baselineArtifact, majorVersion));
+    assert.equal(majorStatus.updateRequired, true);
+    assert.deepEqual(majorStatus.reasons, ["major-version"]);
+    assert.equal(majorStatus.currentHash, majorStatus.candidateHash);
+    assert.deepEqual(majorStatus.changedFiles, ["index.d.ts", "package.json"]);
+
+    const olderArtifact = withProviderVersion(contractsChange(baselineArtifact), olderVersion);
+    const olderStatus = status(olderArtifact);
+    assert.equal(olderStatus.updateRequired, false);
+    assert.deepEqual(olderStatus.reasons, []);
+    assert.deepEqual(olderStatus.changedFiles, []);
+    assert.match(olderStatus.warning, /older than the tracked/);
+
+    const changedContracts = contractsChange(baselineArtifact);
+    const declarationStatus = status(changedContracts);
+    assert.equal(declarationStatus.updateRequired, true);
+    assert.deepEqual(declarationStatus.reasons, ["declarations"]);
+    assert.notEqual(declarationStatus.currentHash, declarationStatus.candidateHash);
+    assert.deepEqual(declarationStatus.changedFiles, ["index.d.ts"]);
+
+    const documentationChange = contractsChange(
+        baselineArtifact,
+        "/** Status-only generated documentation. */\nexport interface DocumentedStatusContract {}",
+    );
+    const documentationStatus = status(documentationChange);
+    assert.equal(documentationStatus.updateRequired, true);
+    assert.deepEqual(documentationStatus.reasons, ["declarations"]);
+
+    const grantsChange = structuredClone(baselineArtifact);
+    grantsChange.files["lib/helpers/grants.d.ts"] += "\nexport interface StatusOnlyGrantHelper {}\n";
+    updateHash(grantsChange);
+    const grantsStatus = status(grantsChange);
+    assert.equal(grantsStatus.updateRequired, true);
+    assert.deepEqual(grantsStatus.reasons, ["declarations"]);
+    assert.deepEqual(grantsStatus.changedFiles, ["index.d.ts", "lib/helpers/grants.d.ts"]);
+
+    const formattingOnly = structuredClone(baselineArtifact);
+    formattingOnly.indexFragments.contracts += "\n\n";
+    formattingOnly.files["lib/helpers/grants.d.ts"] += "\n\n";
+    updateHash(formattingOnly);
+    const formattingStatus = status(formattingOnly);
+    assert.equal(formattingStatus.updateRequired, false);
+    assert.deepEqual(formattingStatus.reasons, []);
+    assert.equal(formattingStatus.currentHash, formattingStatus.candidateHash);
+
+    writeArtifact(formattingOnly);
+    expectFailure(
+        "exact check retains normalized content drift",
+        ["--check", "--artifact", artifactPath],
+        /declaration mirrors are not up to date/,
+    );
+
+    restorePackage();
+    const nextMinorChange = withProviderVersion(changedContracts, minorVersion);
+    writeArtifact(nextMinorChange);
+    const updateMinor = updater(["--artifact", artifactPath]);
+    assert.equal(updateMinor.status, 0, updateMinor.stderr);
+    assert.equal(
+        JSON.parse(readFileSync(packagePath, "utf8")).version,
+        `${baselineVersion.major}.${baselineVersion.minor + 1}.9999`,
+    );
+    const updatedMinorCheck = check(["--artifact", artifactPath]);
+    assert.equal(updatedMinorCheck.status, 0, updatedMinorCheck.stderr);
+
+    restorePackage();
+    const majorOnly = withProviderVersion(baselineArtifact, majorVersion);
+    writeArtifact(majorOnly);
+    const updateMajor = updater(["--artifact", artifactPath]);
+    assert.equal(updateMajor.status, 0, updateMajor.stderr);
+    assert.equal(JSON.parse(readFileSync(packagePath, "utf8")).version, `${baselineVersion.major + 1}.0.9999`);
+    const updatedMajorCheck = check(["--artifact", artifactPath]);
+    assert.equal(updatedMajorCheck.status, 0, updatedMajorCheck.stderr);
+
+    restorePackage();
+    writeArtifact(withProviderVersion(baselineArtifact, minorVersion));
+    const minorOnlyUpdate = updater(["--artifact", artifactPath]);
+    assert.equal(minorOnlyUpdate.status, 0, minorOnlyUpdate.stderr);
+    assert.match(minorOnlyUpdate.stdout, /No declaration update is required/);
+    assert.equal(readFileSync(packagePath, "utf8"), baselineFiles.get(packagePath));
+    expectFailure(
+        "exact check retains major/minor compatibility check",
+        ["--check", "--artifact", artifactPath],
+        /version mismatch/,
+    );
+
+    restorePackage();
+    writeArtifact(olderArtifact);
+    const olderUpdate = updater(["--artifact", artifactPath]);
+    assert.equal(olderUpdate.status, 0, olderUpdate.stderr);
+    assert.match(olderUpdate.stderr, /older than the tracked/);
+    assert.equal(readFileSync(indexPath, "utf8"), baselineFiles.get(indexPath));
+
+    restorePackage();
+    const generatedIndex = readFileSync(indexPath, "utf8");
+    writeFileSync(
+        indexPath,
+        generatedIndex.replace("// BEGIN GENERATED OIDC-PROVIDER CONTRACTS\n", ""),
+    );
+    writeArtifact(baselineArtifact);
+    expectFailure(
+        "partial generated-region layout",
+        ["--status", "--artifact", artifactPath],
+        /partial or duplicated generated-region layout/,
+    );
+
+    restorePackage();
+    const markerlessIndex = readFileSync(indexPath, "utf8").replaceAll(
+        /^\s*\/\/ (?:BEGIN|END) GENERATED OIDC-PROVIDER (?:CONTRACTS|MEMBERS|RELATED CONTRACTS)\n/gm,
+        "",
+    );
+    writeFileSync(indexPath, markerlessIndex);
+    rmSync(grantsPath, { force: true });
+    expectFailure(
+        "unrecognized markerless layout",
+        ["--status", "--artifact", artifactPath],
+        /not the supported bootstrap baseline/,
+    );
+
+    restorePackage();
+    const index = readFileSync(indexPath, "utf8");
+    const altered = index.replace("export type TokenFormat =", "export type AlteredTokenFormat =");
+    assert.notEqual(altered, index, "expected to alter the generated contracts region");
+    writeFileSync(indexPath, altered);
+    writeArtifact(baselineArtifact);
+    expectFailure(
+        "altered generated region",
+        ["--check", "--artifact", artifactPath],
+        /declaration mirrors are not up to date/,
+    );
+
+    if (providerDirectory !== undefined) {
+        const artifactOnlyRun = run(
+            process.execPath,
+            [fileURLToPath(import.meta.url), "--artifact", artifactPath],
+            packageDirectory,
+        );
+        assert.equal(artifactOnlyRun.status, 0, artifactOnlyRun.stderr);
+        assert.match(artifactOnlyRun.stdout, /update-types artifact and status checks passed/);
+    }
+
+    process.stdout.write("update-types artifact and status checks passed.\n");
+} finally {
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+}


### PR DESCRIPTION
Add artifact-driven update and submission helpers without changing the published declarations. The first provider release performs the hash-gated migration to generated contracts and matching tests.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
