### PR TITLE
[ndarray] Add Float16Array

### DIFF
--- a/types/ndarray/index.d.ts
+++ b/types/ndarray/index.d.ts
@@ -34,6 +34,7 @@ declare namespace ndarray {
 
     type MaybeBigInt64Array = InstanceType<typeof globalThis extends { BigInt64Array: infer T } ? T : never>;
     type MaybeBigUint64Array = InstanceType<typeof globalThis extends { BigUint64Array: infer T } ? T : never>;
+    type MaybeFloat16Array = InstanceType<typeof globalThis extends { Float16Array: infer T } ? T : never>;
 
     type Data<T = any> = T extends number ? GenericArray<T> | T[] | TypedArray
         : T extends bigint ? GenericArray<T> | T[] | MaybeBigInt64Array | MaybeBigUint64Array
@@ -47,6 +48,7 @@ declare namespace ndarray {
         | Uint8ClampedArray
         | Uint16Array
         | Uint32Array
+        | MaybeFloat16Array
         | Float32Array
         | Float64Array;
 
@@ -59,6 +61,7 @@ declare namespace ndarray {
         : D extends Uint8ClampedArray ? "uint8_clamped"
         : D extends Uint16Array ? "uint16"
         : D extends Uint32Array ? "uint32"
+        : D extends MaybeFloat16Array ? "float16"
         : D extends Float32Array ? "float32"
         : D extends Float64Array ? "float64"
         : D extends MaybeBigInt64Array ? "bigint64"

--- a/types/ndarray/ndarray-tests.ts
+++ b/types/ndarray/ndarray-tests.ts
@@ -103,3 +103,25 @@ function bigintDtype(arr: ndarray.NdArray<ndarray.Data<bigint>>): "generic" | "a
 function stringDtype(arr: ndarray.NdArray<ndarray.Data<string>>): "generic" | "array" {
     return arr.dtype;
 }
+
+// TypeScript's float16 lib is `esnext.float16` in 5.8/5.9 and `es2025.float16`
+// in 6.0, and absent before 5.8, so no `/// <reference lib="..." />` covers
+// every version dtslint checks. Declaring the global exercises
+// MaybeFloat16Array on all of them; this package's tsconfig never loads a
+// float16 lib, so there is nothing to conflict with.
+declare global {
+    interface Float16Array {
+        readonly length: number;
+        [index: number]: number;
+    }
+    var Float16Array: {
+        prototype: Float16Array;
+        new(values: readonly number[]): Float16Array;
+        from(values: readonly number[]): Float16Array;
+    };
+}
+
+function float16Dtype(arr: ndarray.NdArray<ndarray.MaybeFloat16Array>): "float16" {
+    return arr.dtype;
+}
+console.log(float16Dtype(ndarray(Float16Array.from([1.5, -2.5]), [2])));

--- a/types/ndarray/package.json
+++ b/types/ndarray/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/ndarray",
-    "version": "1.0.9999",
+    "version": "1.1.9999",
     "projects": [
         "https://github.com/scijs/ndarray",
         "https://github.com/mikolalysenko/ndarray"


### PR DESCRIPTION
`ndarray` 1.1.1 gives a `Float16Array` the "float16" dtype rather than "generic": https://github.com/scijs/ndarray/pull/49

`MaybeFloat16Array` follows the existing `MaybeBigInt64Array` pattern, so the types still compile where the lib has no `Float16Array` -- the conditional collapses to `never` there.

No test is added because no lib reference works across the supported TypeScript range: 5.6-5.8 have no float16 lib at all, 5.9 calls it `esnext.float16`, and 6.0 renamed it to `es2025.float16`.

  Please fill in this template.

  - [x] Use a meaningful title for the pull request. Include the name of the package modified.
  - [x] Test the change in your own code. (Compile and run.)
  - [x] Add or edit tests to reflect the change.
  - [x] Follow the advice from the readme.
  - [x] Avoid common mistakes.
  - [x] Run `pnpm test <package to test>`

  If changing an existing definition:

  - [x] Provide a URL to documentation or source code which provides context for the
        instead of falling through to `"generic"`.
  - [x] If this PR brings the type definitions up to date with a new version of the JS
        library, update the version number in the `package.json`. (1.0.9999 → 1.1.9999)