### PR TITLE
[n3] add getRulesFromDataset top-level function export

### DIFF
--- a/types/n3/index.d.ts
+++ b/types/n3/index.d.ts
@@ -395,3 +395,4 @@ export namespace Util {
 
 export function termToId(term: Term): string;
 export function termFromId(id: string, factory?: RDF.DataFactory): Term;
+export function getRulesFromDataset(dataset: RDF.DatasetCore<RDF.Quad>): Rule[];

--- a/types/n3/n3-tests.ts
+++ b/types/n3/n3-tests.ts
@@ -633,5 +633,10 @@ function test_term_from_id_optional_factory() {
     const t1: N3.Term = N3.termFromId("http://example.org/");
 }
 
+function test_get_rules_from_dataset() {
+    const store = new N3.Store();
+    const rules: N3.Rule[] = N3.getRulesFromDataset(store);
+}
+
 export const namedNode: ReturnType<RDF.DataFactory["namedNode"]> = N3.DataFactory.namedNode("hello world");
 export const df: RDF.DataFactory = N3.DataFactory;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rdfjs/N3.js/blob/main/src/N3Reasoner.js#L6
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---

**What this PR does:**

Exports `getRulesFromDataset(dataset: RDF.DatasetCore<RDF.Quad>): Rule[]` at the package root.

In N3.js, `getRulesFromDataset` is exported at the package root (`src/index.js:5`, re-exported from `src/N3Reasoner.js:6`). It parses horn rules from an RDF dataset matching `log:implies` and returns an array of `Rule` objects (`{ premise: RDF.Quad[], conclusion: RDF.Quad[] }`). This function was missing from `@types/n3`.
