### PR TITLE
fix(node): expose ReadableWritablePair as a global

### DIFF
--- a/types/node/node-tests/globals-non-dom.ts
+++ b/types/node/node-tests/globals-non-dom.ts
@@ -69,3 +69,9 @@
         }
     })();
 }
+
+{
+    const transform: ReadableWritablePair<string, string> = new TransformStream<string, string>();
+    const piped = new ReadableStream<string>().pipeThrough(transform); // $ExpectType ReadableStream<string>
+    void piped;
+}

--- a/types/node/v22/stream/web.d.ts
+++ b/types/node/v22/stream/web.d.ts
@@ -16,6 +16,8 @@ type _ReadableStreamDefaultController<R = any> = typeof globalThis extends { onm
     : import("stream/web").ReadableStreamDefaultController<R>;
 type _ReadableStreamDefaultReader<R = any> = typeof globalThis extends { onmessage: any } ? {}
     : import("stream/web").ReadableStreamDefaultReader<R>;
+type _ReadableWritablePair<R = any, W = any> = typeof globalThis extends { onmessage: any } ? {}
+    : import("stream/web").ReadableWritablePair<R, W>;
 type _TextDecoderStream = typeof globalThis extends { onmessage: any } ? {}
     : import("stream/web").TextDecoderStream;
 type _TextEncoderStream = typeof globalThis extends { onmessage: any } ? {}
@@ -500,6 +502,8 @@ declare module "stream/web" {
         var ReadableStreamDefaultReader: typeof globalThis extends
             { onmessage: any; ReadableStreamDefaultReader: infer T } ? T
             : typeof import("stream/web").ReadableStreamDefaultReader;
+
+        interface ReadableWritablePair<R = any, W = any> extends _ReadableWritablePair<R, W> {}
 
         interface TextDecoderStream extends _TextDecoderStream {}
         /**

--- a/types/node/v22/test/globals-non-dom.ts
+++ b/types/node/v22/test/globals-non-dom.ts
@@ -64,3 +64,9 @@
         }
     })();
 }
+
+{
+    const transform: ReadableWritablePair<string, string> = new TransformStream<string, string>();
+    const piped = new ReadableStream<string>().pipeThrough(transform); // $ExpectType ReadableStream<string>
+    void piped;
+}

--- a/types/node/v24/stream/web.d.ts
+++ b/types/node/v24/stream/web.d.ts
@@ -16,6 +16,8 @@ type _ReadableStreamDefaultController<R = any> = typeof globalThis extends { onm
     : import("stream/web").ReadableStreamDefaultController<R>;
 type _ReadableStreamDefaultReader<R = any> = typeof globalThis extends { onmessage: any } ? {}
     : import("stream/web").ReadableStreamDefaultReader<R>;
+type _ReadableWritablePair<R = any, W = any> = typeof globalThis extends { onmessage: any } ? {}
+    : import("stream/web").ReadableWritablePair<R, W>;
 type _TextDecoderStream = typeof globalThis extends { onmessage: any } ? {}
     : import("stream/web").TextDecoderStream;
 type _TextEncoderStream = typeof globalThis extends { onmessage: any } ? {}
@@ -500,6 +502,8 @@ declare module "stream/web" {
         var ReadableStreamDefaultReader: typeof globalThis extends
             { onmessage: any; ReadableStreamDefaultReader: infer T } ? T
             : typeof import("stream/web").ReadableStreamDefaultReader;
+
+        interface ReadableWritablePair<R = any, W = any> extends _ReadableWritablePair<R, W> {}
 
         interface TextDecoderStream extends _TextDecoderStream {}
         /**

--- a/types/node/v24/test/globals-non-dom.ts
+++ b/types/node/v24/test/globals-non-dom.ts
@@ -69,3 +69,9 @@
         }
     })();
 }
+
+{
+    const transform: ReadableWritablePair<string, string> = new TransformStream<string, string>();
+    const piped = new ReadableStream<string>().pipeThrough(transform); // $ExpectType ReadableStream<string>
+    void piped;
+}

--- a/types/node/v25/node-tests/globals-non-dom.ts
+++ b/types/node/v25/node-tests/globals-non-dom.ts
@@ -69,3 +69,9 @@
         }
     })();
 }
+
+{
+    const transform: ReadableWritablePair<string, string> = new TransformStream<string, string>();
+    const piped = new ReadableStream<string>().pipeThrough(transform); // $ExpectType ReadableStream<string>
+    void piped;
+}

--- a/types/node/v25/web-globals/streams.d.ts
+++ b/types/node/v25/web-globals/streams.d.ts
@@ -19,6 +19,8 @@ type _ReadableStreamDefaultController<R = any> = typeof globalThis extends { onm
     : webstreams.ReadableStreamDefaultController<R>;
 type _ReadableStreamDefaultReader<R = any> = typeof globalThis extends { onmessage: any } ? {}
     : webstreams.ReadableStreamDefaultReader<R>;
+type _ReadableWritablePair<R = any, W = any> = typeof globalThis extends { onmessage: any } ? {}
+    : webstreams.ReadableWritablePair<R, W>;
 type _TextDecoderStream = typeof globalThis extends { onmessage: any } ? {} : webstreams.TextDecoderStream;
 type _TextEncoderStream = typeof globalThis extends { onmessage: any } ? {} : webstreams.TextEncoderStream;
 type _TransformStream<I = any, O = any> = typeof globalThis extends { onmessage: any } ? {}
@@ -81,6 +83,8 @@ declare global {
     var ReadableStreamDefaultReader: typeof globalThis extends { onmessage: any; ReadableStreamDefaultReader: infer T }
         ? T
         : typeof webstreams.ReadableStreamDefaultReader;
+
+    interface ReadableWritablePair<R = any, W = any> extends _ReadableWritablePair<R, W> {}
 
     interface TextDecoderStream extends _TextDecoderStream {}
     var TextDecoderStream: typeof globalThis extends { onmessage: any; TextDecoderStream: infer T } ? T

--- a/types/node/web-globals/streams.d.ts
+++ b/types/node/web-globals/streams.d.ts
@@ -19,6 +19,8 @@ type _ReadableStreamDefaultController<R = any> = typeof globalThis extends { onm
     : webstreams.ReadableStreamDefaultController<R>;
 type _ReadableStreamDefaultReader<R = any> = typeof globalThis extends { onmessage: any } ? {}
     : webstreams.ReadableStreamDefaultReader<R>;
+type _ReadableWritablePair<R = any, W = any> = typeof globalThis extends { onmessage: any } ? {}
+    : webstreams.ReadableWritablePair<R, W>;
 type _TextDecoderStream = typeof globalThis extends { onmessage: any } ? {} : webstreams.TextDecoderStream;
 type _TextEncoderStream = typeof globalThis extends { onmessage: any } ? {} : webstreams.TextEncoderStream;
 type _TransformStream<I = any, O = any> = typeof globalThis extends { onmessage: any } ? {}
@@ -81,6 +83,8 @@ declare global {
     var ReadableStreamDefaultReader: typeof globalThis extends { onmessage: any; ReadableStreamDefaultReader: infer T }
         ? T
         : typeof webstreams.ReadableStreamDefaultReader;
+
+    interface ReadableWritablePair<R = any, W = any> extends _ReadableWritablePair<R, W> {}
 
     interface TextDecoderStream extends _TextDecoderStream {}
     var TextDecoderStream: typeof globalThis extends { onmessage: any; TextDecoderStream: infer T } ? T


### PR DESCRIPTION
`ReadableStream` is a global, and its `pipeThrough` is typed as `pipeThrough<T>(transform: ReadableWritablePair<T, R>)`, but the pair type itself was only reachable via `node:stream/web`. That leaves the argument type of a global method unnameable without a module import, and library authors who reference it as a bare global get `TS2304` -- or, under `skipLibCheck`, a silent `any` for everything read off the value, with no diagnostic at all.

`lib.dom`, `@types/web`, `@cloudflare/workers-types`, `bun-types` and Deno all declare it globally, so Node is the only environment where referencing it breaks.

Follows the existing pattern for type-only stream dictionaries, which already exposes `QueuingStrategy` this way in the same block.

Applied to every maintained major: 26.x, v25, v24 and v22. The global block lives in `web-globals/streams.d.ts` on 26.x and v25, but in `stream/web.d.ts` on v24 and v22.

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://streams.spec.whatwg.org/#dictdef-readablewritablepair

