### PR TITLE
node: v26.5

### DIFF
--- a/types/node/buffer.d.ts
+++ b/types/node/buffer.d.ts
@@ -1776,6 +1776,7 @@ declare module "node:buffer" {
         slice(start?: number, end?: number, contentType?: string): Blob;
         stream(): ReadableStream<NodeJS.NonSharedUint8Array>;
         text(): Promise<string>;
+        textStream(): ReadableStream<string>;
     }
     export var Blob: {
         prototype: Blob;

--- a/types/node/diagnostics_channel.d.ts
+++ b/types/node/diagnostics_channel.d.ts
@@ -529,10 +529,10 @@ declare module "node:diagnostics_channel" {
          * @param context Shared object to correlate trace events through
          * @param thisArg The receiver to be used for the function call
          * @param args Optional arguments to pass to the function
-         * @returns The return value of the given function, or the result of
-         * calling `.then(...)` on the return value if the tracing channel has active
-         * subscribers. If the return value is not a Promise or thenable, then
-         * it is returned as-is and a warning is emitted.
+         * @returns The return value of the given function. If the return value
+         * is a Promise or thenable, tracing events will be published when it settles.
+         * If the return value is not a Promise or thenable, it is returned as-is and
+         * a warning is emitted.
          */
         tracePromise<ThisArg = any, Args extends any[] = any[], Result extends PromiseLike<unknown> = any>(
             fn: (this: ThisArg, ...args: Args) => Result,

--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -225,7 +225,7 @@ declare module "node:http" {
          * The number of milliseconds of inactivity a server needs to wait for additional incoming data,
          * after it has finished writing the last response, before a socket will be destroyed.
          * @see Server.keepAliveTimeout for more information.
-         * @default 5000
+         * @default 65000
          * @since v18.0.0
          */
         keepAliveTimeout?: number | undefined;

--- a/types/node/node-tests/buffer.ts
+++ b/types/node/node-tests/buffer.ts
@@ -562,6 +562,7 @@ declare class NodeFile implements File {
     arrayBuffer(): Promise<ArrayBuffer>;
     bytes(): Promise<NodeJS.NonSharedUint8Array>;
     text(): Promise<string>;
+    textStream(): ReadableStream;
 }
 
 {

--- a/types/node/node-tests/perf_hooks.ts
+++ b/types/node/node-tests/perf_hooks.ts
@@ -1,8 +1,8 @@
 import {
     createHistogram,
+    ELDHistogram,
     EntryType,
     eventLoopUtilization,
-    IntervalHistogram,
     monitorEventLoopDelay,
     performance as NodePerf,
     PerformanceEntry,
@@ -46,7 +46,7 @@ obs.observe({
     buffered: true,
 });
 
-const monitor: IntervalHistogram = monitorEventLoopDelay({
+const monitor: ELDHistogram = monitorEventLoopDelay({
     resolution: 42,
 });
 

--- a/types/node/node-tests/stream-web.ts
+++ b/types/node/node-tests/stream-web.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert";
-import { ReadableStream, TransformStream, WritableStream } from "node:stream/web";
+import { ReadableStream, ReadableStreamTee, TransformStream, WritableStream } from "node:stream/web";
 import type { QueuingStrategySize } from "node:stream/web";
 
 async function readResultHasRequiredValueProperty() {
@@ -109,4 +109,19 @@ async function queuingStrategySizeReceivesTheChunk() {
             reason; // $ExpectType any
         },
     });
+}
+
+{
+    const stream = new ReadableStream<number>({
+        pull(controller) {
+            controller.enqueue(Math.random());
+        },
+    });
+
+    const [stream1, stream2] = ReadableStreamTee(stream);
+
+    stream1; // $ExpectType ReadableStream<number>
+    stream2; // $ExpectType ReadableStream<number>
+
+    ReadableStreamTee(stream, true);
 }

--- a/types/node/package.json
+++ b/types/node/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/node",
-    "version": "26.4.9999",
+    "version": "26.5.9999",
     "nonNpm": "conflict",
     "nonNpmDescription": "Node.js",
     "projects": [

--- a/types/node/package.json
+++ b/types/node/package.json
@@ -18,7 +18,7 @@
         }
     },
     "dependencies": {
-        "undici-types": "~8.3.0"
+        "undici-types": "~8.9.0"
     },
     "devDependencies": {
         "@types/node": "workspace:."

--- a/types/node/perf_hooks.d.ts
+++ b/types/node/perf_hooks.d.ts
@@ -314,9 +314,14 @@ declare module "node:perf_hooks" {
     }
     interface EventLoopMonitorOptions {
         /**
-         * The sampling rate in milliseconds.
-         * Must be greater than zero.
-         * @default 10
+         * When `true`, samples are taken once per
+         * event loop iteration. **Default:** `false`.
+         */
+        samplePerIteration?: boolean | undefined;
+        /**
+         * The sampling rate in milliseconds for interval-based
+         * sampling. Must be greater than zero. This option is ignored when
+         * `samplePerIteration` is `true`. **Default:** `10`.
          */
         resolution?: number | undefined;
     }
@@ -400,21 +405,25 @@ declare module "node:perf_hooks" {
          */
         readonly stddev: number;
     }
-    interface IntervalHistogram extends Histogram {
+    /**
+     * A `Histogram` that records event loop delay, returned by
+     * `perf_hooks.monitorEventLoopDelay()`.
+     */
+    interface ELDHistogram extends Histogram {
         /**
-         * Enables the update interval timer. Returns `true` if the timer was
-         * started, `false` if it was already started.
-         * @since v11.10.0
-         */
-        enable(): boolean;
-        /**
-         * Disables the update interval timer. Returns `true` if the timer was
+         * Disables event loop delay sampling. Returns `true` if sampling was
          * stopped, `false` if it was already stopped.
          * @since v11.10.0
          */
         disable(): boolean;
         /**
-         * Disables the update interval timer when the histogram is disposed.
+         * Enables event loop delay sampling. Returns `true` if sampling was
+         * started, `false` if it was already started.
+         * @since v11.10.0
+         */
+        enable(): boolean;
+        /**
+         * Disables event loop delay sampling when the histogram is disposed.
          *
          * ```js
          * const { monitorEventLoopDelay } = require('node:perf_hooks');
@@ -509,14 +518,16 @@ declare module "node:perf_hooks" {
     /**
      * _This property is an extension by Node.js. It is not available in Web browsers._
      *
-     * Creates an `IntervalHistogram` object that samples and reports the event loop
-     * delay over time. The delays will be reported in nanoseconds.
+     * Creates a histogram object that samples and reports the event loop delay over
+     * time. The delays will be reported in nanoseconds.
      *
-     * Using a timer to detect approximate event loop delay works because the
-     * execution of timers is tied specifically to the lifecycle of the libuv
-     * event loop. That is, a delay in the loop will cause a delay in the execution
-     * of the timer, and those delays are specifically what this API is intended to
-     * detect.
+     * By default, the histogram is updated by a timer using the configured
+     * `resolution`. When `samplePerIteration` is `true`, samples are taken once per
+     * event loop iteration using `uv_prepare_t` and `uv_check_t` hooks. In that mode,
+     * the histogram does not keep the loop alive or force additional iterations when
+     * the application is idle.
+     * The two sampling modes produce significantly different results and should not
+     * be compared directly.
      *
      * ```js
      * import { monitorEventLoopDelay } from 'node:perf_hooks';
@@ -534,7 +545,7 @@ declare module "node:perf_hooks" {
      * ```
      * @since v11.10.0
      */
-    function monitorEventLoopDelay(options?: EventLoopMonitorOptions): IntervalHistogram;
+    function monitorEventLoopDelay(options?: EventLoopMonitorOptions): ELDHistogram;
     interface TimerifyOptions {
         /**
          * A histogram object created using

--- a/types/node/perf_hooks.d.ts
+++ b/types/node/perf_hooks.d.ts
@@ -301,6 +301,7 @@ declare module "node:perf_hooks" {
     namespace constants {
         const NODE_PERFORMANCE_GC_MAJOR: number;
         const NODE_PERFORMANCE_GC_MINOR: number;
+        const NODE_PERFORMANCE_GC_MINOR_MARK_SWEEP: number;
         const NODE_PERFORMANCE_GC_INCREMENTAL: number;
         const NODE_PERFORMANCE_GC_WEAKCB: number;
         const NODE_PERFORMANCE_GC_FLAGS_NO: number;

--- a/types/node/quic.d.ts
+++ b/types/node/quic.d.ts
@@ -1059,8 +1059,8 @@ declare module "node:quic" {
     interface CreateStreamOptions {
         /**
          * The outbound body source. See `stream.setBody()` for details on
-         * supported types. When omitted, the stream starts half-closed (writable
-         * side open, no body queued).
+         * supported types. When omitted, the stream's outgoing side remains
+         * writable with no body queued; no FIN is sent immediately.
          */
         body?: StreamBody | undefined;
         /**
@@ -1375,7 +1375,8 @@ declare module "node:quic" {
         onqlog: OnQlogCallback | undefined;
         /**
          * Open a new bidirectional stream. If the `body` option is not specified,
-         * the outgoing stream will be half-closed. The `priority` and `incremental`
+         * the stream's outgoing side remains writable and no FIN is sent
+         * immediately. The `priority` and `incremental`
          * options are only used when the session supports priority (e.g. HTTP/3).
          * The `headers`, `onheaders`, `ontrailers`, `oninfo`, and `onwanttrailers`
          * options are only used when the session supports headers (e.g. HTTP/3).
@@ -1384,7 +1385,8 @@ declare module "node:quic" {
         createBidirectionalStream(options?: CreateStreamOptions): Promise<QuicStream>;
         /**
          * Open a new unidirectional stream. If the `body` option is not specified,
-         * the outgoing stream will be closed. The `priority` and `incremental`
+         * the stream's outgoing side remains writable and no FIN is sent
+         * immediately. The `priority` and `incremental`
          * options are only used when the session supports priority (e.g. HTTP/3).
          * @since v23.8.0
          */

--- a/types/node/stream/web.d.ts
+++ b/types/node/stream/web.d.ts
@@ -294,6 +294,26 @@ declare module "node:stream/web" {
         prototype: WritableStreamDefaultWriter;
         new<W = any>(stream: WritableStream<W>): WritableStreamDefaultWriter<W>;
     };
+    // Node.js extensions
+    /**
+     * Runs the WHATWG `ReadableStreamTee` abstract operation on `stream`.
+     *
+     * This differs from `readableStream.tee()` only when `cloneForBranch2` is
+     * `true`. The `tee()` method always passes `false`, while other web platform
+     * specifications, such as Fetch body cloning, pass `true` so that the second
+     * branch receives cloned chunks and consumption of one branch cannot mutate chunks
+     * seen by the other.
+     * @since v26.5.0
+     * @experimental
+     * @param cloneForBranch2 When `true`, chunks enqueued into the second
+     * branch are cloned from chunks enqueued into the first branch. **Default:**
+     * `false`.
+     * @returns Two `ReadableStream` branches.
+     */
+    function ReadableStreamTee<R>(
+        stream: ReadableStream<R>,
+        cloneForBranch2?: boolean,
+    ): [ReadableStream<R>, ReadableStream<R>];
 }
 declare module "stream/web" {
     export * from "node:stream/web";

--- a/types/node/tls.d.ts
+++ b/types/node/tls.d.ts
@@ -270,11 +270,19 @@ declare module "node:tls" {
          */
         getCipher(): CipherNameAndProtocol;
         /**
-         * Returns an object representing the type, name, and size of parameter of
-         * an ephemeral key exchange in `perfect forward secrecy` on a client
-         * connection. It returns an empty object when the key exchange is not
-         * ephemeral. As this is only supported on a client socket; `null` is returned
-         * if called on a server socket. The supported types are `'DH'` and `'ECDH'`. The `name` property is available only when type is `'ECDH'`.
+         * Returns an object describing ephemeral key agreement in [perfect forward
+         * secrecy](https://nodejs.org/docs/latest-v26.x/api/tls.html#perfect-forward-secrecy) on a client connection. It returns an empty object when the key
+         * agreement is not ephemeral. As this is only supported on a client socket;
+         * `null` is returned if called on a server socket. The supported types are `'DH'`,
+         * `'ECDH'`, and `'TLSGroup'`. For `'DH'` and `'ECDH'`, the object describes peer
+         * temporary key parameters. For `'TLSGroup'`, the object identifies the negotiated
+         * TLS Supported Group used for key agreement when a peer temporary key object is
+         * not available.
+         *
+         * The `name` property is available only when type is `'ECDH'` or `'TLSGroup'`. The
+         * `size` property is not available when type is `'TLSGroup'`. For `'TLSGroup'`,
+         * `name` is the negotiated TLS Supported Group name. Standardized TLS group names
+         * and code points are listed in the [IANA TLS Supported Groups registry](https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8).
          *
          * For example: `{ type: 'ECDH', name: 'prime256v1', size: 256 }`.
          * @since v5.0.0
@@ -822,13 +830,16 @@ declare module "node:tls" {
          */
         dhparam?: string | Buffer | undefined;
         /**
-         * A string describing a named curve or a colon separated list of curve
-         * NIDs or names, for example P-521:P-384:P-256, to use for ECDH key
-         * agreement. Set to auto to select the curve automatically. Use
-         * crypto.getCurves() to obtain a list of available curve names. On
-         * recent releases, openssl ecparam -list_curves will also display the
-         * name and description of each available elliptic curve. Default:
-         * tls.DEFAULT_ECDH_CURVE.
+         * A string describing a named curve, TLS group, or
+         * colon-separated list of named curves or TLS groups to use for key agreement,
+         * for example `P-521:P-384:P-256`, `X25519`, or `X25519MLKEM768`. The
+         * historical name of this option refers to ECDH key agreement in TLSv1.2 and
+         * below. In TLSv1.3, this option configures the TLS Supported Groups and
+         * key share groups offered or accepted by the TLS stack. Set to `auto` to
+         * select the group automatically. Use `crypto.getCurves()` to obtain a
+         * list of available elliptic curve names. For TLS group names, use
+         * `openssl list -tls-groups` or consult the [IANA TLS Supported Groups
+         * registry](https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8).
          */
         ecdhCurve?: string | undefined;
         /**
@@ -1167,9 +1178,9 @@ declare module "node:tls" {
      */
     function setDefaultCACertificates(certs: ReadonlyArray<string | NodeJS.ArrayBufferView>): void;
     /**
-     * The default curve name to use for ECDH key agreement in a tls server.
-     * The default value is `'auto'`. See `{@link createSecureContext()}` for further
-     * information.
+     * The default named curve or TLS group list to use for key agreement in a TLS
+     * server. The default value is `'auto'`. See `tls.createSecureContext()` for
+     * further information.
      * @since v0.11.13
      */
     let DEFAULT_ECDH_CURVE: string;

--- a/types/node/vfs.d.ts
+++ b/types/node/vfs.d.ts
@@ -182,10 +182,11 @@ declare module "node:vfs" {
         setReadOnly(): void;
     }
     /**
-     * A provider that wraps a directory (i.e. one on the actual file system) and exposes its
-     * contents through the VFS API. All VFS paths are resolved relative to
-     * the root and verified to stay inside it; symbolic links resolving
-     * outside the root are rejected.
+     * A provider that wraps a directory (i.e. one on the actual file system) and
+     * exposes its contents through the VFS API. All VFS paths are resolved relative to
+     * the root and verified to stay inside it; symbolic links resolving outside the
+     * root are rejected. This path mapping is not a sandbox or access-control
+     * mechanism.
      * @since v26.4.0
      */
     class RealFSProvider extends VirtualProvider {
@@ -193,8 +194,8 @@ declare module "node:vfs" {
          * ```js
          * const vfs = require('node:vfs');
          *
-         * const realVfs = vfs.create(new vfs.RealFSProvider('/tmp/sandbox'));
-         * realVfs.writeFileSync('/file.txt', 'hello'); // writes /tmp/sandbox/file.txt
+         * const realVfs = vfs.create(new vfs.RealFSProvider('/tmp/vfs-root'));
+         * realVfs.writeFileSync('/file.txt', 'hello'); // writes /tmp/vfs-root/file.txt
          * ```
          * @since v26.4.0
          * @param rootPath The absolute file-system path to use as the root.

--- a/types/node/zlib.d.ts
+++ b/types/node/zlib.d.ts
@@ -32,6 +32,13 @@ declare module "node:zlib" {
          * @default buffer.kMaxLength
          */
         maxOutputLength?: number | undefined;
+        /**
+         * If `true`, decompression fails when
+         * trailing input is detected after the end of the compressed stream. This
+         * includes unreadable bytes and, when decompressing gzip, additional gzip
+         * members following the first member. **Default:** `false`
+         */
+        rejectGarbageAfterEnd?: boolean | undefined;
     }
     interface BrotliOptions {
         /**
@@ -63,6 +70,11 @@ declare module "node:zlib" {
          * If `true`, returns an object with `buffer` and `engine`.
          */
         info?: boolean | undefined;
+        /**
+         * If `true`, decompression fails when
+         * input remains after the first complete compressed stream. **Default:** `false`
+         */
+        rejectGarbageAfterEnd?: boolean | undefined;
     }
     interface ZstdOptions {
         /**
@@ -98,6 +110,11 @@ declare module "node:zlib" {
          * @since v24.6.0
          */
         dictionary?: NodeJS.ArrayBufferView | undefined;
+        /**
+         * If `true`, decompression fails when
+         * input remains after the first complete compressed stream. **Default:** `false`
+         */
+        rejectGarbageAfterEnd?: boolean | undefined;
     }
     interface Zlib {
         readonly bytesWritten: number;


### PR DESCRIPTION
- buffer: implement blob.textStream()
- deps: update undici to 8.9.0 
- perf_hooks: add NODE_PERFORMANCE_GC_MINOR_MARK_SWEEP constant
- perf_hooks: sample delay per event loop iteration
- stream: expose ReadableStreamTee
- zlib: expose rejectGarbageAfterEnd option