### PR TITLE
[@types/chrome] Fix types for chrome.devtools.inspectedWindow.eval

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -2902,20 +2902,29 @@ declare namespace chrome {
             injectedScript?: string | undefined;
         }
 
-        interface EvaluationExceptionInfo {
+        interface PreEvaluationError {
             /** Set if the error occurred on the DevTools side before the expression is evaluated. */
-            isError: boolean;
+            isError: true;
+            /** Omitted if the error occured on the DevTools side before the expression is evaluated. */
+            isException?: undefined;
             /** Set if the error occurred on the DevTools side before the expression is evaluated. */
             code: string;
             /** Set if the error occurred on the DevTools side before the expression is evaluated. */
             description: string;
             /** Set if the error occurred on the DevTools side before the expression is evaluated, contains the array of the values that may be substituted into the description string to provide more information about the cause of the error. */
             details: any[];
+        }
+
+        interface EvaluationException {
+            /** Omitted if the evaluated code produces an unhandled exception. */
+            isError?: undefined;
             /** Set if the evaluated code produces an unhandled exception. */
-            isException: boolean;
+            isException?: true;
             /** Set if the evaluated code produces an unhandled exception. */
             value: string;
         }
+
+        type EvaluationExceptionInfo = PreEvaluationError | EvaluationException;
 
         /** The ID of the tab being inspected. This ID may be used with {@link chrome.tabs} API. */
         const tabId: number;
@@ -2932,18 +2941,18 @@ declare namespace chrome {
          *
          * Can return its result via Promise in Manifest V3 or later since Chrome 151.
          */
-        function eval<T = { [key: string]: unknown }>(
+        function eval<T>(
             expression: string,
             options?: EvalOptions,
-        ): Promise<{ result: T; exceptionInfo: EvaluationExceptionInfo }>;
-        function eval<T = { [key: string]: unknown }>(
+        ): Promise<T>;
+        function eval<T>(
             expression: string,
-            callback?: (result: T, exceptionInfo: EvaluationExceptionInfo) => void,
+            callback?: (result: T | undefined, exceptionInfo?: EvaluationExceptionInfo) => void,
         ): void;
-        function eval<T = { [key: string]: unknown }>(
+        function eval<T>(
             expression: string,
             options: EvalOptions | undefined,
-            callback?: (result: T, exceptionInfo: EvaluationExceptionInfo) => void,
+            callback?: (result: T| undefined, exceptionInfo?: EvaluationExceptionInfo) => void,
         ): void;
 
         /**

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1996,23 +1996,39 @@ function testDevtoolsInspectedWindow() {
         useContentScriptContext: true,
     };
 
-    chrome.devtools.inspectedWindow.eval(expression); // $ExpectType Promise<{ result: { [key: string]: unknown; }; exceptionInfo: EvaluationExceptionInfo}>
-    chrome.devtools.inspectedWindow.eval(expression, evalOptions); // $ExpectType Promise<{ result: { [key: string]: unknown; }; exceptionInfo: EvaluationExceptionInfo}>
-    chrome.devtools.inspectedWindow.eval(expression, evalOptions, (result, exceptionInfo) => { // $ExpectType void
-        result; // $ExpectType { [key: string]: unknown; }
+    chrome.devtools.inspectedWindow.eval(expression); // $ExpectType Promise<unknown>
+    chrome.devtools.inspectedWindow.eval(expression, evalOptions); // $ExpectType Promise<unknown>
+    chrome.devtools.inspectedWindow.eval<number>(expression); // $ExpectType Promise<number>
 
-        exceptionInfo.code; // $ExpectType string
-        exceptionInfo.description; // $ExpectType string
-        exceptionInfo.details; // $ExpectType any[]
-        exceptionInfo.isError; // $ExpectType boolean
-        exceptionInfo.isException; // $ExpectType boolean
-        exceptionInfo.value; // $ExpectType string
+    chrome.devtools.inspectedWindow.eval(expression, evalOptions, (result, exceptionInfo) => { // $ExpectType void
+        result; // $ExpectType unknown
+
+        if (exceptionInfo) {
+            exceptionInfo; // $ExpectType EvaluationExceptionInfo
+            exceptionInfo.isError; // $ExpectType true | undefined
+            exceptionInfo.isException; // $ExpectType true | undefined
+
+            if (exceptionInfo.isError) {
+                exceptionInfo; // $ExpectType PreEvaluationError
+                exceptionInfo.code; // $ExpectType string
+                exceptionInfo.description; // $ExpectType string
+                exceptionInfo.details; // $ExpectType any[]
+            } else if (exceptionInfo.isException) {
+                exceptionInfo; // $ExpectType EvaluationException
+                exceptionInfo.value; // $ExpectType string
+            }
+        }
     });
+
     chrome.devtools.inspectedWindow.eval(expression, (result, exceptionInfo) => { // $ExpectType void
-        result; // $ExpectType { [key: string]: unknown; }
+        result; // $ExpectType unknown
     });
+
     chrome.devtools.inspectedWindow.eval<{ title: string }>(expression, evalOptions, (result) => { // $ExpectType void
-        result.title; // $ExpectType string
+        result; // $ExpectType { title: string; } | undefined
+        if (result) {
+            result.title; // $ExpectType string
+        }
     });
 
     chrome.devtools.inspectedWindow.getResources(); // $ExpectType Promise<Resource[]>


### PR DESCRIPTION
Fixed type of returned promise and callback arguments, including fixes for EvaluationExceptionInfo

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/75484
