### PR TITLE
[nodemailer] Add href to regular attachments

### DIFF
--- a/types/nodemailer/lib/mailer/index.d.ts
+++ b/types/nodemailer/lib/mailer/index.d.ts
@@ -77,8 +77,6 @@ declare namespace Mail {
         method?: string | undefined;
         /** optional filename, defaults to ‘invite.ics’ */
         filename?: string | false | undefined;
-        /** is an alternative for content to load the calendar data from an URL */
-        href?: string | undefined;
         /** defines optional content encoding, eg. ‘base64’ or ‘hex’. This only applies if the content is a string. By default an unicode string is assumed. */
         encoding?: string | undefined;
     }

--- a/types/nodemailer/lib/mailer/index.d.ts
+++ b/types/nodemailer/lib/mailer/index.d.ts
@@ -40,6 +40,8 @@ declare namespace Mail {
         content?: string | Buffer | Readable | undefined;
         /** path to a file or an URL (data uris are allowed as well) if you want to stream the file instead of including it (better for larger attachments) */
         path?: string | Url | undefined;
+        /** URL to stream the attachment from instead of including it */
+        href?: string | undefined;
     }
 
     interface Attachment extends AttachmentLike {
@@ -62,8 +64,6 @@ declare namespace Mail {
     }
 
     interface AmpAttachment extends AttachmentLike {
-        /** is an alternative for content to load the AMP4EMAIL data from an URL */
-        href?: string | undefined;
         /** defines optional content encoding, eg. ‘base64’ or ‘hex’. This only applies if the content is a string. By default an unicode string is assumed. */
         encoding?: string | undefined;
         /** optional content type for the attachment, if not set will be derived from the filename property */

--- a/types/nodemailer/nodemailer-tests.ts
+++ b/types/nodemailer/nodemailer-tests.ts
@@ -214,6 +214,11 @@ function message_attachments_test() {
                 path: "https://raw.github.com/nodemailer/nodemailer/master/LICENSE",
             },
             {
+                // use href as an attachment URL
+                filename: "license.txt",
+                href: "https://raw.github.com/nodemailer/nodemailer/master/LICENSE",
+            },
+            {
                 // encoded string as an attachment
                 filename: "text1.txt",
                 content: "aGVsbG8gd29ybGQh",


### PR DESCRIPTION
Nodemailer 9 accepts href on normal attachment objects, uses it to derive the filename/content type, and resolves it through the same URL-access policy as path. The declaration currently exposes href only through AmpAttachment, so valid regular attachments fail to type-check.

Source evidence:
- https://github.com/nodemailer/nodemailer/blob/742cff9e2d5376962da19f8fcf2408e910ff2020/lib/mailer/mail-message.js#L62-L74
- https://github.com/nodemailer/nodemailer/blob/742cff9e2d5376962da19f8fcf2408e910ff2020/lib/shared/index.js#L564-L574

This moves href to AttachmentLike, where regular, AMP, iCalendar, and message-body attachment-like inputs inherit the runtime-supported field, and adds a regular attachment compile test.

- [x] Used a meaningful package-scoped title.
- [x] Tested the change against Nodemailer 9.0.5 behavior in the consuming project.
- [x] Added a test covering the changed attachment shape.
- [x] Reviewed the contributor guidance and common mistakes.
- [x] Ran pnpm test nodemailer successfully.
- [x] This changes an existing definition and does not claim a new library version.

The added compile case fails on the previous declaration across TypeScript 5.6, 5.7, 5.8, 5.9, and 6.0 because href is absent, and passes with this change.

Consumer context: https://github.com/Verjson/toquorum/issues/704