### PR TITLE
[chrome] fix chrome.audio namespace

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -537,14 +537,14 @@ declare namespace chrome {
             /** The stable/persisted device id string when available. */
             stableDeviceId?: string;
             /** Stream type associated with this device. */
-            streamType: StreamType;
+            streamType: `${StreamType}`;
         }
 
         interface DeviceFilter {
             /** If set, only audio devices whose active state matches this value will satisfy the filter. */
             isActive?: boolean;
             /** If set, only audio devices whose stream type is included in this list will satisfy the filter. */
-            streamTypes?: StreamType[];
+            streamTypes?: `${StreamType}`[];
         }
 
         interface DeviceIdLists {
@@ -600,7 +600,7 @@ declare namespace chrome {
             /** Whether or not the stream is now muted. */
             isMuted: boolean;
             /** The type of the stream for which the mute value changed. The updated mute value applies to all devices with this stream type. */
-            streamType: StreamType;
+            streamType: `${StreamType}`;
         }
 
         /** Type of stream an audio device provides. */
@@ -611,14 +611,17 @@ declare namespace chrome {
 
         /**
          * Gets a list of audio devices filtered based on filter.
+         * @param filter Device properties by which to filter the list of returned audio devices. If the filter is not set or set to `{}`, returned device list will contain all available audio devices.
+         *
          * Can return its result via Promise in Manifest V3 or later since Chrome 116.
          */
         function getDevices(filter?: DeviceFilter): Promise<AudioDeviceInfo[]>;
-        function getDevices(filter: DeviceFilter, callback: (devices: AudioDeviceInfo[]) => void): void;
         function getDevices(callback: (devices: AudioDeviceInfo[]) => void): void;
+        function getDevices(filter: DeviceFilter | undefined, callback: (devices: AudioDeviceInfo[]) => void): void;
 
         /**
          * Gets the system-wide mute state for the specified stream type.
+         *
          * Can return its result via Promise in Manifest V3 or later since Chrome 116.
          */
         function getMute(streamType: `${StreamType}`): Promise<boolean>;
@@ -626,6 +629,7 @@ declare namespace chrome {
 
         /**
          * Sets lists of active input and/or output devices.
+         *
          * Can return its result via Promise in Manifest V3 or later since Chrome 116.
          */
         function setActiveDevices(ids: DeviceIdLists): Promise<void>;
@@ -633,6 +637,7 @@ declare namespace chrome {
 
         /**
          * Sets mute state for a stream type. The mute state will apply to all audio devices with the specified audio stream type.
+         *
          * Can return its result via Promise in Manifest V3 or later since Chrome 116.
          */
         function setMute(streamType: `${StreamType}`, isMuted: boolean): Promise<void>;
@@ -640,6 +645,7 @@ declare namespace chrome {
 
         /**
          * Sets the properties for the input or output device.
+         *
          * Can return its result via Promise in Manifest V3 or later since Chrome 116.
          */
         function setProperties(id: string, properties: DeviceProperties): Promise<void>;
@@ -648,18 +654,18 @@ declare namespace chrome {
         /**
          * Fired when audio devices change, either new devices being added, or existing devices being removed.
          */
-        const onDeviceListChanged: chrome.events.Event<(devices: AudioDeviceInfo[]) => void>;
+        const onDeviceListChanged: events.Event<(devices: AudioDeviceInfo[]) => void>;
 
         /**
          * Fired when sound level changes for an active audio device.
          */
-        const onLevelChanged: chrome.events.Event<(event: LevelChangedEvent) => void>;
+        const onLevelChanged: events.Event<(event: LevelChangedEvent) => void>;
 
         /**
          * Fired when the mute state of the audio input or output changes.
          * Note that mute state is system-wide and the new value applies to every audio device with specified stream type.
          */
-        const onMuteChanged: chrome.events.Event<(event: MuteChangedEvent) => void>;
+        const onMuteChanged: events.Event<(event: MuteChangedEvent) => void>;
     }
 
     ////////////////////

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -525,7 +525,7 @@ declare namespace chrome {
             /** Device name */
             deviceName: string;
             /** Type of the device */
-            deviceType: DeviceType;
+            deviceType: `${DeviceType}`;
             /** The user-friendly name (e.g. "USB Microphone"). */
             displayName: string;
             /** The unique identifier of the audio device. */

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -2857,29 +2857,37 @@ function testAudio() {
     chrome.audio.getDevices(); // $ExpectType Promise<AudioDeviceInfo[]>
     chrome.audio.getDevices(undefined); // $ExpectType Promise<AudioDeviceInfo[]>
     chrome.audio.getDevices(filter); // $ExpectType Promise<AudioDeviceInfo[]>
-    chrome.audio.getDevices(devices => {}); // $ExpectType void
-    chrome.audio.getDevices(undefined, devices => {}); // $ExpectType void
-    chrome.audio.getDevices(filter, devices => {}); // $ExpectType void
+    chrome.audio.getDevices(devices => { // $ExpectType void
+        devices; // $ExpectType AudioDeviceInfo[]
+    });
+    chrome.audio.getDevices(undefined, devices => { // $ExpectType void
+        devices; // $ExpectType AudioDeviceInfo[]
+    });
+    chrome.audio.getDevices(filter, devices => { // $ExpectType void
+        devices; // $ExpectType AudioDeviceInfo[]
+    });
     // @ts-expect-error
     chrome.audio.getDevices(() => {}).then(devices => {});
 
     chrome.audio.getMute("INPUT"); // $ExpectType Promise<boolean>
-    chrome.audio.getMute("INPUT", value => {}); // $ExpectType void
+    chrome.audio.getMute("INPUT", value => { // $ExpectType void
+        value; // $ExpectType boolean
+    });
     // @ts-expect-error
     chrome.audio.getMute("INPUT", value => {}).then(value => {});
 
     chrome.audio.setActiveDevices({}); // $ExpectType Promise<void>
-    chrome.audio.setActiveDevices({}, () => {}); // $ExpectType void
+    chrome.audio.setActiveDevices({}, () => void 0); // $ExpectType void
     // @ts-expect-error
     chrome.audio.setActiveDevices(() => {}).then(() => {});
 
     chrome.audio.setMute("INPUT", true); // $ExpectType Promise<void>
-    chrome.audio.setMute("INPUT", true, () => {}); // $ExpectType void
+    chrome.audio.setMute("INPUT", true, () => void 0); // $ExpectType void
     // @ts-expect-error
     chrome.audio.setMute("INPUT", true, () => {}).then(() => {});
 
     chrome.audio.setProperties("INPUT", {}); // $ExpectType Promise<void>
-    chrome.audio.setProperties("INPUT", {}, () => {}); // $ExpectType void
+    chrome.audio.setProperties("INPUT", {}, () => void 0); // $ExpectType void
     // @ts-expect-error
     chrome.audio.setProperties("INPUT", {}, () => {}).then(() => {});
 

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -2849,10 +2849,17 @@ function testAudio() {
     chrome.audio.StreamType.INPUT === "INPUT";
     chrome.audio.StreamType.OUTPUT === "OUTPUT";
 
+    const filter: chrome.audio.DeviceFilter = {
+        isActive: true,
+        streamTypes: ["INPUT", "OUTPUT"],
+    };
+
     chrome.audio.getDevices(); // $ExpectType Promise<AudioDeviceInfo[]>
-    chrome.audio.getDevices({}); // $ExpectType Promise<AudioDeviceInfo[]>
+    chrome.audio.getDevices(undefined); // $ExpectType Promise<AudioDeviceInfo[]>
+    chrome.audio.getDevices(filter); // $ExpectType Promise<AudioDeviceInfo[]>
     chrome.audio.getDevices(devices => {}); // $ExpectType void
-    chrome.audio.getDevices({}, devices => {}); // $ExpectType void
+    chrome.audio.getDevices(undefined, devices => {}); // $ExpectType void
+    chrome.audio.getDevices(filter, devices => {}); // $ExpectType void
     // @ts-expect-error
     chrome.audio.getDevices(() => {}).then(devices => {});
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/api/audio
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Notes:
- don't require the enum for `StreamType`.

  
  <img width="1057" height="137" alt="image" src="https://github.com/user-attachments/assets/a57a18f0-e794-472e-8b97-5c185f6ec517" />

- fix `getDevices()`: `filter` can be `undefined` with `callback`
  
  
  <img width="842" height="140" alt="image" src="https://github.com/user-attachments/assets/7e45301e-e9d2-429b-9233-57ec00d77f92" />

- clean JSDoc  / TS