### PR TITLE
[luxon] Export validity helper types from the barrel

### DIFF
--- a/types/luxon/src/luxon.d.ts
+++ b/types/luxon/src/luxon.d.ts
@@ -1,5 +1,7 @@
 export const VERSION: string;
 
+export type { CanBeInvalid, DefaultValidity, IfValid, Invalid, Valid } from "./_util";
+
 export * from "./datetime";
 export * from "./duration";
 export * from "./info";

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -1103,11 +1103,12 @@ function Interval_isValidNarrowsFactoryResult() {
     interval.toISO(); // $ExpectType "Invalid Interval"
 }
 
-function Validity_helperTypes() {
-    const canBeInvalid: CanBeInvalid = true;
-    const valid = DateTime.now() as DateTime<Valid>;
-    const invalid = DateTime.fromISO("nope") as DateTime<Invalid>;
-    const maybeValid = DateTime.now() as DateTime<DefaultValidity>;
+function Validity_helperTypes(
+    canBeInvalid: CanBeInvalid,
+    valid: DateTime<Valid>,
+    invalid: DateTime<Invalid>,
+    maybeValid: DateTime<DefaultValidity>,
+) {
     const start: IfValid<DateTime<Valid>, null, DefaultValidity> = Interval.fromISO("2016-05-25/2016-05-27").start;
 
     canBeInvalid; // $ExpectType true

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -1,12 +1,17 @@
 import {
+    CanBeInvalid,
     DateTime,
+    DefaultValidity,
     Duration,
     FixedOffsetZone,
     IANAZone,
+    IfValid,
     Info,
     Interval,
+    Invalid,
     Settings,
     SystemZone,
+    Valid,
     VERSION,
     Zone,
     ZoneOffsetFormat,
@@ -1096,4 +1101,18 @@ function Interval_isValidNarrowsFactoryResult() {
 
     interval; // $ExpectType Interval<false>
     interval.toISO(); // $ExpectType "Invalid Interval"
+}
+
+function Validity_helperTypes() {
+    const canBeInvalid: CanBeInvalid = true;
+    const valid = DateTime.now() as DateTime<Valid>;
+    const invalid = DateTime.fromISO("nope") as DateTime<Invalid>;
+    const maybeValid = DateTime.now() as DateTime<DefaultValidity>;
+    const start: IfValid<DateTime<Valid>, null, DefaultValidity> = Interval.fromISO("2016-05-25/2016-05-27").start;
+
+    canBeInvalid; // $ExpectType true
+    valid.toISO(); // $ExpectType string
+    invalid.toISO(); // $ExpectType null
+    maybeValid.toISO(); // $ExpectType string | null
+    start?.toISO(); // $ExpectType string | undefined
 }


### PR DESCRIPTION
`Valid`, `Invalid` and `DefaultValidity` are the type arguments of the exported `DateTime<IsValid>`, `Interval<IsValid>` and `Duration<IsValid>` generics, but they live in `src/_util.d.ts`, which the barrel never re-exported. Until 3.7.0 you could still reach them through `luxon/src/_util`; the `exports` map added in #73292 closed that path, so there is now no way to name them.

This re-exports the five validity helpers from `src/luxon.d.ts`. Doing it that way keeps the `exports` map (and the `arethetypeswrong` fix) untouched, and doesn't expose the rest of the internals the way adding `"./src/*"` would.

Fixes #75462

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/luxon/src/_util.d.ts
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
