### PR TITLE
fix(node/v24): update fs and fs/promises to Node v24.20

### DIFF
--- a/types/node/v24/buffer.buffer.d.ts
+++ b/types/node/v24/buffer.buffer.d.ts
@@ -463,6 +463,11 @@ declare module "buffer" {
          */
         type AllowSharedBuffer = Buffer<ArrayBufferLike>;
     }
+    /**
+     * @deprecated This is intended for internal use, and will be removed once `@types/node` no longer supports
+     * TypeScript versions earlier than 5.7.
+     */
+    type BufferView<T extends NodeJS.ArrayBufferView> = T extends NodeJS.ArrayBufferView<infer B> ? Buffer<B> : never;
     /** @deprecated Use `Buffer.allocUnsafeSlow()` instead. */
     var SlowBuffer: {
         /** @deprecated Use `Buffer.allocUnsafeSlow()` instead. */

--- a/types/node/v24/fs.d.ts
+++ b/types/node/v24/fs.d.ts
@@ -3594,10 +3594,12 @@ declare module "fs" {
      */
     export function unwatchFile(filename: PathLike, listener?: StatsListener): void;
     export function unwatchFile(filename: PathLike, listener?: BigIntStatsListener): void;
+    export type WatchIgnorePredicate = string | RegExp | ((filename: string) => boolean);
     export interface WatchOptions extends Abortable {
         encoding?: BufferEncoding | "buffer" | undefined;
         persistent?: boolean | undefined;
         recursive?: boolean | undefined;
+        ignore?: WatchIgnorePredicate | readonly WatchIgnorePredicate[] | undefined;
     }
     export interface WatchOptionsWithBufferEncoding extends WatchOptions {
         encoding: "buffer";

--- a/types/node/v24/fs.d.ts
+++ b/types/node/v24/fs.d.ts
@@ -19,7 +19,7 @@
  * @see [source](https://github.com/nodejs/node/blob/v24.x/lib/fs.js)
  */
 declare module "fs" {
-    import { NonSharedBuffer } from "node:buffer";
+    import { BufferView, NonSharedBuffer } from "node:buffer";
     import * as stream from "node:stream";
     import { Abortable, EventEmitter } from "node:events";
     import { URL } from "node:url";
@@ -147,6 +147,8 @@ declare module "fs" {
         bavail: T;
         /** Total file nodes in file system. */
         files: T;
+        /** Fundamental file system block size. */
+        frsize: T;
         /** Free file nodes in file system. */
         ffree: T;
     }
@@ -1180,6 +1182,7 @@ declare module "fs" {
         options:
             | (StatOptions & {
                 bigint?: false | undefined;
+                throwIfNoEntry?: true | undefined;
             })
             | undefined,
         callback: (err: NodeJS.ErrnoException | null, stats: Stats) => void,
@@ -1188,32 +1191,80 @@ declare module "fs" {
         path: PathLike,
         options: StatOptions & {
             bigint: true;
+            throwIfNoEntry?: true | undefined;
         },
         callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats) => void,
     ): void;
     export function stat(
         path: PathLike,
-        options: StatOptions | undefined,
+        options: StatOptions & {
+            bigint?: false | undefined;
+            throwIfNoEntry: false;
+        },
+        callback: (err: NodeJS.ErrnoException | null, stats: Stats | undefined) => void,
+    ): void;
+    export function stat(
+        path: PathLike,
+        options: StatOptions & {
+            bigint: true;
+            throwIfNoEntry: false;
+        },
+        callback: (err: NodeJS.ErrnoException | null, stats: BigIntStats | undefined) => void,
+    ): void;
+    export function stat(
+        path: PathLike,
+        options: StatOptions & {
+            throwIfNoEntry?: true | undefined;
+        },
         callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats) => void,
     ): void;
+    export function stat(
+        path: PathLike,
+        options: StatOptions | undefined,
+        callback: (err: NodeJS.ErrnoException | null, stats: Stats | BigIntStats | undefined) => void,
+    ): void;
     export namespace stat {
+        // TODO: aliased promisify signatures
         /**
          * Asynchronous stat(2) - Get file status.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
+        function __promisify__(path: PathLike): Promise<Stats>;
         function __promisify__(
             path: PathLike,
             options?: StatOptions & {
                 bigint?: false | undefined;
+                throwIfNoEntry?: true | undefined;
             },
         ): Promise<Stats>;
         function __promisify__(
             path: PathLike,
             options: StatOptions & {
                 bigint: true;
+                throwIfNoEntry?: true | undefined;
             },
         ): Promise<BigIntStats>;
-        function __promisify__(path: PathLike, options?: StatOptions): Promise<Stats | BigIntStats>;
+        function __promisify__(
+            path: PathLike,
+            options: StatOptions & {
+                bigint?: false | undefined;
+                throwIfNoEntry: false;
+            },
+        ): Promise<Stats | undefined>;
+        function __promisify__(
+            path: PathLike,
+            options: StatOptions & {
+                bigint: true;
+                throwIfNoEntry: false;
+            },
+        ): Promise<BigIntStats | undefined>;
+        function __promisify__(
+            path: PathLike,
+            options: StatOptions & {
+                throwIfNoEntry?: true | undefined;
+            },
+        ): Promise<Stats | BigIntStats>;
+        function __promisify__(path: PathLike, options?: StatOptions): Promise<Stats | BigIntStats | undefined>;
     }
     export interface StatSyncFn extends Function {
         (path: PathLike, options?: undefined): Stats;
@@ -2965,6 +3016,19 @@ declare module "fs" {
      * If no `options` object is specified, it will default with the above values.
      */
     export function readSync(fd: number, buffer: NodeJS.ArrayBufferView, opts?: ReadOptions): number;
+    export interface ReadFileOptions extends Abortable {
+        encoding?: BufferEncoding | null | undefined;
+        flag?: OpenMode | undefined;
+    }
+    export interface ReadFileOptionsWithStringEncoding extends ReadFileOptions {
+        encoding: BufferEncoding;
+    }
+    export interface ReadFileOptionsWithBufferEncoding extends ReadFileOptions {
+        encoding?: null | undefined;
+    }
+    export interface ReadFileOptionsWithBuffer<T extends NodeJS.ArrayBufferView> extends ReadFileOptionsWithBufferEncoding {
+        buffer: T | ((size: number) => T);
+    }
     /**
      * Asynchronously reads the entire contents of a file.
      *
@@ -3031,15 +3095,14 @@ declare module "fs" {
      * @since v0.1.29
      * @param path filename or file descriptor
      */
+    export function readFile<T extends NodeJS.ArrayBufferView>(
+        path: PathOrFileDescriptor,
+        options: ReadFileOptionsWithBuffer<T>,
+        callback: (err: NodeJS.ErrnoException | null, data: BufferView<T>) => void,
+    ): void;
     export function readFile(
         path: PathOrFileDescriptor,
-        options:
-            | ({
-                encoding?: null | undefined;
-                flag?: string | undefined;
-            } & Abortable)
-            | undefined
-            | null,
+        options: ReadFileOptionsWithBufferEncoding | null | undefined,
         callback: (err: NodeJS.ErrnoException | null, data: NonSharedBuffer) => void,
     ): void;
     /**
@@ -3051,12 +3114,7 @@ declare module "fs" {
      */
     export function readFile(
         path: PathOrFileDescriptor,
-        options:
-            | ({
-                encoding: BufferEncoding;
-                flag?: string | undefined;
-            } & Abortable)
-            | BufferEncoding,
+        options: ReadFileOptionsWithStringEncoding | BufferEncoding,
         callback: (err: NodeJS.ErrnoException | null, data: string) => void,
     ): void;
     /**
@@ -3068,13 +3126,7 @@ declare module "fs" {
      */
     export function readFile(
         path: PathOrFileDescriptor,
-        options:
-            | (ObjectEncodingOptions & {
-                flag?: string | undefined;
-            } & Abortable)
-            | BufferEncoding
-            | undefined
-            | null,
+        options: ReadFileOptions | BufferEncoding | null | undefined,
         callback: (err: NodeJS.ErrnoException | null, data: string | NonSharedBuffer) => void,
     ): void;
     /**
@@ -3136,6 +3188,21 @@ declare module "fs" {
                 | null,
         ): Promise<string | NonSharedBuffer>;
     }
+    export interface ReadFileSyncOptions {
+        encoding?: BufferEncoding | null | undefined;
+        flag?: OpenMode | undefined;
+    }
+    export interface ReadFileSyncOptionsWithStringEncoding extends ReadFileSyncOptions {
+        encoding: BufferEncoding;
+    }
+    export interface ReadFileSyncOptionsWithBufferEncoding extends ReadFileSyncOptions {
+        encoding?: null | undefined;
+    }
+    export interface ReadFileSyncOptionsWithBuffer<T extends NodeJS.ArrayBufferView>
+        extends ReadFileSyncOptionsWithBufferEncoding
+    {
+        buffer: T | ((size: number) => T);
+    }
     /**
      * Returns the contents of the `path`.
      *
@@ -3160,12 +3227,13 @@ declare module "fs" {
      * @since v0.1.8
      * @param path filename or file descriptor
      */
+    export function readFileSync<T extends NodeJS.ArrayBufferView>(
+        path: PathOrFileDescriptor,
+        options: ReadFileSyncOptionsWithBuffer<T>,
+    ): BufferView<T>;
     export function readFileSync(
         path: PathOrFileDescriptor,
-        options?: {
-            encoding?: null | undefined;
-            flag?: string | undefined;
-        } | null,
+        options?: ReadFileSyncOptionsWithBufferEncoding | null,
     ): NonSharedBuffer;
     /**
      * Synchronously reads the entire contents of a file.
@@ -3176,12 +3244,7 @@ declare module "fs" {
      */
     export function readFileSync(
         path: PathOrFileDescriptor,
-        options:
-            | {
-                encoding: BufferEncoding;
-                flag?: string | undefined;
-            }
-            | BufferEncoding,
+        options: ReadFileSyncOptionsWithStringEncoding | BufferEncoding,
     ): string;
     /**
      * Synchronously reads the entire contents of a file.
@@ -3190,15 +3253,7 @@ declare module "fs" {
      * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
      * If a flag is not provided, it defaults to `'r'`.
      */
-    export function readFileSync(
-        path: PathOrFileDescriptor,
-        options?:
-            | (ObjectEncodingOptions & {
-                flag?: string | undefined;
-            })
-            | BufferEncoding
-            | null,
-    ): string | NonSharedBuffer;
+    export function readFileSync(path: PathOrFileDescriptor, options: ReadFileSyncOptions): string | NonSharedBuffer;
     export type WriteFileOptions =
         | (
             & ObjectEncodingOptions
@@ -4521,11 +4576,11 @@ declare module "fs" {
         bigint: true;
     }
     export interface StatOptions {
+        // TODO: add signal option once we sort its behavior out upstream
         bigint?: boolean | undefined;
-    }
-    export interface StatSyncOptions extends StatOptions {
         throwIfNoEntry?: boolean | undefined;
     }
+    export interface StatSyncOptions extends StatOptions {}
     interface CopyOptionsBase {
         /**
          * Dereference symlinks
@@ -4638,6 +4693,12 @@ declare module "fs" {
          * @default undefined
          */
         exclude?: ((fileName: T) => boolean) | readonly string[] | undefined;
+        /**
+         * When `true`, symbolic links to directories are
+         * followed while expanding `**` patterns.
+         * @default false
+         */
+        followSymlinks?: boolean | undefined;
     }
     export interface GlobOptions extends _GlobOptions<Dirent | string> {}
     export interface GlobOptionsWithFileTypes extends _GlobOptions<Dirent> {

--- a/types/node/v24/fs.d.ts
+++ b/types/node/v24/fs.d.ts
@@ -3026,7 +3026,9 @@ declare module "fs" {
     export interface ReadFileOptionsWithBufferEncoding extends ReadFileOptions {
         encoding?: null | undefined;
     }
-    export interface ReadFileOptionsWithBuffer<T extends NodeJS.ArrayBufferView> extends ReadFileOptionsWithBufferEncoding {
+    export interface ReadFileOptionsWithBuffer<T extends NodeJS.ArrayBufferView>
+        extends ReadFileOptionsWithBufferEncoding
+    {
         buffer: T | ((size: number) => T);
     }
     /**

--- a/types/node/v24/fs/promises.d.ts
+++ b/types/node/v24/fs/promises.d.ts
@@ -9,7 +9,7 @@
  * @since v10.0.0
  */
 declare module "fs/promises" {
-    import { NonSharedBuffer } from "node:buffer";
+    import { BufferView, NonSharedBuffer } from "node:buffer";
     import { Abortable } from "node:events";
     import { Stream } from "node:stream";
     import { ReadableStream } from "node:stream/web";
@@ -31,6 +31,10 @@ declare module "fs/promises" {
         OpenDirOptions,
         OpenMode,
         PathLike,
+        ReadFileOptions,
+        ReadFileOptionsWithBuffer,
+        ReadFileOptionsWithBufferEncoding,
+        ReadFileOptionsWithStringEncoding,
         ReadOptions,
         ReadOptionsWithBuffer,
         ReadPosition,
@@ -290,30 +294,20 @@ declare module "fs/promises" {
          * @return Fulfills upon a successful read with the contents of the file. If no encoding is specified (using `options.encoding`), the data is returned as a {Buffer} object. Otherwise, the
          * data will be a string.
          */
-        readFile(
-            options?:
-                | ({ encoding?: null | undefined } & Abortable)
-                | null,
-        ): Promise<NonSharedBuffer>;
+        readFile<T extends NodeJS.ArrayBufferView>(
+            options: Omit<ReadFileOptionsWithBuffer<T>, "flag">,
+        ): Promise<BufferView<T>>;
+        readFile(options?: Omit<ReadFileOptionsWithBufferEncoding, "flag"> | null): Promise<NonSharedBuffer>;
         /**
          * Asynchronously reads the entire contents of a file. The underlying file will _not_ be closed automatically.
          * The `FileHandle` must have been opened for reading.
          */
-        readFile(
-            options:
-                | ({ encoding: BufferEncoding } & Abortable)
-                | BufferEncoding,
-        ): Promise<string>;
+        readFile(options: Omit<ReadFileOptionsWithStringEncoding, "flag"> | BufferEncoding): Promise<string>;
         /**
          * Asynchronously reads the entire contents of a file. The underlying file will _not_ be closed automatically.
          * The `FileHandle` must have been opened for reading.
          */
-        readFile(
-            options?:
-                | (ObjectEncodingOptions & Abortable)
-                | BufferEncoding
-                | null,
-        ): Promise<string | NonSharedBuffer>;
+        readFile(options: Omit<ReadFileOptions, "flag"> | BufferEncoding | null): Promise<string | NonSharedBuffer>;
         /**
          * Convenience method to create a `readline` interface and stream over the file.
          * See `filehandle.createReadStream()` for the options.
@@ -821,19 +815,42 @@ declare module "fs/promises" {
      * @since v10.0.0
      * @return Fulfills with the {fs.Stats} object for the given `path`.
      */
+    function stat(path: PathLike): Promise<Stats>;
     function stat(
         path: PathLike,
         opts?: StatOptions & {
             bigint?: false | undefined;
+            throwIfNoEntry?: true | undefined;
         },
     ): Promise<Stats>;
     function stat(
         path: PathLike,
         opts: StatOptions & {
             bigint: true;
+            throwIfNoEntry?: true | undefined;
         },
     ): Promise<BigIntStats>;
-    function stat(path: PathLike, opts?: StatOptions): Promise<Stats | BigIntStats>;
+    function stat(
+        path: PathLike,
+        opts: StatOptions & {
+            bigint?: false | undefined;
+            throwIfNoEntry: false;
+        },
+    ): Promise<Stats | undefined>;
+    function stat(
+        path: PathLike,
+        opts: StatOptions & {
+            bigint: true;
+            throwIfNoEntry: false;
+        },
+    ): Promise<BigIntStats | undefined>;
+    function stat(
+        path: PathLike,
+        opts: StatOptions & {
+            throwIfNoEntry?: true | undefined;
+        },
+    ): Promise<Stats | BigIntStats>;
+    function stat(path: PathLike, opts?: StatOptions): Promise<Stats | BigIntStats | undefined>;
     /**
      * @since v19.6.0, v18.15.0
      * @return Fulfills with the {fs.StatFs} object for the given `path`.
@@ -1172,14 +1189,13 @@ declare module "fs/promises" {
      * @param path filename or `FileHandle`
      * @return Fulfills with the contents of the file.
      */
+    function readFile<T extends NodeJS.ArrayBufferView>(
+        path: PathLike | FileHandle,
+        options: ReadFileOptionsWithBuffer<T>,
+    ): Promise<BufferView<T>>;
     function readFile(
         path: PathLike | FileHandle,
-        options?:
-            | ({
-                encoding?: null | undefined;
-                flag?: OpenMode | undefined;
-            } & Abortable)
-            | null,
+        options?: ReadFileOptionsWithBufferEncoding | null,
     ): Promise<NonSharedBuffer>;
     /**
      * Asynchronously reads the entire contents of a file.
@@ -1190,12 +1206,7 @@ declare module "fs/promises" {
      */
     function readFile(
         path: PathLike | FileHandle,
-        options:
-            | ({
-                encoding: BufferEncoding;
-                flag?: OpenMode | undefined;
-            } & Abortable)
-            | BufferEncoding,
+        options: ReadFileOptionsWithStringEncoding | BufferEncoding,
     ): Promise<string>;
     /**
      * Asynchronously reads the entire contents of a file.
@@ -1206,16 +1217,7 @@ declare module "fs/promises" {
      */
     function readFile(
         path: PathLike | FileHandle,
-        options?:
-            | (
-                & ObjectEncodingOptions
-                & Abortable
-                & {
-                    flag?: OpenMode | undefined;
-                }
-            )
-            | BufferEncoding
-            | null,
+        options: ReadFileOptions | BufferEncoding | null,
     ): Promise<string | NonSharedBuffer>;
     /**
      * Asynchronously open a directory for iterative scanning. See the POSIX [`opendir(3)`](http://man7.org/linux/man-pages/man3/opendir.3.html) documentation for more detail.

--- a/types/node/v24/test/fs.ts
+++ b/types/node/v24/test/fs.ts
@@ -269,11 +269,20 @@ async function testPromisify() {
         persistent: true,
         encoding: "utf8",
         signal: new AbortSignal(),
+        ignore: ["**/node_modules/**", /\.log$/, (filename) => filename.startsWith(".")],
     }, (event, filename) => {
         console.log(event, filename);
     });
 
     fsWatcher.unref().ref().close();
+
+    fs.watch("/tmp/foo-", { ignore: "**/dist/**" });
+    fs.watch("/tmp/foo-", { ignore: /^\.git$/ });
+    fs.watch("/tmp/foo-", { ignore: (filename) => filename === "secret.txt" });
+
+    const ignorePatterns: fs.WatchIgnorePredicate[] = ["**/dist/**", /^\.git$/];
+    // $ExpectType FSWatcher
+    fs.watch("/tmp/foo-", { ignore: ignorePatterns });
 }
 
 {
@@ -1042,7 +1051,16 @@ const anyStatFs: fs.StatsFs | fs.BigIntStatsFs = fs.statfsSync(".", { bigint: Ma
     // $ExpectType AsyncIterator<FileChangeInfo<NonSharedBuffer>, undefined, any>
     watchAsync("y33t", { encoding: "buffer", signal: new AbortSignal() });
     // $ExpectType AsyncIterator<FileChangeInfo<string>, undefined, any>
-    watchAsync("test", { persistent: true, recursive: true, encoding: "utf-8", maxQueue: 2048, overflow: "ignore" });
+    watchAsync("test", {
+        persistent: true,
+        recursive: true,
+        encoding: "utf-8",
+        maxQueue: 2048,
+        overflow: "ignore",
+        ignore: ["**/node_modules/**", (filename) => filename.startsWith(".")],
+    });
+    // $ExpectType AsyncIterator<FileChangeInfo<NonSharedBuffer>, undefined, any>
+    watchAsync("test", { encoding: "buffer", ignore: /\.log$/ });
 }
 
 {

--- a/types/node/v24/test/fs.ts
+++ b/types/node/v24/test/fs.ts
@@ -84,6 +84,11 @@ import { CopyOptions, CopySyncOptions, cp, cpSync, glob, globSync } from "fs";
 
     buffer = fs.readFileSync("testfile", { flag: "r" });
 
+    const syncBuf = fs.readFileSync("testfile", { buffer: new Uint8Array(16) });
+    syncBuf; // $ExpectType Buffer || Buffer<ArrayBuffer>
+    const syncBufFromFn = fs.readFileSync("testfile", { buffer: (size) => new Uint8Array(size) });
+    syncBufFromFn; // $ExpectType Buffer || Buffer<ArrayBuffer>
+
     fs.readFile("testfile", "utf8", (err, data) => content = data);
     // @ts-expect-error
     fs.readFile("testfile", "invalid encoding", (err, data) => content = data);
@@ -100,6 +105,19 @@ import { CopyOptions, CopySyncOptions, cp, cpSync, glob, globSync } from "fs";
     fs.readFile("testfile", { encoding: nullEncoding }, (err, data) => stringOrBuffer = data);
 
     fs.readFile("testfile", { flag: "r" }, (err, data) => buffer = data);
+
+    fs.readFile("testfile", { buffer: new Uint8Array(16) }, (err, data) => {
+        data; // $ExpectType Buffer || Buffer<ArrayBuffer>
+    });
+    fs.readFile("testfile", { buffer: new Uint8Array(new SharedArrayBuffer(16)) }, (err, data) => {
+        data; // $ExpectType Buffer || Buffer<SharedArrayBuffer>
+    });
+    fs.readFile("testfile", { buffer }, (err, data) => {
+        data; // $ExpectType Buffer || Buffer<ArrayBufferLike>
+    });
+    fs.readFile("testfile", { buffer: (size) => new Uint8Array(size) }, (err, data) => {
+        data; // $ExpectType Buffer || Buffer<ArrayBuffer>
+    });
 }
 
 {
@@ -821,8 +839,8 @@ async function testStat(
     path: string,
     fd: number,
     opts: fs.StatOptions,
-    bigintMaybeFalse: fs.StatOptions & { bigint: false } | undefined,
-    bigIntMaybeTrue: fs.StatOptions & { bigint: true } | undefined,
+    bigintMaybeFalse: { bigint: false } | undefined,
+    bigIntMaybeTrue: { bigint: true } | undefined,
     maybe?: fs.StatOptions,
 ) {
     /* Need to test these variants:
@@ -872,7 +890,7 @@ async function testStat(
     fs.fstat(fd, { bigint: true }, (err, st: fs.BigIntStats) => {});
 
     fs.stat(path, bigIntMaybeTrue, (err, st) => {
-        st; // $ExpectType Stats | BigIntStats
+        st; // $ExpectType Stats | BigIntStats | undefined
     });
     fs.lstat(path, bigIntMaybeTrue, (err, st) => {
         st; // $ExpectType Stats | BigIntStats
@@ -882,7 +900,7 @@ async function testStat(
     });
 
     fs.stat(path, opts, (err, st) => {
-        st; // $ExpectType Stats | BigIntStats
+        st; // $ExpectType Stats | BigIntStats | undefined
     });
 
     fs.lstat(path, opts, (err, st) => {
@@ -949,11 +967,11 @@ async function testStat(
     util.promisify(fs.lstat)(path, { bigint: true }); // $ExpectType Promise<BigIntStats>
     util.promisify(fs.fstat)(fd, { bigint: true }); // $ExpectType Promise<BigIntStats>
 
-    util.promisify(fs.stat)(path, bigIntMaybeTrue); // $ExpectType Promise<Stats | BigIntStats>
+    util.promisify(fs.stat)(path, bigIntMaybeTrue); // $ExpectType Promise<Stats | BigIntStats | undefined>
     util.promisify(fs.lstat)(path, bigIntMaybeTrue); // $ExpectType Promise<Stats | BigIntStats>
     util.promisify(fs.fstat)(fd, bigIntMaybeTrue); // $ExpectType Promise<Stats | BigIntStats>
 
-    util.promisify(fs.stat)(path, opts); // $ExpectType Promise<Stats | BigIntStats>
+    util.promisify(fs.stat)(path, opts); // $ExpectType Promise<Stats | BigIntStats | undefined>
     util.promisify(fs.lstat)(path, opts); // $ExpectType Promise<Stats | BigIntStats>
     util.promisify(fs.fstat)(fd, opts); // $ExpectType Promise<Stats | BigIntStats>
 
@@ -979,13 +997,23 @@ async function testStat(
     fs.promises.lstat(path, { bigint: true }); // $ExpectType Promise<BigIntStats>
     fh.stat({ bigint: true }); // $ExpectType Promise<BigIntStats>
 
-    fs.promises.stat(path, bigIntMaybeTrue); // $ExpectType Promise<Stats | BigIntStats>
+    fs.promises.stat(path, bigIntMaybeTrue); // $ExpectType Promise<Stats | BigIntStats | undefined>
     fs.promises.lstat(path, bigIntMaybeTrue); // $ExpectType Promise<Stats | BigIntStats>
     fh.stat(bigIntMaybeTrue); // $ExpectType Promise<Stats | BigIntStats>
 
-    fs.promises.stat(path, opts); // $ExpectType Promise<Stats | BigIntStats>
+    fs.promises.stat(path, opts); // $ExpectType Promise<Stats | BigIntStats | undefined>
     fs.promises.lstat(path, opts); // $ExpectType Promise<Stats | BigIntStats>
     fh.stat(opts); // $ExpectType Promise<Stats | BigIntStats>
+
+    fs.stat(path, { throwIfNoEntry: false }, (err, st) => {
+        st; // $ExpectType Stats | undefined
+    });
+    fs.stat(path, { bigint: true, throwIfNoEntry: false }, (err, st) => {
+        st; // $ExpectType BigIntStats | undefined
+    });
+
+    fs.promises.stat(path, { throwIfNoEntry: false }); // $ExpectType Promise<Stats | undefined>
+    fs.promises.stat(path, { bigint: true, throwIfNoEntry: false }); // $ExpectType Promise<BigIntStats | undefined>
 }
 
 const bigStats: fs.BigIntStats = fs.statSync(".", { bigint: true });
@@ -1041,7 +1069,9 @@ async function testStatfs(
 
 const bigStatFs: fs.BigIntStatsFs = fs.statfsSync(".", { bigint: true });
 const bigIntStatFs: bigint = bigStatFs.bfree;
+const bigIntStatFsFrsize: bigint = bigStatFs.frsize;
 const anyStatFs: fs.StatsFs | fs.BigIntStatsFs = fs.statfsSync(".", { bigint: Math.random() > 0.5 });
+const statFsFrsize: number = fs.statfsSync(".").frsize;
 
 {
     // $ExpectType AsyncIterator<FileChangeInfo<string>, undefined, any>
@@ -1131,6 +1161,9 @@ const anyStatFs: fs.StatsFs | fs.BigIntStatsFs = fs.statfsSync(".", { bigint: Ma
     for await (const entry of globAsync("**/*.js", { withFileTypes: Math.random() > 0.5 })) {
         entry; // $ExpectType Dirent<string> | string
     }
+    for await (const entry of globAsync("**/*.js", { followSymlinks: true })) {
+        entry; // $ExpectType string
+    }
 
     for await (
         const entry of globAsync("**/*.js", {
@@ -1169,6 +1202,9 @@ const anyStatFs: fs.StatsFs | fs.BigIntStatsFs = fs.statfsSync(".", { bigint: Ma
         matches; // $ExpectType string[]
     });
     glob("**/*.js", { cwd: new URL("") }, (err, matches) => {
+        matches; // $ExpectType string[]
+    });
+    glob("**/*.js", { cwd: new URL(""), followSymlinks: true }, (err, matches) => {
         matches; // $ExpectType string[]
     });
     glob("**/*.js", { withFileTypes: true }, (err, matches) => {
@@ -1222,6 +1258,7 @@ const anyStatFs: fs.StatsFs | fs.BigIntStatsFs = fs.statfsSync(".", { bigint: Ma
 
     globSync("**/*.js"); // $ExpectType string[]
     globSync("**/*.js", { cwd: "/" }); // $ExpectType string[]
+    globSync("**/*.js", { cwd: "/", followSymlinks: true }); // $ExpectType string[]
     globSync("**/*.js", { withFileTypes: true }); // $ExpectType Dirent<string>[]
     globSync("**/*.js", { withFileTypes: Math.random() > 0.5 }); // $ExpectType string[] | Dirent<string>[]
 
@@ -1265,6 +1302,12 @@ const anyStatFs: fs.StatsFs | fs.BigIntStatsFs = fs.statfsSync(".", { bigint: Ma
     fd.readFile({ signal: new AbortSignal(), encoding: "utf-8" });
     // @ts-expect-error
     fd.readFile({ encoding: "utf-8", flag: "r" });
+
+    await fd.readFile({ buffer: new Uint8Array(256) }); // $ExpectType Buffer || Buffer<ArrayBuffer>
+    await fd.readFile({ buffer: (size) => new Uint8Array(size) }); // $ExpectType Buffer || Buffer<ArrayBuffer>
+
+    await fs.promises.readFile("/tmp/tmp.txt", { buffer: new Uint8Array(256) }); // $ExpectType Buffer || Buffer<ArrayBuffer>
+    await fs.promises.readFile("/tmp/tmp.txt", { buffer: (size) => new Uint8Array(size) }); // $ExpectType Buffer || Buffer<ArrayBuffer>
 });
 
 {

--- a/types/node/v24/ts5.6/buffer.buffer.d.ts
+++ b/types/node/v24/ts5.6/buffer.buffer.d.ts
@@ -459,6 +459,11 @@ declare module "buffer" {
          */
         type AllowSharedBuffer = Buffer;
     }
+    /**
+     * @deprecated This is intended for internal use, and will be removed once `@types/node` no longer supports
+     * TypeScript versions earlier than 5.7.
+     */
+    type BufferView<T extends NodeJS.ArrayBufferView> = Buffer;
     /** @deprecated Use `Buffer.allocUnsafeSlow()` instead. */
     var SlowBuffer: {
         /** @deprecated Use `Buffer.allocUnsafeSlow()` instead. */


### PR DESCRIPTION
## Package in scope

`@types/node` — the `v24` snapshot only (`types/node/v24`). `types/node` (v26) and `types/node/v25` already ship all of these APIs.

## What changes

Brings `types/node/v24`'s `fs` and `fs/promises` modules up to date with the Node.js v24.20 API surface:

- `fs.watch()`: `ignore` option (v24.14, [nodejs/node#61433](https://github.com/nodejs/node/pull/61433)) — new `WatchIgnorePredicate` type plus `WatchOptions.ignore`; `fsPromises.watch()` inherits it via `_WatchOptions`.
- `fs.stat()` / `fs.promises.stat()`: `throwIfNoEntry` option (v24.15, [nodejs/node#61178](https://github.com/nodejs/node/pull/61178)). `StatOptions` gains the field (previously only on `StatSyncOptions`), and the async overloads now return `Stats | undefined` / `BigIntStats | undefined` when it is set to `false`.
- `fs.statfs()` family: `frsize` on `StatsFs` / `BigIntStatsFs` (v24.16, [nodejs/node#62277](https://github.com/nodejs/node/pull/62277)).
- `fs.glob()` / `fs.globSync()` / `fsPromises.glob()`: `followSymlinks` option (v24.16, [nodejs/node#62695](https://github.com/nodejs/node/pull/62695)).
- `fs.readFile()` / `fs.readFileSync()` / `fsPromises.readFile()` / `filehandle.readFile()`: `buffer` option accepting a pre-allocated view or a `(size) => buffer` factory (v24.19, [nodejs/node#63634](https://github.com/nodejs/node/pull/63634)). Returns `BufferView<T>`, which required adding the `BufferView` type to `buffer.buffer.d.ts` (including the TS 5.6 fallback).

`stat`'s `signal` option is intentionally not typed: in v24.20 the implementation only exists on callback `fs.stat()` while the docs also mention it on `filehandle.stat()`. `types/node` carries a TODO on `StatOptions` to revisit this once upstream sorts the behavior out, and this PR mirrors that decision.

## Why v24 is missing these

`types/node/v24` was cut while `types/node` tracked Node 24.13 (`types/node/v24/package.json` is still `24.13.9999`). Every API above landed on the v24 line after that cut, and the `vNN/` snapshots don't pick up new APIs automatically.

## Tests

`types/node/v24/test/fs.ts` covers:

- all four accepted `ignore` shapes (glob string, `RegExp`, predicate, array) for `fs.watch()`, plus two `fsPromises.watch()` cases;
- `throwIfNoEntry` for `fs.stat()` and `fs.promises.stat()` (return-type widening for the `false` case), with existing `statSync`/`lstatSync` expectations kept;
- `frsize` on both `StatsFs` variants;
- `followSymlinks` for `fs.glob()` / `fs.globSync()` / `fsPromises.glob()`;
- the `buffer` option for all four `readFile` variants (pre-allocated `Uint8Array`, `SharedArrayBuffer`-backed, `Buffer`, and factory function).

## Notes for reviewers

- `types/node/v24/package.json` version is intentionally left at `24.13.9999`: bumping that marker is what the periodic `node: v24.x` PRs do, together with the full multi-module sync.
- All changes are ports of the declarations already in `types/node` (v26), adjusted to the v24.20 API surface.
- Verified locally with `pnpm run lint types/node/v24` (dtslint, TS 5.6 – 6.0) and `dprint fmt`; leaving the authoritative run to CI.

Context for the suggested changes:

- https://nodejs.org/docs/latest-v24.x/api/fs.html
- https://github.com/nodejs/node/pull/61433
- https://github.com/nodejs/node/pull/61178
- https://github.com/nodejs/node/pull/62277
- https://github.com/nodejs/node/pull/62695
- https://github.com/nodejs/node/pull/63634

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/docs/latest-v24.x/api/fs.html
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`. (intentionally not bumped; see notes above)
