### PR TITLE
[n3] add hashCode method to Term classes

### DIFF
--- a/types/n3/index.d.ts
+++ b/types/n3/index.d.ts
@@ -18,6 +18,7 @@ export class NamedNode<Iri extends string = string> implements RDF.NamedNode<Iri
     readonly id: string;
     toJSON(): {};
     equals(other: RDF.Term): boolean;
+    hashCode(): number;
     static subclass(type: any): void;
 }
 
@@ -29,6 +30,7 @@ export class BlankNode implements RDF.BlankNode {
     readonly id: string;
     toJSON(): {};
     equals(other: RDF.Term): boolean;
+    hashCode(): number;
     static subclass(type: any): void;
 }
 
@@ -39,6 +41,7 @@ export class Variable implements RDF.Variable {
     readonly id: string;
     toJSON(): {};
     equals(other: RDF.Term): boolean;
+    hashCode(): number;
     static subclass(type: any): void;
 }
 
@@ -49,6 +52,7 @@ export class Literal implements RDF.Literal {
     readonly id: string;
     toJSON(): {};
     equals(other: RDF.Term): boolean;
+    hashCode(): number;
     static subclass(type: any): void;
     readonly language: string;
     readonly datatype: NamedNode;
@@ -63,6 +67,7 @@ export class DefaultGraph implements RDF.DefaultGraph {
     readonly id: string;
     toJSON(): {};
     equals(other: RDF.Term): boolean;
+    hashCode(): number;
     static subclass(type: any): void;
 }
 
@@ -86,6 +91,7 @@ export class BaseQuad implements RDF.BaseQuad {
     readonly object: Term;
     readonly graph: Term;
     equals(other: RDF.BaseQuad): boolean;
+    hashCode(): number;
     toJSON(): string;
 }
 

--- a/types/n3/n3-tests.ts
+++ b/types/n3/n3-tests.ts
@@ -638,5 +638,10 @@ function test_get_rules_from_dataset() {
     const rules: N3.Rule[] = N3.getRulesFromDataset(store);
 }
 
+function test_term_hash_code() {
+    const node: N3.NamedNode = N3.DataFactory.namedNode("http://example.org/");
+    const hash: number = node.hashCode();
+}
+
 export const namedNode: ReturnType<RDF.DataFactory["namedNode"]> = N3.DataFactory.namedNode("hello world");
 export const df: RDF.DataFactory = N3.DataFactory;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rdfjs/N3.js/blob/main/src/N3DataFactory.js#L52
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---

**What this PR does:**

Adds `hashCode(): number` method declaration to N3's term classes (`NamedNode`, `BlankNode`, `Variable`, `Literal`, `DefaultGraph`, and `BaseQuad`).

In N3.js (`src/N3DataFactory.js`, line 52), the base `Term` class defines `hashCode() { return 0; }` for compatibility with the Immutable.js `ValueObject` interface. Since `@types/n3` represents terms via individual concrete class declarations rather than a shared base class, `hashCode(): number` is declared across each term class.
