### PR TITLE
[emscripten] Add FS node lookup cache functions and FSNode.name_next

### DIFF
--- a/types/emscripten/emscripten-tests.ts
+++ b/types/emscripten/emscripten-tests.ts
@@ -172,6 +172,33 @@ function FSTest(): void {
     const analyze = FS.analyzePath("path");
     // $ExpectType boolean
     analyze.exists;
+
+    // Test hashAddNode - adds a node to the cache lookupNode reads before node_ops.lookup
+    const dir = FS.lookupPath("/", { follow: true }).node;
+    const node = new FS.FSNode(dir, "file", parseInt("0100644", 8), 0);
+    FS.hashAddNode(node);
+    // $ExpectType FSNode
+    FS.lookupNode(dir, "file");
+    // $ExpectType number
+    FS.hashName(dir.id, "file");
+    // $ExpectType FSNode | undefined
+    FS.nameTable[FS.hashName(dir.id, "file")];
+    // $ExpectType FSNode | undefined
+    node.name_next;
+
+    // Test hashRemoveNode and destroyNode - takes a node back out of the cache
+    FS.hashRemoveNode(node);
+    FS.destroyNode(node);
+
+    // Test createNode - NODEFS and WORKERFS build their root with a null parent and no rdev
+    // $ExpectType FSNode
+    FS.createNode(dir, "other", parseInt("0100644", 8), 0);
+    // $ExpectType number | undefined
+    FS.createNode(null, "/", parseInt("0040777", 8)).rdev;
+
+    // Test FSNode - the constructor takes the same root case createNode passes it
+    // $ExpectType FSNode
+    new FS.FSNode(null, "/", parseInt("0040777", 8));
 }
 
 /// String conversions

--- a/types/emscripten/index.d.ts
+++ b/types/emscripten/index.d.ts
@@ -167,11 +167,13 @@ declare namespace FS {
         contents?: any;
         id: number;
         name: string;
+        // Next node in the nameTable bucket
+        name_next?: FSNode;
         mode: number;
-        rdev: number;
+        rdev: number | undefined;
         readMode: number;
         writeMode: number;
-        constructor(parent: FSNode, name: string, mode: number, rdev: number);
+        constructor(parent: FSNode | null, name: string, mode: number, rdev?: number);
         read: boolean;
         write: boolean;
         readonly isFolder: boolean;
@@ -254,6 +256,14 @@ declare namespace FS {
     //
     // nodes
     //
+    let nameTable: Array<FSNode | undefined>;
+    function hashName(parentid: number, name: string): number;
+    function hashAddNode(node: FSNode): void;
+    function hashRemoveNode(node: FSNode): void;
+    function lookupNode(parent: FSNode, name: string): FSNode;
+    function createNode(parent: FSNode | null, name: string, mode: number, rdev?: number): FSNode;
+    function destroyNode(node: FSNode): void;
+
     function isFile(mode: number): boolean;
     function isDir(mode: number): boolean;
     function isLink(mode: number): boolean;


### PR DESCRIPTION

`FS.lookupNode` consults `FS.nameTable` before it calls a backend's `node_ops.lookup`, and
`FS.createNode` is what puts a node there. None of that was declared, so a backend written against
`Emscripten.FileSystemType` had to assert its way to `hashAddNode`. That assertion is in
[zen-fs/emscripten#7](https://github.com/zen-fs/emscripten/pull/7), and the maintainer asked for the
type upstream instead.

`@types/emscripten` · types only · **no runtime change**

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change.
- [x] Follow the advice from the readme.
- [x] Avoid common mistakes.
- [x] Run `pnpm test emscripten`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  [`libfs.js#L320-L388`](https://github.com/emscripten-core/emscripten/blob/01346488e29fcd589e99abffc3e99f48b18d8d1e/src/lib/libfs.js#L320-L388)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`. — **n/a.** These APIs are not new; they were never
  declared.

Ref: https://github.com/emscripten-core/emscripten/blob/01346488e29fcd589e99abffc3e99f48b18d8d1e/src/lib/libfs.js#L320-L388

