### PR TITLE
[pg] Add pipeline mode controls

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -289,6 +289,9 @@ export class ClientBase extends events.EventEmitter {
 
     getTransactionStatus(): TransactionStatus;
 
+    isIdle(): boolean;
+    waitForIdle(): Promise<void>;
+
     on<E extends "connect" | "drain" | "error" | "notice" | "notification" | "end">(
         event: E,
         listener: E extends "connect" | "drain" | "end" ? () => void
@@ -305,7 +308,7 @@ export class Client extends ClientBase {
     host: string;
     password?: string | undefined;
     ssl: boolean;
-    readonly pipeline: boolean;
+    pipeline: boolean;
     readonly connection: Connection;
 
     constructor(config?: string | ClientConfig);

--- a/types/pg/pg-tests.mts
+++ b/types/pg/pg-tests.mts
@@ -44,7 +44,11 @@ const client = new pg.Client({
     password: "secretpassword!!",
     application_name: "DefinitelyTyped",
     keepAlive: true,
+    pipeline: true,
 });
+client.pipeline = false;
+client.isIdle();
+client.waitForIdle();
 client.setTypeParser(20, val => Number(val));
 client.getTypeParser(20);
 

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -45,8 +45,11 @@ const client = new Client({
 });
 // $ExpectType boolean
 client.pipeline;
-// @ts-expect-error – pipeline is readonly
 client.pipeline = false;
+// $ExpectType boolean
+client.isIdle();
+// $ExpectType Promise<void>
+client.waitForIdle();
 client.setTypeParser(20, val => Number(val));
 client.getTypeParser(20);
 


### PR DESCRIPTION
Tracks https://github.com/brianc/node-postgres/pull/3766.

Makes `Client.pipeline` writable and adds `ClientBase.isIdle()` and `ClientBase.waitForIdle()`.

Tested: `pnpm test pg`.