### PR TITLE
webextension-polyfill: Update to latest type definitions from Firefox

### DIFF
--- a/types/webextension-polyfill/index.d.ts
+++ b/types/webextension-polyfill/index.d.ts
@@ -43,6 +43,7 @@ import { Permissions as ImportedPermissions } from "./namespaces/permissions";
 import { Pkcs11 as ImportedPkcs11 } from "./namespaces/pkcs11";
 import { Privacy as ImportedPrivacy } from "./namespaces/privacy";
 import { Proxy as ImportedProxy } from "./namespaces/proxy";
+import { PublicSuffix as ImportedPublicSuffix } from "./namespaces/publicSuffix";
 import { Runtime as ImportedRuntime } from "./namespaces/runtime";
 import { Scripting as ImportedScripting } from "./namespaces/scripting";
 import { Search as ImportedSearch } from "./namespaces/search";
@@ -320,6 +321,13 @@ declare namespace Browser {
      * Permissions: "proxy"
      */
     const proxy: Proxy.Static;
+
+    /**
+     * API to obtain the registrable domain / eTLD+1 from a domain name.
+     *
+     * Permissions: "publicSuffix"
+     */
+    const publicSuffix: PublicSuffix.Static;
 
     /**
      * Use the <code>browser.runtime</code> API to retrieve the background page, return details about the manifest,
@@ -688,6 +696,13 @@ declare namespace Browser {
         proxy: Proxy.Static;
 
         /**
+         * API to obtain the registrable domain / eTLD+1 from a domain name.
+         *
+         * Permissions: "publicSuffix"
+         */
+        publicSuffix: PublicSuffix.Static;
+
+        /**
          * Use the <code>browser.runtime</code> API to retrieve the background page, return details about the manifest,
          * and listen for and respond to events in the app or extension lifecycle. You can also use this API to convert the
          * relative path of URLs to fully-qualified URLs.
@@ -834,6 +849,7 @@ declare namespace Browser {
     export import Pkcs11 = ImportedPkcs11;
     export import Privacy = ImportedPrivacy;
     export import Proxy = ImportedProxy;
+    export import PublicSuffix = ImportedPublicSuffix;
     export import Runtime = ImportedRuntime;
     export import Scripting = ImportedScripting;
     export import Search = ImportedSearch;

--- a/types/webextension-polyfill/namespaces/contextualIdentities.d.ts
+++ b/types/webextension-polyfill/namespaces/contextualIdentities.d.ts
@@ -44,6 +44,21 @@ export namespace ContextualIdentities {
     }
 
     /**
+     * Represents the association between a site and a contextual identity.
+     */
+    interface SiteAssociation {
+        /**
+         * The associated host, normalized to lower case and encoded as ASCII.
+         */
+        site: string;
+
+        /**
+         * The cookie store ID of the contextual identity the host is associated with.
+         */
+        cookieStoreId: string;
+    }
+
+    /**
      * Information to filter the contextual identities being retrieved.
      */
     interface QueryDetailsType {
@@ -52,6 +67,30 @@ export namespace ContextualIdentities {
          * Optional.
          */
         name?: string;
+    }
+
+    interface GetSupportedColorsCallbackColorsItemType {
+        /**
+         * The color name, as accepted by the color property of create and update.
+         */
+        color: string;
+
+        /**
+         * The color hash for this color name.
+         */
+        colorCode: string;
+    }
+
+    interface GetSupportedIconsCallbackIconsItemType {
+        /**
+         * The icon name, as accepted by the icon property of create and update.
+         */
+        icon: string;
+
+        /**
+         * The icon url for this icon name.
+         */
+        iconUrl: string;
     }
 
     /**
@@ -97,6 +136,52 @@ export namespace ContextualIdentities {
         icon?: string;
     }
 
+    /**
+     * Details about the site association.
+     */
+    interface SetSiteAssociationDetailsType {
+        /**
+         * The host to associate with the container (matched as an exact host).
+         */
+        site: string;
+
+        /**
+         * The cookie store ID of the container to associate the site with.
+         */
+        cookieStoreId: string;
+    }
+
+    /**
+     * Details about the site association to remove.
+     */
+    interface RemoveSiteAssociationDetailsType {
+        /**
+         * The host whose container association should be removed.
+         */
+        site: string;
+    }
+
+    /**
+     * Details about the site to look up.
+     */
+    interface GetSiteAssociationDetailsType {
+        /**
+         * The host to look up.
+         */
+        site: string;
+    }
+
+    /**
+     * Information to filter the associations being retrieved.
+     */
+    interface QuerySiteAssociationsDetailsType {
+        /**
+         * If provided, only associations for this container are returned.
+         * Optional.
+         */
+        cookieStoreId?: string;
+    }
+
     interface OnUpdatedChangeInfoType {
         /**
          * Contextual identity that has been updated
@@ -118,6 +203,19 @@ export namespace ContextualIdentities {
         contextualIdentity: ContextualIdentity;
     }
 
+    interface OnSiteAssociationChangedChangeInfoType {
+        /**
+         * The host whose association changed.
+         */
+        site: string;
+
+        /**
+         * The cookie store ID of the now-associated container, or omitted if the association was removed.
+         * Optional.
+         */
+        cookieStoreId?: string;
+    }
+
     interface Static {
         /**
          * Retrieves information about a single contextual identity.
@@ -132,6 +230,16 @@ export namespace ContextualIdentities {
          * @param details Information to filter the contextual identities being retrieved.
          */
         query(details: QueryDetailsType): Promise<ContextualIdentity[]>;
+
+        /**
+         * Retrieves the list of colors supported by contextual identities.
+         */
+        getSupportedColors(): Promise<GetSupportedColorsCallbackColorsItemType[]>;
+
+        /**
+         * Retrieves the list of icons supported by contextual identities.
+         */
+        getSupportedIcons(): Promise<GetSupportedIconsCallbackIconsItemType[]>;
 
         /**
          * Creates a contextual identity with the given data.
@@ -164,6 +272,34 @@ export namespace ContextualIdentities {
         remove(cookieStoreId: string): Promise<ContextualIdentity>;
 
         /**
+         * Associates a site with a container. Top-level navigations to that site will load in the given container.
+         *
+         * @param details Details about the site association.
+         */
+        setSiteAssociation(details: SetSiteAssociationDetailsType): Promise<void>;
+
+        /**
+         * Removes the container association for a site.
+         *
+         * @param details Details about the site association to remove.
+         */
+        removeSiteAssociation(details: RemoveSiteAssociationDetailsType): Promise<void>;
+
+        /**
+         * Retrieves the association of a site, or null if the site is not associated with any container.
+         *
+         * @param details Details about the site to look up.
+         */
+        getSiteAssociation(details: GetSiteAssociationDetailsType): Promise<SiteAssociation | undefined>;
+
+        /**
+         * Retrieves the list of site-to-container associations.
+         *
+         * @param details Information to filter the associations being retrieved.
+         */
+        querySiteAssociations(details: QuerySiteAssociationsDetailsType): Promise<SiteAssociation[]>;
+
+        /**
          * Fired when a container is updated.
          */
         onUpdated: Events.Event<(changeInfo: OnUpdatedChangeInfoType) => void>;
@@ -177,5 +313,10 @@ export namespace ContextualIdentities {
          * Fired when a container is removed.
          */
         onRemoved: Events.Event<(changeInfo: OnRemovedChangeInfoType) => void>;
+
+        /**
+         * Fired when a site-to-container association is added, changed, or removed.
+         */
+        onSiteAssociationChanged: Events.Event<(changeInfo: OnSiteAssociationChangedChangeInfoType) => void>;
     }
 }

--- a/types/webextension-polyfill/namespaces/events.d.ts
+++ b/types/webextension-polyfill/namespaces/events.d.ts
@@ -48,7 +48,7 @@ export namespace Events {
          * Registers an event listener <em>callback</em> to an event.
          *
          * @param callback Called when an event occurs. The parameters of this function depend on the type of event.
-         * @param ...params Further parameters, depending on the event.
+         * @param params Further parameters, depending on the event.
          */
         addListener(callback: T, ...params: unknown[]): void;
 

--- a/types/webextension-polyfill/namespaces/geckoProfiler.d.ts
+++ b/types/webextension-polyfill/namespaces/geckoProfiler.d.ts
@@ -23,7 +23,6 @@ export namespace GeckoProfiler {
         | "nativeallocations"
         | "ipcmessages"
         | "audiocallbacktracing"
-        | "cpu"
         | "notimerresolutionchange"
         | "cpuallthreads"
         | "samplingallthreads"

--- a/types/webextension-polyfill/namespaces/manifest.d.ts
+++ b/types/webextension-polyfill/namespaces/manifest.d.ts
@@ -127,6 +127,11 @@ export namespace Manifest {
         /**
          * Optional.
          */
+        sandbox?: WebExtensionManifestSandboxType;
+
+        /**
+         * Optional.
+         */
         permissions?: PermissionOrOrigin[] | Permission[];
 
         /**
@@ -285,6 +290,7 @@ export namespace Manifest {
         | "idle"
         | "cookies"
         | "menus.overrideContext"
+        | "publicSuffix"
         | "scripting"
         | "search"
         | "tabGroups"
@@ -641,6 +647,21 @@ export namespace Manifest {
         properties?: ThemeExperimentPropertiesType;
     }
 
+    /**
+     * A CSS gradient that can be used as a theme background, in addition to image assets.
+     * The single property name selects the gradient function, and its value holds the gradient's arguments, e.g.
+     * `{ "linear-gradient": "to bottom, #FF6BBA, #FFC999" }`.
+     */
+    type ThemeCSSGradient =
+        | ThemeCSSGradientC1Type
+        | ThemeCSSGradientC2Type
+        | ThemeCSSGradientC3Type
+        | ThemeCSSGradientC4Type
+        | ThemeCSSGradientC5Type
+        | ThemeCSSGradientC6Type;
+
+    type ThemeBackground = ImageDataOrExtensionURL | ThemeCSSGradient;
+
     interface ThemeType {
         /**
          * Optional.
@@ -778,6 +799,19 @@ export namespace Manifest {
          * Optional.
          */
         sandbox?: string;
+    }
+
+    interface WebExtensionManifestSandboxType {
+        /**
+         * The list of pages in the form of globs to serve as sandboxed extension pages.
+         */
+        pages: string[];
+
+        /**
+         * The content security policy used for sandboxed extension pages.
+         * Optional.
+         */
+        content_security_policy?: string;
     }
 
     interface WebExtensionManifestWebAccessibleResourcesC2ItemType {
@@ -1068,16 +1102,40 @@ export namespace Manifest {
         [s: string]: unknown;
     }
 
+    interface ThemeCSSGradientC1Type {
+        "linear-gradient": string;
+    }
+
+    interface ThemeCSSGradientC2Type {
+        "radial-gradient": string;
+    }
+
+    interface ThemeCSSGradientC3Type {
+        "conic-gradient": string;
+    }
+
+    interface ThemeCSSGradientC4Type {
+        "repeating-linear-gradient": string;
+    }
+
+    interface ThemeCSSGradientC5Type {
+        "repeating-radial-gradient": string;
+    }
+
+    interface ThemeCSSGradientC6Type {
+        "repeating-conic-gradient": string;
+    }
+
     interface ThemeTypeImagesType {
         /**
          * Optional.
          */
-        additional_backgrounds?: ImageDataOrExtensionURL[];
+        additional_backgrounds?: ThemeBackground[];
 
         /**
          * Optional.
          */
-        theme_frame?: ImageDataOrExtensionURL;
+        theme_frame?: ThemeBackground;
     }
 
     interface ThemeTypeColorsType {
@@ -1278,6 +1336,8 @@ export namespace Manifest {
         toolbar_field_highlight_text?: ThemeColor;
     }
 
+    type ThemeTypePropertiesBackgroundsAreaEnum = "auto" | "window" | "top_toolbars";
+
     type ThemeTypePropertiesAdditionalBackgroundsAlignmentItemEnum =
         | "bottom"
         | "center"
@@ -1304,12 +1364,22 @@ export namespace Manifest {
         /**
          * Optional.
          */
+        backgrounds_area?: ThemeTypePropertiesBackgroundsAreaEnum;
+
+        /**
+         * Optional.
+         */
         additional_backgrounds_alignment?: ThemeTypePropertiesAdditionalBackgroundsAlignmentItemEnum[];
 
         /**
          * Optional.
          */
         additional_backgrounds_tiling?: ThemeTypePropertiesAdditionalBackgroundsTilingItemEnum[];
+
+        /**
+         * Optional.
+         */
+        additional_backgrounds_size?: string[];
 
         /**
          * Optional.

--- a/types/webextension-polyfill/namespaces/proxy.d.ts
+++ b/types/webextension-polyfill/namespaces/proxy.d.ts
@@ -112,6 +112,18 @@ export namespace Proxy {
         parentFrameId: number;
 
         /**
+         * The UUID of the document making the request.
+         * Optional.
+         */
+        documentId?: string;
+
+        /**
+         * The UUID of the parent document owning this frame. This is not set if there is no parent.
+         * Optional.
+         */
+        parentDocumentId?: string;
+
+        /**
          * True for private browsing requests.
          * Optional.
          */

--- a/types/webextension-polyfill/namespaces/publicSuffix.d.ts
+++ b/types/webextension-polyfill/namespaces/publicSuffix.d.ts
@@ -1,0 +1,65 @@
+//////////////////////////////////////////////////////
+// BEWARE: DO NOT EDIT MANUALLY! Changes will be lost!
+//////////////////////////////////////////////////////
+
+/**
+ * Namespace: browser.publicSuffix
+ */
+export namespace PublicSuffix {
+    /**
+     * The available encoding types for the returned domain.
+     */
+    type DomainEncoding = "punycode" | "display";
+
+    interface GetDomainOptionsType {
+        /**
+         * Determines how the returned domain should be encoded.
+         * Optional.
+         */
+        encoding?: DomainEncoding;
+
+        /**
+         * If true, and the input hostname is an IP address, then this is returned as-is.
+         * Optional.
+         */
+        allowIPAddress?: boolean;
+
+        /**
+         * If true, and the input hostname is itself a known eTLD (without a preceding label) then this is returned as-is.
+         * Optional.
+         */
+        allowPlainSuffix?: boolean;
+
+        /**
+         * If true, and the input hostname lacks a known eTLD, and is neither itself a known eTLD nor an IP address,
+         * then the returned domain consists of the penultimate two domain labels of the input.
+         * Optional.
+         */
+        allowUnknownSuffix?: boolean;
+    }
+
+    interface Static {
+        /**
+         * Checks if the given hostname is itself a known public suffix / eTLD (i.e. in the PSL).
+         *
+         * @returns True if the given hostname is itself a known eTLD.
+         */
+        isKnownSuffix(hostname: string): boolean;
+
+        /**
+         * Gets the known public suffix / eTLD (i.e. in the PSL), if any, of a given hostname.
+         *
+         * @returns The known eTLD of the given hostname, or null if no such known eTLD exists.
+         */
+        getKnownSuffix(hostname: string): string;
+
+        /**
+         * Gets the eTLD+1 of a given hostname, or a variant such as IP address if the options allow.
+         *
+         * @param options Optional.
+         * @returns The eTLD+1 (or a variant such as IP address if allowed) of the given hostname,
+         * or null if no such eTLD+1 (variant) exists.
+         */
+        getDomain(hostname: string, options?: GetDomainOptionsType): string;
+    }
+}

--- a/types/webextension-polyfill/namespaces/runtime.d.ts
+++ b/types/webextension-polyfill/namespaces/runtime.d.ts
@@ -80,6 +80,12 @@ export namespace Runtime {
         contextType: ContextType;
 
         /**
+         * An UUID for the document associated with this context, or undefined if it is not hosted in a document
+         * Optional.
+         */
+        documentId?: string;
+
+        /**
          * The origin of the document associated with this context, or undefined if it is not hosted in a document
          * Optional.
          */
@@ -163,6 +169,12 @@ export namespace Runtime {
          * Optional.
          */
         frameId?: number;
+
+        /**
+         * A UUID of the document that opened the connection.
+         * Optional.
+         */
+        documentId?: string;
 
         /**
          * The ID of the extension or app that opened the connection, if any.
@@ -426,9 +438,19 @@ export namespace Runtime {
         getURL(path: string): string;
 
         /**
+         * Get the documentId of any window global or frame element. Throws for invalid targets, such as unloaded frames.
+         *
+         * @param target A WindowProxy or a browsing context container Element (iframe, frame, embed, or object)
+         * for the target frame.
+         * @returns The documentId of the target document.
+         */
+        getDocumentId(target: unknown): string;
+
+        /**
          * Get the frameId of any window global or frame element.
          *
-         * @param target A WindowProxy or a Browsing Context container element (IFrame, Frame, Embed, Object) for the target frame.
+         * @param target A WindowProxy or a browsing context container Element (iframe, frame, embed, or object)
+         * for the target frame.
          * @returns The frameId of the target frame, or -1 if it doesn't exist.
          */
         getFrameId(target: unknown): number;

--- a/types/webextension-polyfill/namespaces/scripting.d.ts
+++ b/types/webextension-polyfill/namespaces/scripting.d.ts
@@ -32,7 +32,7 @@ export namespace Scripting {
          * This means that any bound parameters and execution context will be lost. Exactly one of <code>files</code> and <code>
          * func</code> must be specified.
          *
-         * @param ...args The arguments
+         * @param args The arguments
          * @returns The return value
          */
         func?(...args: unknown[]): unknown;
@@ -58,6 +58,11 @@ export namespace Scripting {
      * Result of a script injection.
      */
     interface InjectionResult {
+        /**
+         * The document associated with the injection.
+         */
+        documentId: string;
+
         /**
          * The frame ID associated with the injection.
          */
@@ -106,6 +111,13 @@ export namespace Scripting {
          * The ID of the tab into which to inject.
          */
         tabId: number;
+
+        /**
+         * The IDs of specific documents to inject into. This must not be set if <code>frameIds</code> or <code>allFrames</code>
+         * is set.
+         * Optional.
+         */
+        documentIds?: string[];
     }
 
     interface CSSInjection {

--- a/types/webextension-polyfill/namespaces/tabs.d.ts
+++ b/types/webextension-polyfill/namespaces/tabs.d.ts
@@ -238,6 +238,13 @@ export namespace Tabs {
         groupId?: number;
 
         /**
+         * The ID of the Split View that the tab belongs to. $(ref:tabs.SPLIT_VIEW_ID_NONE) if the tab does not belong to a split
+         * view.
+         * Optional.
+         */
+        splitViewId?: number;
+
+        /**
          * The URL the tab is navigating to, before it has committed. This property is only present if the extension's manifest
          * includes the "tabs" permission and there is a pending navigation.
          * Optional.
@@ -466,6 +473,7 @@ export namespace Tabs {
         | "mutedInfo"
         | "pinned"
         | "sharingState"
+        | "splitViewId"
         | "status"
         | "title"
         | "url";
@@ -515,6 +523,12 @@ export namespace Tabs {
          * Optional.
          */
         frameId?: number;
+
+        /**
+         * Open a port to a specific document identified by <code>documentId</code> instead of all frames in the tab.
+         * Optional.
+         */
+        documentId?: string;
     }
 
     interface SendMessageOptionsType {
@@ -524,6 +538,12 @@ export namespace Tabs {
          * Optional.
          */
         frameId?: number;
+
+        /**
+         * Send a message to a specific document identified by <code>documentId</code> instead of all frames in the tab.
+         * Optional.
+         */
+        documentId?: string;
     }
 
     interface CreateCreatePropertiesType {
@@ -734,6 +754,13 @@ export namespace Tabs {
          * Optional.
          */
         groupId?: number;
+
+        /**
+         * The ID of the Split View that the tab belongs to. $(ref:tabs.SPLIT_VIEW_ID_NONE) if the tab does not belong to a split
+         * view.
+         * Optional.
+         */
+        splitViewId?: number;
 
         /**
          * True for any screen sharing, or a string to specify type of screen sharing.
@@ -960,6 +987,13 @@ export namespace Tabs {
          * Optional.
          */
         sharingState?: SharingState;
+
+        /**
+         * The ID of the Split View that the tab belongs to. $(ref:tabs.SPLIT_VIEW_ID_NONE) if the tab does not belong to a split
+         * view.
+         * Optional.
+         */
+        splitViewId?: number;
 
         /**
          * The status of the tab. Can be either <em>loading</em> or <em>complete</em>.
@@ -1475,5 +1509,10 @@ export namespace Tabs {
          * An ID which represents the absence of a browser tab.
          */
         TAB_ID_NONE: -1;
+
+        /**
+         * A value for use with splitViewId to represent that the tab is not a member of a Split View.
+         */
+        SPLIT_VIEW_ID_NONE: -1;
     }
 }

--- a/types/webextension-polyfill/namespaces/userScripts.d.ts
+++ b/types/webextension-polyfill/namespaces/userScripts.d.ts
@@ -180,6 +180,99 @@ export namespace UserScripts {
     }
 
     /**
+     * Details of a user script injection
+     */
+    interface UserScriptInjection {
+        /**
+         * Whether the injection should be triggered in the target as soon as possible. Note that this is not a guarantee that
+         * injection will occur prior to page load, as the page may have already loaded by the time the script reaches the target.
+         * Optional.
+         */
+        injectImmediately?: boolean;
+
+        /**
+         * The list of ScriptSource objects defining sources of scripts to be injected into matching pages.
+         */
+        js: ScriptSource[];
+
+        /**
+         * Details specifying the target into which to inject the script.
+         */
+        target: InjectionTarget;
+
+        /**
+         * The JavaScript "world" to run the script in. The default is `USER_SCRIPT`.
+         * Optional.
+         */
+        world?: ExecutionWorld;
+
+        /**
+         * A specific user script world ID to execute in. Only valid if `world` is omitted or is `USER_SCRIPT`.
+         * If `worldId` is omitted, the default value is an empty string ("") and the script will execute in the default world.
+         * Optional.
+         */
+        worldId?: string;
+    }
+
+    /**
+     * Details specifying the target into which to inject the script.
+     */
+    interface InjectionTarget {
+        /**
+         * Whether the script should inject into all frames within the tab. Defaults to false.
+         * This must not be true if `frameIds` is specified.
+         * Optional.
+         */
+        allFrames?: boolean;
+
+        /**
+         * The IDs of specific documentIds to inject into. This must not be set if frameIds is set.
+         * Optional.
+         */
+        documentIds?: string[];
+
+        /**
+         * The IDs of specific frames to inject into.
+         * Optional.
+         */
+        frameIds?: number[];
+
+        /**
+         * The ID of the tab into which to inject.
+         */
+        tabId: number;
+    }
+
+    /**
+     * Result of a user script injection.
+     */
+    interface InjectionResult {
+        /**
+         * Document ID associated with the injection.
+         */
+        documentId: string;
+
+        /**
+         * Frame ID associated with the injection.
+         */
+        frameId: number;
+
+        /**
+         * Result of the script injection if any. This is mutually exclusive with error.
+         * Optional.
+         */
+        result?: unknown;
+
+        /**
+         * Error message if any. This is mutually exclusive with result. The value is typically an (Error)
+         * object with a message property, but could be any value (including primitives and undefined)
+         * if the user script threw or rejected with such a value.
+         * Optional.
+         */
+        error?: unknown;
+    }
+
+    /**
      * An object that represents a user script registered programmatically
      */
     interface RegisterCallbackLegacyRegisteredUserScriptType {
@@ -261,5 +354,14 @@ export namespace UserScripts {
          * Returns all registered USER_SCRIPT world configurations.
          */
         getWorldConfigurations(): Promise<WorldProperties[]>;
+
+        /**
+         * Executes one or more ephemeral user scripts into a specific tab.
+         *
+         * @param injection The details of the user script which to inject.
+         * @returns Invoked upon completion of the injection. The resulting array contains the result of execution for each frame
+         * where the injection succeeded.
+         */
+        execute(injection: UserScriptInjection): Promise<InjectionResult[]>;
     }
 }

--- a/types/webextension-polyfill/namespaces/webNavigation.d.ts
+++ b/types/webextension-polyfill/namespaces/webNavigation.d.ts
@@ -37,9 +37,10 @@ export namespace WebNavigation {
      */
     interface GetFrameDetailsType {
         /**
-         * The ID of the tab in which the frame is.
+         * The ID of the tab in which the frame is. Must be specified if documentId is not set.
+         * Optional.
          */
-        tabId: number;
+        tabId?: number;
 
         /**
          * The ID of the process runs the renderer for this tab.
@@ -48,9 +49,17 @@ export namespace WebNavigation {
         processId?: number;
 
         /**
-         * The ID of the frame in the given tab.
+         * The ID of the frame in the given tab. Must be specified if documentId is not set.
+         * Optional.
          */
-        frameId: number;
+        frameId?: number;
+
+        /**
+         * The UUID of the document. If provided, tabId and frameId are optional. If all are provided,
+         * the frame is only returned if all properties match.
+         * Optional.
+         */
+        documentId?: string;
     }
 
     /**
@@ -83,6 +92,17 @@ export namespace WebNavigation {
          * ID of frame that wraps the frame. Set to -1 of no parent frame exists.
          */
         parentFrameId: number;
+
+        /**
+         * A UUID of the document loaded.
+         */
+        documentId: string;
+
+        /**
+         * A UUID of the parent document owning this frame. This is not set if there is no parent.
+         * Optional.
+         */
+        parentDocumentId?: string;
     }
 
     /**
@@ -118,6 +138,17 @@ export namespace WebNavigation {
         parentFrameId: number;
 
         /**
+         * A UUID of the document loaded.
+         */
+        documentId: string;
+
+        /**
+         * A UUID of the parent document owning this frame. This is not set if there is no parent.
+         * Optional.
+         */
+        parentDocumentId?: string;
+
+        /**
          * The URL currently associated with this frame.
          */
         url: string;
@@ -143,6 +174,12 @@ export namespace WebNavigation {
         parentFrameId: number;
 
         /**
+         * A UUID of the parent document owning this frame. This is not set if there is no parent.
+         * Optional.
+         */
+        parentDocumentId?: string;
+
+        /**
          * The time when the browser was about to start the navigation, in milliseconds since the epoch.
          */
         timeStamp: number;
@@ -161,6 +198,17 @@ export namespace WebNavigation {
          * Frame IDs are unique within a tab.
          */
         frameId: number;
+
+        /**
+         * A UUID of the document loaded.
+         */
+        documentId: string;
+
+        /**
+         * A UUID of the parent document owning this frame. This is not set if there is no parent.
+         * Optional.
+         */
+        parentDocumentId?: string;
 
         /**
          * Cause of the navigation.
@@ -193,6 +241,17 @@ export namespace WebNavigation {
         frameId: number;
 
         /**
+         * A UUID of the document loaded.
+         */
+        documentId: string;
+
+        /**
+         * A UUID of the parent document owning this frame. This is not set if there is no parent.
+         * Optional.
+         */
+        parentDocumentId?: string;
+
+        /**
          * The time when the page's DOM was fully constructed, in milliseconds since the epoch.
          */
         timeStamp: number;
@@ -213,6 +272,17 @@ export namespace WebNavigation {
         frameId: number;
 
         /**
+         * A UUID of the document loaded.
+         */
+        documentId: string;
+
+        /**
+         * A UUID of the parent document owning this frame. This is not set if there is no parent.
+         * Optional.
+         */
+        parentDocumentId?: string;
+
+        /**
          * The time when the document finished loading, in milliseconds since the epoch.
          */
         timeStamp: number;
@@ -231,6 +301,17 @@ export namespace WebNavigation {
          * Frame IDs are unique within a tab.
          */
         frameId: number;
+
+        /**
+         * A UUID of the document loaded.
+         */
+        documentId: string;
+
+        /**
+         * A UUID of the parent document owning this frame. This is not set if there is no parent.
+         * Optional.
+         */
+        parentDocumentId?: string;
 
         /**
          * The time when the error occurred, in milliseconds since the epoch.
@@ -285,6 +366,17 @@ export namespace WebNavigation {
         frameId: number;
 
         /**
+         * A UUID of the document loaded.
+         */
+        documentId: string;
+
+        /**
+         * A UUID of the parent document owning this frame. This is not set if there is no parent.
+         * Optional.
+         */
+        parentDocumentId?: string;
+
+        /**
          * Cause of the navigation.
          */
         transitionType: TransitionType;
@@ -330,6 +422,17 @@ export namespace WebNavigation {
          * Frame IDs are unique within a tab.
          */
         frameId: number;
+
+        /**
+         * A UUID of the document loaded.
+         */
+        documentId: string;
+
+        /**
+         * A UUID of the parent document owning this frame. This is not set if there is no parent.
+         * Optional.
+         */
+        parentDocumentId?: string;
 
         /**
          * Cause of the navigation.
@@ -472,7 +575,7 @@ export namespace WebNavigation {
     interface Static {
         /**
          * Retrieves information about the given frame. A frame refers to an &lt;iframe&gt; or a &lt;frame&gt; of a web page and is
-         * identified by a tab ID and a frame ID.
+         * identified by a tab ID and a frame ID, or by its document ID.
          *
          * @param details Information about the frame to retrieve information about.
          */

--- a/types/webextension-polyfill/namespaces/webRequest.d.ts
+++ b/types/webextension-polyfill/namespaces/webRequest.d.ts
@@ -484,6 +484,18 @@ export namespace WebRequest {
         parentFrameId: number;
 
         /**
+         * The UUID of the document making the request.
+         * Optional.
+         */
+        documentId?: string;
+
+        /**
+         * The UUID of the parent document owning this frame. This is not set if there is no parent.
+         * Optional.
+         */
+        parentDocumentId?: string;
+
+        /**
          * True for private browsing requests.
          * Optional.
          */
@@ -572,6 +584,18 @@ export namespace WebRequest {
          * ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists.
          */
         parentFrameId: number;
+
+        /**
+         * The UUID of the document making the request.
+         * Optional.
+         */
+        documentId?: string;
+
+        /**
+         * The UUID of the parent document owning this frame. This is not set if there is no parent.
+         * Optional.
+         */
+        parentDocumentId?: string;
 
         /**
          * True for private browsing requests.
@@ -664,6 +688,18 @@ export namespace WebRequest {
         parentFrameId: number;
 
         /**
+         * The UUID of the document making the request.
+         * Optional.
+         */
+        documentId?: string;
+
+        /**
+         * The UUID of the parent document owning this frame. This is not set if there is no parent.
+         * Optional.
+         */
+        parentDocumentId?: string;
+
+        /**
          * True for private browsing requests.
          * Optional.
          */
@@ -752,6 +788,18 @@ export namespace WebRequest {
          * ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists.
          */
         parentFrameId: number;
+
+        /**
+         * The UUID of the document making the request.
+         * Optional.
+         */
+        documentId?: string;
+
+        /**
+         * The UUID of the parent document owning this frame. This is not set if there is no parent.
+         * Optional.
+         */
+        parentDocumentId?: string;
 
         /**
          * True for private browsing requests.
@@ -853,6 +901,18 @@ export namespace WebRequest {
          * ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists.
          */
         parentFrameId: number;
+
+        /**
+         * The UUID of the document making the request.
+         * Optional.
+         */
+        documentId?: string;
+
+        /**
+         * The UUID of the parent document owning this frame. This is not set if there is no parent.
+         * Optional.
+         */
+        parentDocumentId?: string;
 
         /**
          * True for private browsing requests.
@@ -977,6 +1037,18 @@ export namespace WebRequest {
         parentFrameId: number;
 
         /**
+         * The UUID of the document making the request.
+         * Optional.
+         */
+        documentId?: string;
+
+        /**
+         * The UUID of the parent document owning this frame. This is not set if there is no parent.
+         * Optional.
+         */
+        parentDocumentId?: string;
+
+        /**
          * True for private browsing requests.
          * Optional.
          */
@@ -1087,6 +1159,18 @@ export namespace WebRequest {
          * ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists.
          */
         parentFrameId: number;
+
+        /**
+         * The UUID of the document making the request.
+         * Optional.
+         */
+        documentId?: string;
+
+        /**
+         * The UUID of the parent document owning this frame. This is not set if there is no parent.
+         * Optional.
+         */
+        parentDocumentId?: string;
 
         /**
          * True for private browsing requests.
@@ -1204,6 +1288,18 @@ export namespace WebRequest {
          * ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists.
          */
         parentFrameId: number;
+
+        /**
+         * The UUID of the document making the request.
+         * Optional.
+         */
+        documentId?: string;
+
+        /**
+         * The UUID of the parent document owning this frame. This is not set if there is no parent.
+         * Optional.
+         */
+        parentDocumentId?: string;
 
         /**
          * True for private browsing requests.
@@ -1325,6 +1421,18 @@ export namespace WebRequest {
          * ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists.
          */
         parentFrameId: number;
+
+        /**
+         * The UUID of the document making the request. This value is not present if the request is a navigation of a frame.
+         * Optional.
+         */
+        documentId?: string;
+
+        /**
+         * The UUID of the parent document owning this frame. This is not set if there is no parent.
+         * Optional.
+         */
+        parentDocumentId?: string;
 
         /**
          * True for private browsing requests.


### PR DESCRIPTION
Major schema changes include:

- New `contextualIdentities` APIs for remembering Firefox-native associations between websites and containers
- The new `publicSuffix` API for identifying domains that are "public suffixes", or domains under which anyone can register their own subdomains (e.g. `com`, `co.uk`, etc.).
- The new *documentId* property across various APIs, used to uniquely identify a document loaded in a tab or frame.
- The new *splitViewId* property for identifying tabs that are part of a split view.
- `userScript.execute()`, for injecting scripts into a specific tab.
- Additional theming type definitions in `manifest`.

---

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
  - smoke-tested against josh-berry/tab-stash (only expected compile errors were seen)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. - no test updates needed
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Lusito/webextension-polyfill-ts/pull/119
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.