### PR TITLE
[react-dom] Update server-rendering options 

### DIFF
--- a/types/react-dom/server.browser.d.ts
+++ b/types/react-dom/server.browser.d.ts
@@ -1,1 +1,1 @@
-export { renderToReadableStream, renderToStaticMarkup, renderToString } from "./server";
+export { renderToReadableStream, renderToStaticMarkup, renderToString, resume, version } from "./server";

--- a/types/react-dom/server.bun.d.ts
+++ b/types/react-dom/server.bun.d.ts
@@ -1,1 +1,9 @@
-export { renderToReadableStream, renderToStaticMarkup, renderToString } from "./server";
+export {
+    renderToPipeableStream,
+    renderToReadableStream,
+    renderToStaticMarkup,
+    renderToString,
+    resume,
+    resumeToPipeableStream,
+    version,
+} from "./server";

--- a/types/react-dom/server.d.ts
+++ b/types/react-dom/server.d.ts
@@ -34,9 +34,10 @@ export interface BootstrapScriptDescriptor {
 /**
  * The header content passed to `onHeaders` by `renderToPipeableStream`.
  * Other server rendering APIs pass a `Headers` instance instead.
+ * React passes an empty object when there are no resource hints to send.
  */
 export interface HeadersDescriptor {
-    Link?: string | undefined;
+    Link?: string;
 }
 
 /**
@@ -80,7 +81,7 @@ export interface ReactImportMap {
 export interface RenderToPipeableStreamOptions {
     identifierPrefix?: string;
     namespaceURI?: string;
-    nonce?: NonceOption;
+    nonce?: NonceOption | undefined;
     bootstrapScriptContent?: string;
     bootstrapScripts?: Array<string | BootstrapScriptDescriptor>;
     bootstrapModules?: Array<string | BootstrapScriptDescriptor>;
@@ -143,7 +144,7 @@ export interface RenderToReadableStreamOptions {
     identifierPrefix?: string;
     importMap?: ReactImportMap | undefined;
     namespaceURI?: string;
-    nonce?: NonceOption;
+    nonce?: NonceOption | undefined;
     bootstrapScriptContent?: string;
     bootstrapScripts?: Array<string | BootstrapScriptDescriptor>;
     bootstrapModules?: Array<string | BootstrapScriptDescriptor>;
@@ -177,11 +178,11 @@ export function renderToReadableStream(
 export { ResumeOptions };
 
 export interface ResumeToPipeableStreamOptions {
-    nonce?: NonceOption;
-    onShellReady?: () => void;
-    onShellError?: (error: unknown) => void;
-    onAllReady?: () => void;
-    onError?: (error: unknown, errorInfo: ErrorInfo) => string | void;
+    nonce?: NonceOption | undefined;
+    onShellReady?: (() => void) | undefined;
+    onShellError?: ((error: unknown) => void) | undefined;
+    onAllReady?: (() => void) | undefined;
+    onError?: ((error: unknown, errorInfo: ErrorInfo) => string | void) | undefined;
 }
 
 /**

--- a/types/react-dom/server.d.ts
+++ b/types/react-dom/server.d.ts
@@ -32,6 +32,24 @@ export interface BootstrapScriptDescriptor {
 }
 
 /**
+ * The header content passed to `onHeaders` by `renderToPipeableStream`.
+ * Other server rendering APIs pass a `Headers` instance instead.
+ */
+export interface HeadersDescriptor {
+    Link?: string | undefined;
+}
+
+/**
+ * A nonce string, or an object with separate nonces for scripts and styles.
+ */
+export type NonceOption =
+    | string
+    | {
+        script?: string | undefined;
+        style?: string | undefined;
+    };
+
+/**
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap Import maps}
  */
 // TODO: Ideally TypeScripts standard library would include this type.
@@ -62,7 +80,7 @@ export interface ReactImportMap {
 export interface RenderToPipeableStreamOptions {
     identifierPrefix?: string;
     namespaceURI?: string;
-    nonce?: string;
+    nonce?: NonceOption;
     bootstrapScriptContent?: string;
     bootstrapScripts?: Array<string | BootstrapScriptDescriptor>;
     bootstrapModules?: Array<string | BootstrapScriptDescriptor>;
@@ -71,10 +89,10 @@ export interface RenderToPipeableStreamOptions {
      * Must be a positive integer if specified.
      * @default 2000
      */
-    headersLengthHint?: number | undefined;
+    maxHeadersLength?: number | undefined;
     importMap?: ReactImportMap | undefined;
     progressiveChunkSize?: number;
-    onHeaders?: ((headers: Headers) => void) | undefined;
+    onHeaders?: ((headers: HeadersDescriptor) => void) | undefined;
     onShellReady?: () => void;
     onShellError?: (error: unknown) => void;
     onAllReady?: () => void;
@@ -125,7 +143,7 @@ export interface RenderToReadableStreamOptions {
     identifierPrefix?: string;
     importMap?: ReactImportMap | undefined;
     namespaceURI?: string;
-    nonce?: string;
+    nonce?: NonceOption;
     bootstrapScriptContent?: string;
     bootstrapScripts?: Array<string | BootstrapScriptDescriptor>;
     bootstrapModules?: Array<string | BootstrapScriptDescriptor>;
@@ -134,7 +152,7 @@ export interface RenderToReadableStreamOptions {
      * Must be a positive integer if specified.
      * @default 2000
      */
-    headersLengthHint?: number | undefined;
+    maxHeadersLength?: number | undefined;
     progressiveChunkSize?: number;
     signal?: AbortSignal;
     onError?: (error: unknown, errorInfo: ErrorInfo) => string | void;
@@ -158,6 +176,14 @@ export function renderToReadableStream(
 
 export { ResumeOptions };
 
+export interface ResumeToPipeableStreamOptions {
+    nonce?: NonceOption;
+    onShellReady?: () => void;
+    onShellError?: (error: unknown) => void;
+    onAllReady?: () => void;
+    onError?: (error: unknown, errorInfo: ErrorInfo) => string | void;
+}
+
 /**
  * @see {@link https://react.dev/reference/react-dom/server/resume `resume`` reference documentation}
  * @version 19.2
@@ -175,7 +201,7 @@ export function resume(
 export function resumeToPipeableStream(
     children: React.ReactNode,
     postponedState: PostponedState,
-    options?: ResumeOptions,
+    options?: ResumeToPipeableStreamOptions,
 ): Promise<PipeableStream>;
 
 export const version: string;

--- a/types/react-dom/server.edge.d.ts
+++ b/types/react-dom/server.edge.d.ts
@@ -1,1 +1,1 @@
-export { renderToReadableStream, renderToStaticMarkup, renderToString, resume } from "./server";
+export { renderToReadableStream, renderToStaticMarkup, renderToString, resume, version } from "./server";

--- a/types/react-dom/server.node.d.ts
+++ b/types/react-dom/server.node.d.ts
@@ -5,4 +5,5 @@ export {
     renderToString,
     resume,
     resumeToPipeableStream,
+    version,
 } from "./server";

--- a/types/react-dom/static.browser.d.ts
+++ b/types/react-dom/static.browser.d.ts
@@ -1,1 +1,1 @@
-export { prerender, version } from "./static";
+export { prerender, resumeAndPrerender, version } from "./static";

--- a/types/react-dom/static.d.ts
+++ b/types/react-dom/static.d.ts
@@ -72,6 +72,16 @@ export interface BootstrapScriptDescriptor {
     crossOrigin?: string | undefined;
 }
 
+/**
+ * A nonce string, or an object with separate nonces for scripts and styles.
+ */
+export type NonceOption =
+    | string
+    | {
+        script?: string | undefined;
+        style?: string | undefined;
+    };
+
 export interface PrerenderOptions {
     bootstrapScriptContent?: string;
     bootstrapScripts?: Array<string | BootstrapScriptDescriptor>;
@@ -81,12 +91,12 @@ export interface PrerenderOptions {
      * Must be a positive integer if specified.
      * @default 2000
      */
-    headersLengthHint?: number | undefined;
+    maxHeadersLength?: number | undefined;
     identifierPrefix?: string;
     importMap?: ReactImportMap | undefined;
     namespaceURI?: string;
     onError?: (error: unknown, errorInfo: ErrorInfo) => string | void;
-    onHeaders?: (headers: Headers) => void | undefined;
+    onHeaders?: ((headers: Headers) => void) | undefined;
     progressiveChunkSize?: number;
     signal?: AbortSignal;
 }
@@ -125,7 +135,7 @@ export function prerenderToNodeStream(
 ): Promise<PrerenderToNodeStreamResult>;
 
 export interface ResumeOptions {
-    nonce?: string;
+    nonce?: NonceOption;
     signal?: AbortSignal;
     onError?: (error: unknown) => string | undefined | void;
 }

--- a/types/react-dom/static.d.ts
+++ b/types/react-dom/static.d.ts
@@ -135,7 +135,7 @@ export function prerenderToNodeStream(
 ): Promise<PrerenderToNodeStreamResult>;
 
 export interface ResumeOptions {
-    nonce?: NonceOption;
+    nonce?: NonceOption | undefined;
     signal?: AbortSignal;
     onError?: (error: unknown) => string | undefined | void;
 }

--- a/types/react-dom/test/react-dom-tests.tsx
+++ b/types/react-dom/test/react-dom-tests.tsx
@@ -108,13 +108,36 @@ describe("ReactDOMStatic", () => {
             (await ReactDOMStatic.prerenderToNodeStream(React.createElement("div"))).prelude;
         ReactDOMStatic.prerenderToNodeStream(React.createElement("div"), {
             bootstrapScripts: ["./my-script.js"],
-            headersLengthHint: 4000,
+            maxHeadersLength: 4000,
             importMap,
             onHeaders(headers) {
                 // $ExpectType Headers
                 headers;
             },
         });
+    });
+
+    it("resumeToPipeableStream", async () => {
+        const { postponed } = await ReactDOMStatic.prerenderToNodeStream(children);
+        if (postponed !== null) {
+            ReactDOMServer.resumeToPipeableStream(children, postponed, {
+                nonce: { script: "script-nonce", style: "style-nonce" },
+                onShellReady() {},
+                onShellError(error) {
+                    console.error(error);
+                },
+                onAllReady() {},
+                onError(error, errorInfo) {
+                    // $ExpectType ErrorInfo
+                    errorInfo;
+                    return (error as { digest?: string | undefined }).digest;
+                },
+            });
+            ReactDOMServer.resumeToPipeableStream(children, postponed, {
+                // @ts-expect-error The Node.js stream variant does not support an abort signal
+                signal: new AbortController().signal,
+            });
+        }
     });
 });
 
@@ -254,10 +277,10 @@ function pipeableStreamDocumentedExample() {
     const response: Response = {} as any;
     const { pipe, abort } = ReactDOMServer.renderToPipeableStream(<App />, {
         bootstrapScripts: ["/main.js"],
-        headersLengthHint: 4000,
+        maxHeadersLength: 4000,
         importMap,
         onHeaders(headers) {
-            // $ExpectType Headers
+            // $ExpectType HeadersDescriptor
             headers;
         },
         onShellReady() {
@@ -307,10 +330,10 @@ function pipeableStreamDocumentedStringExample() {
     const response: Response = {} as any;
     const { pipe, abort } = ReactDOMServer.renderToPipeableStream("app", {
         bootstrapScripts: ["/main.js"],
-        headersLengthHint: 4000,
+        maxHeadersLength: 4000,
         importMap,
         onHeaders(headers) {
-            // $ExpectType Headers
+            // $ExpectType HeadersDescriptor
             headers;
         },
         onShellReady() {
@@ -354,7 +377,7 @@ async function readableStreamDocumentedExample() {
                 <body>Success</body>
             </html>,
             {
-                headersLengthHint: 4000,
+                maxHeadersLength: 4000,
                 importMap,
                 signal: controller.signal,
                 onError(error) {
@@ -392,7 +415,7 @@ async function readableStreamDocumentedStringExample() {
         const stream = await ReactDOMServer.renderToReadableStream(
             "app",
             {
-                headersLengthHint: 4000,
+                maxHeadersLength: 4000,
                 importMap,
                 signal: controller.signal,
                 onError(error) {


### PR DESCRIPTION
This aligns the `react-dom/server` and `react-dom/static` entrypoints to match the runtime tpyes.

The `headersLengthHint` option is renamed to `maxHeadersLength`. `headersLengthHint` was never published to stable.

The `nonce` option now also accepts an object with `script` and `style` properties for separate script and style nonces.

`onHeaders` no longer gets `Headers` (which is a Web type) and instead gets a custom `HeadersDescriptor`.

`resumeToPipeableStream` gets its own options type without the unsupported `signal` option and with the previously missing `onShellReady`, `onShellError`, and `onAllReady` callbacks. 


The platform entry files now re-export the `version` constant and the `resume` and pipeable stream functions that the published `server.browser`, `server.bun`, `server.edge`, `server.node`, and `static.browser` bundles contain.
