### PR TITLE
[chrome] fix chrome.devtools.inspectedWindow.eval()

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -2902,20 +2902,35 @@ declare namespace chrome {
             injectedScript?: string | undefined;
         }
 
-        interface EvaluationExceptionInfo {
-            /** Set if the error occurred on the DevTools side before the expression is evaluated. */
-            isError: boolean;
-            /** Set if the error occurred on the DevTools side before the expression is evaluated. */
-            code: string;
-            /** Set if the error occurred on the DevTools side before the expression is evaluated. */
-            description: string;
-            /** Set if the error occurred on the DevTools side before the expression is evaluated, contains the array of the values that may be substituted into the description string to provide more information about the cause of the error. */
-            details: any[];
-            /** Set if the evaluated code produces an unhandled exception. */
-            isException: boolean;
-            /** Set if the evaluated code produces an unhandled exception. */
-            value: string;
-        }
+        type EvaluationExceptionInfo =
+            | {
+                /** Set if the error occurred on the DevTools side before the expression is evaluated. */
+                isError: true;
+                /** Set if the error occurred on the DevTools side before the expression is evaluated. */
+                code: string;
+                /** Set if the error occurred on the DevTools side before the expression is evaluated. */
+                description: string;
+                /** Set if the error occurred on the DevTools side before the expression is evaluated, contains the array of the values that may be substituted into the description string to provide more information about the cause of the error. */
+                details: any[];
+                /** Set if the evaluated code produces an unhandled exception. */
+                isException?: undefined;
+                /** Set if the evaluated code produces an unhandled exception. */
+                value?: undefined;
+            }
+            | {
+                /** Set if the error occurred on the DevTools side before the expression is evaluated. */
+                isError?: undefined;
+                /** Set if the error occurred on the DevTools side before the expression is evaluated. */
+                code?: undefined;
+                /** Set if the error occurred on the DevTools side before the expression is evaluated. */
+                description?: undefined;
+                /** Set if the error occurred on the DevTools side before the expression is evaluated, contains the array of the values that may be substituted into the description string to provide more information about the cause of the error. */
+                details?: undefined;
+                /** Set if the evaluated code produces an unhandled exception. */
+                isException: true;
+                /** Set if the evaluated code produces an unhandled exception. */
+                value: string;
+            };
 
         /** The ID of the tab being inspected. This ID may be used with {@link chrome.tabs} API. */
         const tabId: number;
@@ -2935,15 +2950,23 @@ declare namespace chrome {
         function eval<T = { [key: string]: unknown }>(
             expression: string,
             options?: EvalOptions,
-        ): Promise<{ result: T; exceptionInfo: EvaluationExceptionInfo }>;
+        ): Promise<T>;
         function eval<T = { [key: string]: unknown }>(
             expression: string,
-            callback?: (result: T, exceptionInfo: EvaluationExceptionInfo) => void,
+            callback: (
+                ...args:
+                    | [result: T, exceptionInfo: undefined]
+                    | [result: undefined, exceptionInfo: EvaluationExceptionInfo]
+            ) => void,
         ): void;
         function eval<T = { [key: string]: unknown }>(
             expression: string,
             options: EvalOptions | undefined,
-            callback?: (result: T, exceptionInfo: EvaluationExceptionInfo) => void,
+            callback: (
+                ...args:
+                    | [result: T, exceptionInfo: undefined]
+                    | [result: undefined, exceptionInfo: EvaluationExceptionInfo]
+            ) => void,
         ): void;
 
         /**

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -2904,7 +2904,13 @@ declare namespace chrome {
 
         type EvaluationExceptionInfo =
             | {
-                /** Set if the error occurred on the DevTools side before the expression is evaluated. */
+                /**
+                 * Set if the error occurred on the DevTools side before the expression is evaluated.
+                 *
+                 * If `isError` is set to true, a DevTools-side error has occurred, and `code` is set to an error code.
+                 *
+                 * See the docs on `isException` for more details on parsing this object.
+                 */
                 isError: true;
                 /** Set if the error occurred on the DevTools side before the expression is evaluated. */
                 code: string;
@@ -2912,13 +2918,25 @@ declare namespace chrome {
                 description: string;
                 /** Set if the error occurred on the DevTools side before the expression is evaluated, contains the array of the values that may be substituted into the description string to provide more information about the cause of the error. */
                 details: any[];
-                /** Set if the evaluated code produces an unhandled exception. */
+                /**
+                 * Set if the evaluated code produces an unhandled exception.
+                 *
+                 * If `isException` is non-null but not true, and `isError` is true, a DevTools-side error has occurred, and `code` is set to an error code.
+                 *
+                 * If `isException` is set to true, a JavaScript error has occurred, and `value` is set to the string value of the thrown object.
+                 */
                 isException?: undefined;
                 /** Set if the evaluated code produces an unhandled exception. */
                 value?: undefined;
             }
             | {
-                /** Set if the error occurred on the DevTools side before the expression is evaluated. */
+                /**
+                 * Set if the error occurred on the DevTools side before the expression is evaluated.
+                 *
+                 * If `isError` is set to true, a DevTools-side error has occurred, and `code` is set to an error code.
+                 *
+                 * See the docs on `isException` for more details on parsing this object.
+                 */
                 isError?: undefined;
                 /** Set if the error occurred on the DevTools side before the expression is evaluated. */
                 code?: undefined;
@@ -2926,7 +2944,13 @@ declare namespace chrome {
                 description?: undefined;
                 /** Set if the error occurred on the DevTools side before the expression is evaluated, contains the array of the values that may be substituted into the description string to provide more information about the cause of the error. */
                 details?: undefined;
-                /** Set if the evaluated code produces an unhandled exception. */
+                /**
+                 * Set if the evaluated code produces an unhandled exception.
+                 *
+                 * If `isException` is non-null but not true, and `isError` is true, a DevTools-side error has occurred, and `code` is set to an error code.
+                 *
+                 * If `isException` is set to true, a JavaScript error has occurred, and `value` is set to the string value of the thrown object.
+                 */
                 isException: true;
                 /** Set if the evaluated code produces an unhandled exception. */
                 value: string;

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1988,7 +1988,7 @@ function testDevtoolsPanels() {
 
 // https://developer.chrome.com/docs/extensions/reference/api/devtools/inspectedWindow
 function testDevtoolsInspectedWindow() {
-    const expression = "expression";
+    const expression = "typeof jQuery !== 'undefined'";
 
     const evalOptions: chrome.devtools.inspectedWindow.EvalOptions = {
         frameURL: "https://example.com",
@@ -1996,23 +1996,44 @@ function testDevtoolsInspectedWindow() {
         useContentScriptContext: true,
     };
 
-    chrome.devtools.inspectedWindow.eval(expression); // $ExpectType Promise<{ result: { [key: string]: unknown; }; exceptionInfo: EvaluationExceptionInfo}>
-    chrome.devtools.inspectedWindow.eval(expression, evalOptions); // $ExpectType Promise<{ result: { [key: string]: unknown; }; exceptionInfo: EvaluationExceptionInfo}>
+    chrome.devtools.inspectedWindow.eval(expression); // $ExpectType Promise<{ [key: string]: unknown; }>
+    chrome.devtools.inspectedWindow.eval(expression, evalOptions); // $ExpectType Promise<{ [key: string]: unknown; }>
     chrome.devtools.inspectedWindow.eval(expression, evalOptions, (result, exceptionInfo) => { // $ExpectType void
-        result; // $ExpectType { [key: string]: unknown; }
+        result; // $ExpectType { [key: string]: unknown; } | undefined
+        exceptionInfo; // $ExpectType EvaluationExceptionInfo | undefined
 
-        exceptionInfo.code; // $ExpectType string
-        exceptionInfo.description; // $ExpectType string
-        exceptionInfo.details; // $ExpectType any[]
-        exceptionInfo.isError; // $ExpectType boolean
-        exceptionInfo.isException; // $ExpectType boolean
-        exceptionInfo.value; // $ExpectType string
+        if (result) {
+            exceptionInfo; // $ExpectType undefined
+        }
+
+        if (exceptionInfo) {
+            result; // $ExpectType undefined
+
+            if (exceptionInfo.isException) {
+                exceptionInfo.code; // $ExpectType undefined
+                exceptionInfo.description; // $ExpectType undefined
+                exceptionInfo.details; // $ExpectType undefined
+                exceptionInfo.isError; // $ExpectType undefined
+                exceptionInfo.isException; // $ExpectType true
+                exceptionInfo.value; // $ExpectType string
+            } else {
+                exceptionInfo.code; // $ExpectType string
+                exceptionInfo.description; // $ExpectType string
+                exceptionInfo.details; // $ExpectType any[]
+                exceptionInfo.isError; // $ExpectType true
+                exceptionInfo.isException; // $ExpectType undefined
+                exceptionInfo.value; // $ExpectType undefined
+            }
+        }
     });
     chrome.devtools.inspectedWindow.eval(expression, (result, exceptionInfo) => { // $ExpectType void
-        result; // $ExpectType { [key: string]: unknown; }
+        result; // $ExpectType { [key: string]: unknown; } | undefined
+        exceptionInfo; // $ExpectType EvaluationExceptionInfo | undefined
     });
-    chrome.devtools.inspectedWindow.eval<{ title: string }>(expression, evalOptions, (result) => { // $ExpectType void
-        result.title; // $ExpectType string
+    chrome.devtools.inspectedWindow.eval<{ title: string }>(expression, evalOptions, (result, _) => { // $ExpectType void
+        if (result) {
+            result.title; // $ExpectType string
+        }
     });
 
     chrome.devtools.inspectedWindow.getResources(); // $ExpectType Promise<Resource[]>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Notes:
- fix `eval()`: return `result` in promise or throw error 
  
  <img width="597" height="60" alt="image" src="https://github.com/user-attachments/assets/0c0390d3-3799-4a85-869a-8e36ef1c44ca" />

- update `eval()`: strengthen the type au `callback` function :
  - return `result` **OR** `exceptionInfo`
  
    🚨Disclaimer: this requires providing the second parameter to benefit from the discriminant (which isn't necessarily a bad thing, as it encourages checking that the function completed successfully).
     
    <img width="835" height="332" alt="image" src="https://github.com/user-attachments/assets/e2ed3f39-198c-43ac-a1ea-744f3802b9d4" />


  - `exceptionInfo` return `error` **OR** `exception`
    
    <img width="1052" height="380" alt="image" src="https://github.com/user-attachments/assets/055dd6af-eaec-4479-88bd-ef589ddf11e3" />
