### PR TITLE
chrome: Add global `browser` alias

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -11,7 +11,19 @@ type SetPartial<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 ////////////////////
 interface Window {
     chrome: typeof chrome;
+
+    /**
+     * Cross-browser alias of {@link chrome}.
+     * @since Chrome 148 (Chrome 152 for extensions declaring a `devtools_page` in manifest)
+     */
+    browser: typeof chrome;
 }
+
+/**
+ * Cross-browser alias of {@link chrome}.
+ * @since Chrome 148 (Chrome 152 for extensions declaring a `devtools_page` in manifest)
+ */
+declare var browser: typeof chrome;
 
 declare namespace chrome {
     ////////////////////

--- a/types/chrome/package.json
+++ b/types/chrome/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/chrome",
-    "version": "0.2.9999",
+    "version": "0.3.9999",
     "nonNpm": "conflict",
     "nonNpmDescription": "The complete reference to all APIs made available to Chrome Extensions",
     "projects": [

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -8478,3 +8478,12 @@ function testWallpaper() {
     // @ts-expect-error
     chrome.wallpaper.setWallpaper(details, () => {}).then(() => {});
 }
+
+async function testBrowser() {
+    const _b: typeof browser = chrome;
+    const _c: typeof chrome = browser;
+
+    browser.tabs.create({ url: "https://example.test" }); // $ExpectType Promise<void>
+    window.browser.tabs.create({ url: "https://example.test" }); // $ExpectType Promise<void>
+    globalThis.browser.tabs.create({ url: "https://example.test" }); // $ExpectType Promise<void>
+}


### PR DESCRIPTION
As of Chrome 148, the `browser` namespace is a native, drop-in replacement for the `chrome` namespace (see https://developer.chrome.com/docs/extensions/develop/concepts/browser-namespace).

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/develop/concepts/browser-namespace
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
  * Package version doesn't seem to reflect any specific Chrome version and doesn't appear to be casually incremented like that? Not sure how this works, hoping a reviewer can tell me if I'm supposed to update this value.