### PR TITLE
[n3] make termFromId factory parameter optional

### DIFF
--- a/types/n3/index.d.ts
+++ b/types/n3/index.d.ts
@@ -394,4 +394,4 @@ export namespace Util {
 }
 
 export function termToId(term: Term): string;
-export function termFromId(id: string, factory: RDF.DataFactory): Term;
+export function termFromId(id: string, factory?: RDF.DataFactory): Term;

--- a/types/n3/n3-tests.ts
+++ b/types/n3/n3-tests.ts
@@ -628,5 +628,10 @@ function test_base_iri_constructor() {
     const relative1: string = baseIri.toRelative("http://example.org/path/resource");
 }
 
+function test_term_from_id_optional_factory() {
+    // factory defaults to N3's own DataFactory
+    const t1: N3.Term = N3.termFromId("http://example.org/");
+}
+
 export const namedNode: ReturnType<RDF.DataFactory["namedNode"]> = N3.DataFactory.namedNode("hello world");
 export const df: RDF.DataFactory = N3.DataFactory;


### PR DESCRIPTION

### PR Description

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rdfjs/N3.js/blob/main/src/N3DataFactory.js#L248
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---

**What this PR does:**

Makes the `factory` parameter optional in `termFromId(id: string, factory?: RDF.DataFactory)`.

In the N3.js runtime (`src/N3DataFactory.js`, line 198), `termFromId` defaults to N3's internal `DataFactory` when no `factory` argument is passed (`factory = factory || DataFactory;`). Marking `factory` as optional brings `@types/n3` in line with the library's actual runtime behavior.