### PR TITLE
[aws-lambda] Allow null JWT authorizer scopes

### DIFF
--- a/types/aws-lambda/test/api-gateway-tests.ts
+++ b/types/aws-lambda/test/api-gateway-tests.ts
@@ -353,7 +353,10 @@ const proxyHandlerv2WithJKTAuthorizer: APIGatewayProxyHandlerV2WithJWTAuthorizer
     authorizer.jwt.scopes;
     // All non-null or undefined types are converted to string.
     obj = authorizer.jwt.claims;
-    array = authorizer.jwt.scopes;
+    if (authorizer.jwt.scopes !== null) {
+        array = authorizer.jwt.scopes;
+    }
+    const nullableScopes: string[] | null = authorizer.jwt.scopes;
     // And these extra properties are added
     str = authorizer.principalId;
     num = authorizer.integrationLatency;

--- a/types/aws-lambda/trigger/api-gateway-proxy.d.ts
+++ b/types/aws-lambda/trigger/api-gateway-proxy.d.ts
@@ -258,7 +258,7 @@ export interface APIGatewayEventRequestContextJWTAuthorizer {
     integrationLatency: number;
     jwt: {
         claims: { [name: string]: string | number | boolean | string[] };
-        scopes: string[];
+        scopes: string[] | null;
     };
 }
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html (but the sample object in this article does not show the type mismatch)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.


This updates `APIGatewayEventRequestContextJWTAuthorizer.jwt.scopes` to reflect the actual runtime shape emitted by API Gateway HTTP APIs with JWT authorizers.

The current type declares:

```ts
scopes: string[];
```

However, API Gateway can emit `null` for this field. In particular, I observed that when a JWT authorizer is configured but the route itself has no authorization scopes configured, the Lambda event contains:

```json
{
  "authorizer": {
    "jwt": {
      "claims": {
        "scope": "test-frameo-id/scope1 test-frameo-id/scope2"
      },
      "scopes": null
    }
  }
}
```

This is true even when the access token itself contains OAuth scopes.

When the same route is configured to require an authorization scope, API Gateway instead populates `jwt.scopes` as an array containing the scopes from the token:

```json
{
  "authorizer": {
    "jwt": {
      "claims": {
        "scope": "test-frameo-id/scope1 test-frameo-id/scope2"
      },
      "scopes": [
        "test-frameo-id/scope1",
        "test-frameo-id/scope2"
      ]
    }
  }
}
```

So the runtime type is:

```ts
scopes: string[] | null;
```

The current `string[]` declaration can therefore allow code such as `authorizer.jwt.scopes.map(...)` to compile even though it can throw at runtime when API Gateway supplies `null`.

This PR changes the declaration to `string[] | null` and updates the existing API Gateway JWT-authorizer type test to require null handling while preserving normal narrowing to `string[]`.

<details>
<summary>Full Lambda event logs from API Gateway + Cognito</summary>

### No route authorization scopes configured

Invocation at `2026-08-29T07:08:44.422Z`.

```json
{
  "version": "2.0",
  "routeKey": "POST /fulfillment",
  "rawPath": "/fulfillment",
  "rawQueryString": "",
  "headers": {
    "accept": "*/*",
    "accept-encoding": "gzip, deflate, br",
    "authorization": "Bearer <redacted>",
    "cache-control": "no-cache",
    "content-length": "79",
    "content-type": "application/json",
    "host": "6ldrvk5tk5.execute-api.us-east-1.amazonaws.com",
    "postman-token": "<redacted>",
    "user-agent": "PostmanRuntime/7.56.1",
    "x-amzn-trace-id": "Root=1-6a92859f-69edea11436dfe8832c425f5",
    "x-forwarded-for": "<redacted>",
    "x-forwarded-port": "443",
    "x-forwarded-proto": "https"
  },
  "requestContext": {
    "accountId": "947734355387",
    "apiId": "6ldrvk5tk5",
    "authorizer": {
      "jwt": {
        "claims": {
          "auth_time": "1787950748",
          "client_id": "5kek0i61pgkokoob4fsm9fo9it",
          "event_id": "ba02ee15-6581-4f7c-ac37-8088d87478c7",
          "exp": "1787988914",
          "iat": "1787985314",
          "iss": "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_HblcSIjTD",
          "jti": "bcc16066-26df-406e-b108-9ac5ec77b597",
          "origin_jti": "d2a2852d-3fdc-46b4-b2c5-c27c0bb1d84c",
          "scope": "phone openid email",
          "sub": "9428d438-90d1-7087-1fff-0b734913c420",
          "token_use": "access",
          "username": "9428d438-90d1-7087-1fff-0b734913c420",
          "version": "2"
        },
        "scopes": null
      }
    },
    "domainName": "6ldrvk5tk5.execute-api.us-east-1.amazonaws.com",
    "domainPrefix": "6ldrvk5tk5",
    "http": {
      "method": "POST",
      "path": "/fulfillment",
      "protocol": "HTTP/1.1",
      "sourceIp": "<redacted>",
      "userAgent": "PostmanRuntime/7.56.1"
    },
    "requestId": "C2nQ_g8doAMEV8g=",
    "routeKey": "POST /fulfillment",
    "stage": "$default",
    "time": "29/Aug/2026:07:09:19 +0000",
    "timeEpoch": 1787987359463
  },
  "body": "{\n    \"type\": \"play_album\",\n    \"album_name\": \"boarding\"\n}",
  "isBase64Encoded": false
}
```

### Token has custom scopes, but route does not require any scopes

Invocation at `2026-08-29T08:35:37.346Z`.

The access token was granted:

```text
test-frameo-id/scope1 test-frameo-id/scope2
```

but the API Gateway route itself had no required authorization scopes configured.

```json
{
  "version": "2.0",
  "routeKey": "POST /fulfillment",
  "rawPath": "/fulfillment",
  "rawQueryString": "",
  "headers": {
    "accept": "*/*",
    "accept-encoding": "gzip, deflate, br",
    "authorization": "Bearer <redacted>",
    "cache-control": "no-cache",
    "content-length": "75",
    "content-type": "application/json",
    "host": "6ldrvk5tk5.execute-api.us-east-1.amazonaws.com",
    "postman-token": "<redacted>",
    "user-agent": "PostmanRuntime/7.56.1",
    "x-amzn-trace-id": "Root=1-6a9299d8-49fa1ebe4ba1ae342ee07e3a",
    "x-forwarded-for": "<redacted>",
    "x-forwarded-port": "443",
    "x-forwarded-proto": "https"
  },
  "requestContext": {
    "accountId": "947734355387",
    "apiId": "6ldrvk5tk5",
    "authorizer": {
      "jwt": {
        "claims": {
          "auth_time": "1787992402",
          "client_id": "5kek0i61pgkokoob4fsm9fo9it",
          "exp": "1787996002",
          "iat": "1787992402",
          "iss": "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_HblcSIjTD",
          "jti": "afa8fe33-607e-4fdb-99ac-81c27d1ddc73",
          "origin_jti": "2c496ec9-8d59-4e03-913f-ca934fb3e078",
          "scope": "test-frameo-id/scope1 test-frameo-id/scope2",
          "sub": "6418b458-d091-705e-122e-04bf2945fcdf",
          "token_use": "access",
          "username": "google_115119494665302655368",
          "version": "2"
        },
        "scopes": null
      }
    },
    "domainName": "6ldrvk5tk5.execute-api.us-east-1.amazonaws.com",
    "domainPrefix": "6ldrvk5tk5",
    "http": {
      "method": "POST",
      "path": "/fulfillment",
      "protocol": "HTTP/1.1",
      "sourceIp": "<redacted>",
      "userAgent": "PostmanRuntime/7.56.1"
    },
    "requestId": "C2z56hl7IAMEYxA=",
    "routeKey": "POST /fulfillment",
    "stage": "$default",
    "time": "29/Aug/2026:08:35:36 +0000",
    "timeEpoch": 1787992536530
  },
  "body": "{\n    \"type\": \"play_album\",\n    \"album_name\": \"Test\"\n}",
  "isBase64Encoded": false
}
```

### Same token, route requires `test-frameo-id/scope1`

Invocation at `2026-08-29T08:40:44.827Z`.

The access token was granted:

```text
test-frameo-id/scope1 test-frameo-id/scope2
```

and the API Gateway route required:

```text
test-frameo-id/scope1
```

In this case, `jwt.scopes` was populated as an array containing both scopes from the token:

```json
{
  "version": "2.0",
  "routeKey": "POST /fulfillment",
  "rawPath": "/fulfillment",
  "rawQueryString": "",
  "headers": {
    "accept": "*/*",
    "accept-encoding": "gzip, deflate, br",
    "authorization": "Bearer <redacted>",
    "cache-control": "no-cache",
    "content-length": "75",
    "content-type": "application/json",
    "host": "6ldrvk5tk5.execute-api.us-east-1.amazonaws.com",
    "postman-token": "<redacted>",
    "user-agent": "PostmanRuntime/7.56.1",
    "x-amzn-trace-id": "Root=1-6a929b0c-15b5163b721505e578d23174",
    "x-forwarded-for": "<redacted>",
    "x-forwarded-port": "443",
    "x-forwarded-proto": "https"
  },
  "requestContext": {
    "accountId": "947734355387",
    "apiId": "6ldrvk5tk5",
    "authorizer": {
      "jwt": {
        "claims": {
          "auth_time": "1787992402",
          "client_id": "5kek0i61pgkokoob4fsm9fo9it",
          "exp": "1787996002",
          "iat": "1787992402",
          "iss": "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_HblcSIjTD",
          "jti": "afa8fe33-607e-4fdb-99ac-81c27d1ddc73",
          "origin_jti": "2c496ec9-8d59-4e03-913f-ca934fb3e078",
          "scope": "test-frameo-id/scope1 test-frameo-id/scope2",
          "sub": "6418b458-d091-705e-122e-04bf2945fcdf",
          "token_use": "access",
          "username": "google_115119494665302655368",
          "version": "2"
        },
        "scopes": [
          "test-frameo-id/scope1",
          "test-frameo-id/scope2"
        ]
      }
    },
    "domainName": "6ldrvk5tk5.execute-api.us-east-1.amazonaws.com",
    "domainPrefix": "6ldrvk5tk5",
    "http": {
      "method": "POST",
      "path": "/fulfillment",
      "protocol": "HTTP/1.1",
      "sourceIp": "<redacted>",
      "userAgent": "PostmanRuntime/7.56.1"
    },
    "requestId": "C20qEh0doAMEbNw=",
    "routeKey": "POST /fulfillment",
    "stage": "$default",
    "time": "29/Aug/2026:08:40:44 +0000",
    "timeEpoch": 1787992844757
  },
  "body": "{\n    \"type\": \"play_album\",\n    \"album_name\": \"Test\"\n}",
  "isBase64Encoded": false
}
```

</details>
