### PR TITLE
feat(react): attributes and event for the native Invoker Commands API

### DIFF
--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -10,6 +10,7 @@ Warning: all of these interfaces are empty. If you want type definitions for var
 interface Event {}
 interface AnimationEvent extends Event {}
 interface ClipboardEvent extends Event {}
+interface CommandEvent extends Event {}
 interface CompositionEvent extends Event {}
 interface DragEvent extends Event {}
 interface FocusEvent extends Event {}

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -9,6 +9,7 @@ import * as CSS from "csstype";
 type NativeAnimationEvent = AnimationEvent;
 type NativeClipboardEvent = ClipboardEvent;
 type NativeCompositionEvent = CompositionEvent;
+type NativeCommandEvent = CommandEvent;
 type NativeDragEvent = DragEvent;
 type NativeFocusEvent = FocusEvent;
 type NativeInputEvent = InputEvent;
@@ -2057,6 +2058,11 @@ declare namespace React {
         clipboardData: DataTransfer;
     }
 
+    interface CommandEvent<T = Element> extends SyntheticEvent<T, NativeCommandEvent> {
+        source: Element | null;
+        command: string;
+    }
+
     interface CompositionEvent<T = Element> extends SyntheticEvent<T, NativeCompositionEvent> {
         data: string;
     }
@@ -2233,6 +2239,7 @@ declare namespace React {
     type ReactEventHandler<T = Element> = EventHandler<SyntheticEvent<T>>;
 
     type ClipboardEventHandler<T = Element> = EventHandler<ClipboardEvent<T>>;
+    type CommandEventHandler<T = Element> = EventHandler<CommandEvent<T>>;
     type CompositionEventHandler<T = Element> = EventHandler<CompositionEvent<T>>;
     type DragEventHandler<T = Element> = EventHandler<DragEvent<T>>;
     type FocusEventHandler<T = Element> = EventHandler<FocusEvent<T>>;
@@ -2287,6 +2294,9 @@ declare namespace React {
         onCutCapture?: ClipboardEventHandler<T> | undefined;
         onPaste?: ClipboardEventHandler<T> | undefined;
         onPasteCapture?: ClipboardEventHandler<T> | undefined;
+
+        // Command Event
+        onCommand?: CommandEventHandler<T> | undefined;
 
         // Composition Events
         onCompositionEnd?: CompositionEventHandler<T> | undefined;
@@ -3059,6 +3069,16 @@ declare namespace React {
     }
 
     interface ButtonHTMLAttributes<T> extends HTMLAttributes<T> {
+        command?:
+            | "show-modal"
+            | "close"
+            | "request-close"
+            | "show-popover"
+            | "hide-popover"
+            | "toggle-popover"
+            | `--${string}`
+            | undefined;
+        commandfor?: string | undefined;
         disabled?: boolean | undefined;
         form?: string | undefined;
         formAction?:

--- a/types/react/test/elementAttributes.tsx
+++ b/types/react/test/elementAttributes.tsx
@@ -177,6 +177,16 @@ const testCases = [
             <custom-element exportparts="nested" />
         </template>
     </>,
+    // Command API
+    <>
+        <div id="commandable-item" onCommand={() => {}} />
+        <button command="show-modal" commandfor="some-modal">Open…</button>
+        <button command="--custom" commandfor="commandable-item">Dispatch Command</button>
+        <button // @ts-expect-error custom commands must be a CSS custom property starting with "--"
+         command="invalid">
+            Bad Command
+        </button>
+    </>,
     <link rel="expect" href="#lead-content" blocking="render" />,
     <link rel="expect" href="#lead-content" blocking="render render" />,
     <style blocking="render" />,

--- a/types/react/v18/global.d.ts
+++ b/types/react/v18/global.d.ts
@@ -10,6 +10,7 @@ Warning: all of these interfaces are empty. If you want type definitions for var
 interface Event {}
 interface AnimationEvent extends Event {}
 interface ClipboardEvent extends Event {}
+interface CommandEvent extends Event {}
 interface CompositionEvent extends Event {}
 interface DragEvent extends Event {}
 interface FocusEvent extends Event {}

--- a/types/react/v18/index.d.ts
+++ b/types/react/v18/index.d.ts
@@ -9,6 +9,7 @@ import * as PropTypes from "prop-types";
 
 type NativeAnimationEvent = AnimationEvent;
 type NativeClipboardEvent = ClipboardEvent;
+type NativeCommandEvent = CommandEvent;
 type NativeCompositionEvent = CompositionEvent;
 type NativeDragEvent = DragEvent;
 type NativeFocusEvent = FocusEvent;
@@ -2213,6 +2214,11 @@ declare namespace React {
         clipboardData: DataTransfer;
     }
 
+    interface CommandEvent<T = Element> extends SyntheticEvent<T, NativeCommandEvent> {
+        source: Element | null;
+        command: string;
+    }
+
     interface CompositionEvent<T = Element> extends SyntheticEvent<T, NativeCompositionEvent> {
         data: string;
     }
@@ -2364,6 +2370,7 @@ declare namespace React {
     type ReactEventHandler<T = Element> = EventHandler<SyntheticEvent<T>>;
 
     type ClipboardEventHandler<T = Element> = EventHandler<ClipboardEvent<T>>;
+    type CommandEventHandler<T = Element> = EventHandler<CommandEvent<T>>;
     type CompositionEventHandler<T = Element> = EventHandler<CompositionEvent<T>>;
     type DragEventHandler<T = Element> = EventHandler<DragEvent<T>>;
     type FocusEventHandler<T = Element> = EventHandler<FocusEvent<T>>;
@@ -2409,6 +2416,9 @@ declare namespace React {
         onCutCapture?: ClipboardEventHandler<T> | undefined;
         onPaste?: ClipboardEventHandler<T> | undefined;
         onPasteCapture?: ClipboardEventHandler<T> | undefined;
+
+        // Command Event
+        onCommand?: CommandEventHandler<T> | undefined;
 
         // Composition Events
         onCompositionEnd?: CompositionEventHandler<T> | undefined;
@@ -3158,6 +3168,16 @@ declare namespace React {
     }
 
     interface ButtonHTMLAttributes<T> extends HTMLAttributes<T> {
+        command?:
+            | "show-modal"
+            | "close"
+            | "request-close"
+            | "show-popover"
+            | "hide-popover"
+            | "toggle-popover"
+            | `--${string}`
+            | undefined;
+        commandfor?: string | undefined;
         disabled?: boolean | undefined;
         form?: string | undefined;
         formAction?:

--- a/types/react/v18/test/elementAttributes.tsx
+++ b/types/react/v18/test/elementAttributes.tsx
@@ -115,6 +115,16 @@ const testCases = [
             <custom-element exportparts="nested" />
         </template>
     </>,
+    // Command API
+    <>
+        <div id="commandable-item" onCommand={() => {}} />
+        <button command="show-modal" commandfor="some-modal">Open…</button>
+        <button command="--custom" commandfor="commandable-item">Dispatch Command</button>
+        <button // @ts-expect-error custom commands must be a CSS custom property starting with "--"
+         command="invalid">
+            Bad Command
+        </button>
+    </>,
     <link rel="expect" href="#lead-content" blocking="render" />,
     <link rel="expect" href="#lead-content" blocking="render render" />,
     <style blocking="render" />,


### PR DESCRIPTION
The [Invoker Commands API](https://developer.mozilla.org/en-US/docs/Web/API/Invoker_Commands_API) enables declarative JavaScript-free manipulation of dialogs and popovers, and can be extended with custom commands for other uses.

* Add `<button>` attributes [command](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-command) and [commandfor](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-commandfor).
* Add the [CommandEvent](https://html.spec.whatwg.org/multipage/interaction.html#commandevent) and its handler.