### PR TITLE
[auto-generated] Improve gorilla-engine API documentation

### DIFF
--- a/types/gorilla-engine/components/DragContainer.d.ts
+++ b/types/gorilla-engine/components/DragContainer.d.ts
@@ -1,19 +1,30 @@
 declare namespace GorillaEngine.UI {
+    /** Properties for a source in an internal or operating-system drag operation. */
     interface DragContainerProps extends Common, Bounds, Clickable {
+        /** Group used to match this source with compatible drag targets. */
         dragGroup: string;
+        /** Data made available to an internal drag target. */
         dragContent: string;
+        /** Name of the action invoked when an external drag starts. */
         externalDragStartAction: string;
+        /** Name of the action invoked when an external drag ends. */
         externalDragEndAction: string;
+        /** Whether an external destination may move, rather than only copy, dragged files. */
         destinationCanMoveDraggedFiles: boolean;
+        /** File paths supplied to an external drag operation. */
         externallyDraggedFiles: any;
+        /** Name of the action invoked while a drag operation is in progress. */
         onDragging: string;
+        /** Name of the action invoked when an external drag starts. */
         onExternalDragStart: string;
+        /** Name of the action invoked when an external drag ends. */
         onExternalDragEnd: string;
     }
 
     // tslint:disable-next-line:no-empty-interface
     interface DragContainer extends DragContainerProps {}
 
+    /** A component that provides data or files for drag-and-drop operations. */
     class DragContainer extends Component {
         constructor(options: Partial<DragContainerProps>);
     }

--- a/types/gorilla-engine/components/DragTarget.d.ts
+++ b/types/gorilla-engine/components/DragTarget.d.ts
@@ -1,9 +1,13 @@
 declare namespace GorillaEngine.UI {
+    /** Properties for a target that receives internal drag operations. */
     interface DragTargetProps extends Common, Bounds, Clickable {
+        /** Group of drag sources accepted by this target. */
         dragGroup: string;
+        /** Name of the action invoked when compatible content is dropped. */
         onDrop: string;
     }
 
+    /** A component that receives content from a compatible drag container. */
     class DragTarget extends Component {
         constructor(options: Partial<DragTargetProps>);
     }

--- a/types/gorilla-engine/components/DropZone.d.ts
+++ b/types/gorilla-engine/components/DropZone.d.ts
@@ -1,13 +1,21 @@
 declare namespace GorillaEngine.UI {
+    /** Properties for a target that receives files from the operating system. */
     interface DropZoneProps extends Common, Bounds, Clickable {
+        /**
+         * File patterns accepted by the drop zone, such as `"*.wav"`.
+         * Include `"*"` to accept every file type.
+         */
         acceptedFileTypes: string[] | string;
+        /** Name of the action invoked when files are dragged over the component. */
         onDraggedFiles: string;
+        /** Name of the action invoked when a file is dropped. */
         onDroppedFile: string;
     }
 
     // tslint:disable-next-line:no-empty-interface
     interface DropZone extends DropZoneProps {}
 
+    /** A component that accepts files dragged from the operating system. */
     class DropZone extends Component {
         constructor(options: Partial<DropZoneProps>);
     }

--- a/types/gorilla-engine/components/Knob.d.ts
+++ b/types/gorilla-engine/components/Knob.d.ts
@@ -1,7 +1,10 @@
 declare namespace GorillaEngine.UI {
+    /**
+     * Properties for a rotary control that edits a numeric value.
+     */
     interface KnobProps extends Common, Bounds, Clickable, Background, Skinnable, MIDILearn, Highlight {
         /**
-         * The text displayed for component
+         * The text displayed by the control.
          */
         text: string;
         /**
@@ -21,6 +24,9 @@ declare namespace GorillaEngine.UI {
          */
         stepSize: number;
 
+        /**
+         * Whether the control runs from its maximum value to its minimum value.
+         */
         inverted: boolean;
         /**
          * If `true`, the knob's value can be adjusted using the mouse scroll wheel.
@@ -30,7 +36,9 @@ declare namespace GorillaEngine.UI {
          * The path to a single image used for the knob's appearance.
          */
         image: string;
-        /** TODO:: this is rather a slider prop than a knob prop
+        /**
+         * Whether clicking a slider track moves its handle to the pointer position.
+         * This property only affects controls displayed as sliders.
          */
         snapsToMousePosition: boolean;
         /**
@@ -45,6 +53,9 @@ declare namespace GorillaEngine.UI {
 
     // tslint:disable-next-line:no-empty-interface
     interface Knob extends KnobProps {}
+    /**
+     * A rotary control for editing numeric values.
+     */
     class Knob extends Component {
         constructor(options: Partial<KnobProps>);
     }

--- a/types/gorilla-engine/components/Label.d.ts
+++ b/types/gorilla-engine/components/Label.d.ts
@@ -1,4 +1,7 @@
 declare namespace GorillaEngine.UI {
+    /**
+     * Properties for a read-only text label.
+     */
     interface LabelProps extends Common, Bounds, Background, Font, Clickable, Margin, Keyable {
         /**
          * The initial text to display in the label. Doesn't update at runtime.
@@ -8,13 +11,16 @@ declare namespace GorillaEngine.UI {
          * The text to display in the label. Updates at runtime.
          */
         text: string | number;
-        format: string;
+          /** Format string applied to the displayed value. */
+          format: string;
+          /** Whether the label can display multiple lines of text. */
         multiLine: boolean;
+          /** Whether the text is scaled to fit the label's bounds. */
         stretchText: boolean;
     }
 
     /**
-     * Use a Label to...
+      * A read-only control for displaying text or formatted values.
      */
     class Label extends Component {
         constructor(options: Partial<LabelProps>);

--- a/types/gorilla-engine/components/LevelMeter.d.ts
+++ b/types/gorilla-engine/components/LevelMeter.d.ts
@@ -1,4 +1,5 @@
 declare namespace GorillaEngine.UI {
+    /** Properties for a mono or stereo audio level meter. */
     interface LevelMeterProps extends Common, Bounds, Background, Skinnable {
         /**
          * If `true`, the level meter will display and hold the highest peak level reached
@@ -62,13 +63,9 @@ declare namespace GorillaEngine.UI {
          * The thickness of the level meter's indicator.
          */
         indicatorThickness: number;
-        /** TODO::
-         * I have no idea that this does
-         */
+        /** Start of the normalized meter range displayed by the control. */
         visibleSectionStart: number;
-        /** TODO::
-         * I have no idea that this does
-         */
+        /** End of the normalized meter range displayed by the control. */
         visibleSectionEnd: number;
         /**
          * The direction of the level meter. This can be "horizontal" or "vertical".
@@ -87,6 +84,7 @@ declare namespace GorillaEngine.UI {
     // tslint:disable-next-line:no-empty-interface
     interface LevelMeter extends LevelMeterProps {}
 
+    /** A component that displays the current audio signal level. */
     class LevelMeter extends Component {
         constructor(options: Partial<LevelMeterProps>);
     }

--- a/types/gorilla-engine/components/ListBox.d.ts
+++ b/types/gorilla-engine/components/ListBox.d.ts
@@ -9,7 +9,7 @@ declare namespace GorillaEngine.UI {
          */
         horizontalMargin?: number;
         /**
-         * The bakcground color of the items in the list box.
+         * The background color of the items in the list box.
          */
         cellColor?: string;
         /**

--- a/types/gorilla-engine/components/LottieAnimation.d.ts
+++ b/types/gorilla-engine/components/LottieAnimation.d.ts
@@ -1,4 +1,5 @@
 declare namespace GorillaEngine.UI {
+    /** Properties and playback methods for a Lottie animation. */
     interface LottieAnimationProps extends Common, Bounds {
         /**
          * The file path to the Lottie animation JSON file.
@@ -40,13 +41,15 @@ declare namespace GorillaEngine.UI {
          */
         setFrame(frame: number): void;
         /**
-         * TODO:: No idea what this does
-         * @param frame the target frame to set the animation to.
+         * Sets the target frame used by animated controls.
+         * @param frame Target frame between zero and the animation's last frame.
          */
         setTargetFrame(frame: number): void;
         /**
-         * TODO:: No idea what this does
-         * @param frame the target frame to set the animation to.
+         * Maps a value from the supplied range to the animation's frame range and displays that frame.
+         * @param value Value to map.
+         * @param min Lower bound of the value range.
+         * @param max Upper bound of the value range.
          */
         setFrameFromLinearTransform(value: number, min: number, max: number): void;
         setProperties(
@@ -66,6 +69,7 @@ declare namespace GorillaEngine.UI {
         ): void;
     }
 
+    /** A component that renders and controls a Lottie animation. */
     class LottieAnimation extends Component {
         constructor(options: Partial<LottieAnimationProps>);
     }

--- a/types/gorilla-engine/components/Pad.d.ts
+++ b/types/gorilla-engine/components/Pad.d.ts
@@ -5,7 +5,7 @@ declare namespace GorillaEngine.UI {
          */
         midiNote: number;
         /**
-         * The veloctiy of the pad when pressed and not controlled by midi
+         * The velocity sent when the pad is pressed without MIDI input.
          */
         velocity: number;
         /**

--- a/types/gorilla-engine/components/ScrollView.d.ts
+++ b/types/gorilla-engine/components/ScrollView.d.ts
@@ -1,4 +1,5 @@
 declare namespace GorillaEngine.UI {
+    /** Properties and scrolling methods for a viewport containing child components. */
     interface ScrollViewProps extends Common, Bounds, Scrollable {
         /**
          * The thickness of the scrollbar in pixels.
@@ -14,8 +15,8 @@ declare namespace GorillaEngine.UI {
          * @default false
          */
         hideHorizontalScrollbar: boolean;
-        /** TODO:: No idea if this is correct
-         * If true, the scroll view will ignore keypress events.
+        /**
+         * Whether the scroll view declines keyboard input instead of handling it for scrolling.
          * @default false
          */
         ignoreKeypressEvent: boolean;
@@ -32,6 +33,7 @@ declare namespace GorillaEngine.UI {
         setScrollPositionProportionately(xPos: number, yPos: number): void;
     }
 
+    /** A scrollable viewport for child components. */
     class ScrollView extends Component {
         constructor(options: Partial<ScrollViewProps>);
     }

--- a/types/gorilla-engine/components/Slider.d.ts
+++ b/types/gorilla-engine/components/Slider.d.ts
@@ -1,4 +1,7 @@
 declare namespace GorillaEngine.UI {
+    /**
+     * Properties for a numeric control with a handle that moves along a track.
+     */
     interface SliderProps extends KnobProps {
         /**
          * The direction of the slider.
@@ -9,20 +12,21 @@ declare namespace GorillaEngine.UI {
          */
         thumbImage: string;
 
-        /**
-         * TODO:: no idea what this does
-         */
+        /** Bounds of the slider track relative to the control. */
         sliderBounds: {
+            /** Horizontal offset of the track in pixels. */
             x: number;
+            /** Vertical offset of the track in pixels. */
             y: number;
+            /** Width of the track in pixels. */
             width: number;
+            /** Height of the track in pixels. */
             height: number;
         };
     }
 
     /**
-     * Use a slider to
-     * - enable users to control numeric values by dragging up/down or left/right
+     * A control for editing numeric values by dragging horizontally or vertically.
      */
     class Slider extends Component {
         constructor(options: Partial<SliderProps>);

--- a/types/gorilla-engine/components/TextBox.d.ts
+++ b/types/gorilla-engine/components/TextBox.d.ts
@@ -1,4 +1,7 @@
 declare namespace GorillaEngine.UI {
+    /**
+     * Properties for an editable or read-only text field.
+     */
     interface TextBoxProps extends Font, Clickable, Bounds, Background, Margin, Keyable {
         /**
          * The initial text value of the text box.
@@ -8,8 +11,8 @@ declare namespace GorillaEngine.UI {
          * The placeholder text of the text box.
          */
         placeholder: string;
-        /** TODO:: check if it works
-         * An additional suffix displayed in the textbox without alterting the text value.
+        /**
+         * A suffix displayed after the text without changing the text value.
          */
         unit: string;
         /**
@@ -41,8 +44,8 @@ declare namespace GorillaEngine.UI {
          */
         multiLine: boolean;
 
-        /** TODO:: what is even the point of this?
-         * If true, the text box will not allow user input and will be read-only.
+        /**
+         * Whether user input is disabled while the text remains selectable and readable.
          */
         readOnly: boolean;
         /**
@@ -58,10 +61,15 @@ declare namespace GorillaEngine.UI {
          * If acceptedDataType is numeric, this is the maximum value allowed in the text box.
          */
         maxValue: number;
+        /** Zero-based index of the first selected character. */
         highlightStart: number;
+        /** Zero-based index after the last selected character. */
         highlightEnd: number;
+        /** Name of the action invoked when a key is pressed while the text box has focus. */
         keyDownAction: string;
+        /** Name of the action invoked after the user changes the text. */
         textChangedAction: string;
+        /** Whether text changes are committed when the text box loses keyboard focus. */
         focusLostUpdate: boolean;
     }
 
@@ -69,6 +77,9 @@ declare namespace GorillaEngine.UI {
         grabKeyboardFocus(): void;
     }
 
+    /**
+     * A text field for displaying and editing string or numeric input.
+     */
     class TextBox extends Component {
         constructor(props: Partial<TextBoxProps>);
     }

--- a/types/gorilla-engine/components/Trigger.d.ts
+++ b/types/gorilla-engine/components/Trigger.d.ts
@@ -1,16 +1,29 @@
 declare namespace GorillaEngine.UI {
+    /**
+     * Properties for a momentary button that invokes an action when clicked.
+     */
     interface TriggerProps extends Common, Bounds, Font, Clickable, Background, KeyboardFocus, Keyable {
+        /** Text displayed on the button. */
         text: string;
+        /** Whether the button omits its normal pressed-state behavior. */
         isDumb: boolean;
+        /** Images used for the button's interaction states. */
         images: {
+            /** Image displayed in the normal state. */
             normal?: string;
+            /** Image displayed while the pointer is over the button. */
             hover?: string;
+            /** Image displayed while the button is pressed. */
             down?: string;
         };
+        /** Lottie animation associated with the button. */
         animation: LottieAnimation;
     }
     // tslint:disable-next-line:no-empty-interface
     interface Trigger extends TriggerProps {}
+    /**
+     * A momentary button that invokes an action when clicked.
+     */
     class Trigger extends Component {
         constructor(options: Partial<TriggerProps>);
     }

--- a/types/gorilla-engine/gorilla-engine-tests.ts
+++ b/types/gorilla-engine/gorilla-engine-tests.ts
@@ -17,3 +17,8 @@ const slider = new GorillaEngine.UI.Slider({ id: "slider", x: 0, y: 2 });
 const mappingEditor = new GorillaEngine.UI.MappingEditor({ id: "myNewMappingEditor", x: 3, y: 2 });
 
 const levelMeter = new GorillaEngine.UI.LevelMeter({ id: "myLevelMeter", x: 0, y: 2 });
+
+const instrument = GorillaEngine.createEmptyInstrument();
+
+GorillaEngine.loadBlob("/tmp/Test_part1.blob", "0123456789ABCDEF0123456789ABCDEF");
+GorillaEngine.setActiveInstrument(instrument, 2, true);

--- a/types/gorilla-engine/index.d.ts
+++ b/types/gorilla-engine/index.d.ts
@@ -471,11 +471,17 @@ declare namespace GorillaEngine {
     function getManufacturerName(): string;
     function quitApplication(): void;
     /**
-     * Load blob at the specified path
-     * @param blobPath the load blob
-     * @throws if the blob could not be loaded e.g. it is not there or decryption failed
+     * Loads an instrument blob from the file system.
+     *
+     * The returned blob can be used to enumerate and load its instruments. Blob exports
+     * with separate headers must be loaded by passing the path to the first blob part.
+     *
+     * @param blobPath Absolute path to the blob file or the first part of a split blob.
+     * @param encryptionKey Encryption key used to decrypt the blob, when required.
+     * @returns The loaded blob.
+     * @throws If the file cannot be found or decrypted.
      */
-    function loadBlob(blobPath: string): Blob;
+    function loadBlob(blobPath: string, encryptionKey?: string): Blob;
     function getPluginNRTB(enable: boolean): void;
     /**
      * Method updates the list of the automatable parameters note it does not work for all DAWS
@@ -516,12 +522,20 @@ declare namespace GorillaEngine {
     function initialiseSpliceRTO(pluginName?: string): any;
     function disposeInstrument(instrument: Instrument): void;
     /**
-     * Activates an instrument, i.e. route MIDI to the instrument and send Audio from the isntrument to
-     * the DAW. Currently only one instrument can be active. If there was
-     * another instrument active before, it will get deativated.
-     * @param instrument the instrument activate
+     * Activates an instrument for MIDI input and audio output.
+     *
+     * Only one instrument can be active at a time. Activating an instrument deactivates
+     * the previously active instrument.
+     *
+     * @param instrument The instrument to activate.
+     * @param streamBufferSizeSeconds Streaming buffer size in seconds. Omit to keep the current size.
+     * @param waitUntilPreloaded Whether to wait for sample preloading to complete before returning.
      */
-    function setActiveInstrument(instrument: Instrument): void;
+    function setActiveInstrument(
+        instrument: Instrument,
+        streamBufferSizeSeconds?: number,
+        waitUntilPreloaded?: boolean,
+    ): void;
     /**
      * Create an empty dummy instrument. It can be modified with e.g. {@link Instrument.setModuleAtPath}
      * @returns the empty instrument.
@@ -534,8 +548,23 @@ declare namespace GorillaEngine {
      * @returns the instrument
      */
     function LoadInstrumentFromFile(instFilePath: string): Instrument;
-    function setSessionSaveCallback(callback: (state: string) => string, instance: any): void;
-    function setSessionLoadCallback(callback: (state: string) => string, instance: any): void;
+    /**
+     * Registers the callback used to serialize application state when the host saves its session.
+     *
+     * @param callback Called with additional state managed by Gorilla Engine. It must return the
+     * application state to store in the host session.
+     * @param instance Optional object used as `this` when the callback runs.
+     * @returns `true` when the callback was registered.
+     */
+    function setSessionSaveCallback(callback: (state: string) => string, instance?: object): boolean;
+    /**
+     * Registers the callback used to restore application state when the host loads its session.
+     *
+     * @param callback Called with the application state previously returned by the save callback.
+     * @param instance Optional object used as `this` when the callback runs.
+     * @returns `true` when the callback was registered.
+     */
+    function setSessionLoadCallback(callback: (state: string) => string, instance?: object): boolean;
     function setParametersDirty(dirty: boolean): void;
     function areParametersDirty(): boolean;
     /**

--- a/types/gorilla-engine/interfaces/Component.d.ts
+++ b/types/gorilla-engine/interfaces/Component.d.ts
@@ -1,11 +1,19 @@
 declare namespace GorillaEngine.UI {
+    /** Base class for controls in the Gorilla Engine UI component tree. */
     abstract class Component {
+        /** Unique identifier used to look up the component. */
         id: string;
+        /** Components directly contained by this component. */
         children: Component[];
+        /** Component that contains this component. */
         parent: Component;
+        /** Registers a handler for an event emitted by the component. */
         on(event: string, handler: any): void;
+        /** Adds a component after the existing children. */
         appendChild(child: Component): void;
+        /** Removes a direct child component. */
         removeChild(child: Component): void;
+        /** Inserts a component immediately before another direct child. */
         insertBefore(child: Component, beforeChild: Component): void;
     }
 }

--- a/types/gorilla-engine/interfaces/KeyboardFocus.d.ts
+++ b/types/gorilla-engine/interfaces/KeyboardFocus.d.ts
@@ -1,7 +1,6 @@
 declare namespace GorillaEngine.UI {
     /**
-     * KeyboardFocus interface for Gorilla Engine UI.
-     * Defines how a cotrol appears when it has the keyboard focus
+    * Defines how a control appears when it has keyboard focus.
      */
     interface KeyboardFocus {
         keyboardFocus: {


### PR DESCRIPTION
Updates the existing `@types/gorilla-engine` declarations and JSDoc using the Gorilla Engine JavaScript bindings and integration tests as implementation references.

Changes include:
- document core runtime APIs and UI controls
- expose implementation-supported optional arguments for `loadBlob` and `setActiveInstrument`
- correct session callback return values and optional context arguments
- add declaration tests for encrypted blob loading and active-instrument options

Source/project context: https://gorilla-engine.com

Validation: `pnpm test gorilla-engine` passes with dtslint 0.2.47.