### PR TITLE
fix(firefox-webext-browser): allow browser.scripting.executeScript fu…

### DIFF
--- a/types/firefox-webext-browser/firefox-webext-browser-tests.ts
+++ b/types/firefox-webext-browser/firefox-webext-browser-tests.ts
@@ -341,6 +341,28 @@ browser.scripting.executeScript({
     args: [0, "", false, [], {}],
     func: (_n: number, _s: string, _b: boolean, _a: [], _o: {}) => {},
 });
+
+browser.scripting.executeScript({
+    target: { tabId: 1 },
+    func: () => {},
+}).then(([resp]) => {
+    resp.result; // $ExpectType void | undefined
+});
+
+browser.scripting.executeScript({
+    target: { tabId: 1 },
+    func: () => {return true;},
+}).then(([resp]) => {
+    resp.result; // $ExpectType boolean | undefined
+});
+
+browser.scripting.executeScript({
+    target: { tabId: 1 },
+    func: () => {return 1;},
+}).then(([resp]) => {
+    resp.result; // $ExpectType number | undefined
+});
+
 browser.scripting.executeScript({ target: { tabId: 0 }, world: "MAIN" });
 browser.scripting.registerContentScripts([{ id: "scriptId", matchOriginAsFallback: true, world: "MAIN" }]);
 browser.scripting.updateContentScripts([{ id: "scriptId", persistAcrossSessions: true, world: "MAIN" }]);

--- a/types/firefox-webext-browser/firefox-webext-browser-tests.ts
+++ b/types/firefox-webext-browser/firefox-webext-browser-tests.ts
@@ -351,16 +351,30 @@ browser.scripting.executeScript({
 
 browser.scripting.executeScript({
     target: { tabId: 1 },
-    func: () => {return true;},
+    func: () => true,
 }).then(([resp]) => {
     resp.result; // $ExpectType boolean | undefined
 });
 
 browser.scripting.executeScript({
     target: { tabId: 1 },
-    func: () => {return 1;},
+    func: () => 1,
 }).then(([resp]) => {
     resp.result; // $ExpectType number | undefined
+});
+
+browser.scripting.executeScript({
+    target: { tabId: 1 },
+    func: () => Math.random() > 0.5 ? true : 1,
+}).then(([resp]) => {
+    resp.result; // $ExpectType true  | 1 | undefined
+});
+
+browser.scripting.executeScript({
+    target: { tabId: 1 },
+    func: (): number | boolean => Math.random() > 0.5 ? true : 1,
+}).then(([resp]) => {
+    resp.result; // $ExpectType number  | boolean | undefined
 });
 
 browser.scripting.executeScript({ target: { tabId: 0 }, world: "MAIN" });

--- a/types/firefox-webext-browser/index.d.ts
+++ b/types/firefox-webext-browser/index.d.ts
@@ -4839,7 +4839,9 @@ declare namespace browser.scripting {
      * @param injection The details of the script which to inject.
      */
     // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-    function executeScript<Args extends any[], Result>(injection: ScriptInjection<Args, Result>): Promise<InjectionResult<Result>[]>;
+    function executeScript<Args extends any[], Result>(
+        injection: ScriptInjection<Args, Result>,
+    ): Promise<InjectionResult<Result>[]>;
 
     /**
      * Inserts a CSS stylesheet into a target context. If multiple frames are specified, unsuccessful injections are ignored.

--- a/types/firefox-webext-browser/index.d.ts
+++ b/types/firefox-webext-browser/index.d.ts
@@ -4717,7 +4717,7 @@ declare namespace browser.runtime {
 declare namespace browser.scripting {
     /* scripting types */
     /** Details of a script injection */
-    interface ScriptInjection<Args extends any[] = any[]> {
+    interface ScriptInjection<Args extends any[] = any[], Result = any> {
         /**
          * The arguments to curry into a provided function. This is only valid if the `func` parameter is specified. These arguments must be JSON-serializable.
          */
@@ -4730,7 +4730,7 @@ declare namespace browser.scripting {
          * A JavaScript function to inject. This function will be serialized, and then deserialized for injection. This means that any bound parameters and execution context will be lost. Exactly one of `files` and `func` must be specified.
          */
         // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-        func?: (...args: Args) => void | undefined;
+        func?: (...args: Args) => Result;
         /** Details specifying the target into which to inject the script. */
         target: InjectionTarget;
         world?: ExecutionWorld | undefined;
@@ -4741,11 +4741,11 @@ declare namespace browser.scripting {
     }
 
     /** Result of a script injection. */
-    interface InjectionResult {
+    interface InjectionResult<Result = any> {
         /** The frame ID associated with the injection. */
         frameId: number;
         /** The result of the script execution. */
-        result?: any;
+        result?: Result;
         /**
          * The error property is set when the script execution failed. The value is typically an (Error) object with a message property, but could be any value (including primitives and undefined) if the script threw or rejected with such a value.
          */
@@ -4839,7 +4839,7 @@ declare namespace browser.scripting {
      * @param injection The details of the script which to inject.
      */
     // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-    function executeScript<T extends any[]>(injection: ScriptInjection<T>): Promise<InjectionResult[]>;
+    function executeScript<Args extends any[], Result>(injection: ScriptInjection<Args, Result>): Promise<InjectionResult<Result>[]>;
 
     /**
      * Inserts a CSS stylesheet into a target context. If multiple frames are specified, unsuccessful injections are ignored.


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Current definitions does not allow `browser.scripting.executeScript` `func` to return 
<img width="1199" height="583" alt="image" src="https://github.com/user-attachments/assets/3f3a6987-b7ce-4484-98b8-0a62995d34ec" />

`Result` already exists `broswer.urlbar.Result`, I can rename the type.