### PR TITLE
node: v26.6

### DIFF
--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -1304,8 +1304,11 @@ declare module "node:crypto" {
         /**
          * Calculates the signature on all the data passed through using either `sign.update()` or `sign.write()`.
          *
-         * If `privateKey` is not a `KeyObject`, this function behaves as if `privateKey` had been passed to {@link createPrivateKey}. If it is an
-         * object, the following additional properties can be passed:
+         * If `privateKey` is not a `KeyObject`, this function behaves as if
+         * `privateKey` had been passed to `crypto.createPrivateKey()`. When
+         * `privateKey` is a string, `ArrayBuffer`, `Buffer`, `TypedArray`, or
+         * `DataView`, it must contain PEM-encoded key material. If it is an object, the
+         * following additional properties can be passed:
          *
          * If `outputEncoding` is provided a string is returned; otherwise a `Buffer` is returned.
          *
@@ -1375,8 +1378,11 @@ declare module "node:crypto" {
         /**
          * Verifies the provided data using the given `key` and `signature`.
          *
-         * If `key` is not a `KeyObject`, this function behaves as if `key` had been passed to {@link createPublicKey}. If it is an
-         * object, the following additional properties can be passed:
+         * If `key` is not a `KeyObject`, this function behaves as if
+         * `key` had been passed to `crypto.createPublicKey()`. When `key` is a string,
+         * `ArrayBuffer`, `Buffer`, `TypedArray`, or `DataView`, it must contain
+         * PEM-encoded key material. If it is an object, the following additional
+         * properties can be passed:
          *
          * The `signature` argument is the previously calculated signature for the data, in
          * the `signatureEncoding`.
@@ -2690,8 +2696,10 @@ declare module "node:crypto" {
      * ML-DSA.
      *
      * If `key` is not a `KeyObject`, this function behaves as if `key` had been
-     * passed to {@link createPrivateKey}. If it is an object, the following
-     * additional properties can be passed:
+     * passed to `crypto.createPrivateKey()`. When `key` is a string, `ArrayBuffer`,
+     * `Buffer`, `TypedArray`, or `DataView`, it must contain PEM-encoded key
+     * material. If it is an object, the following additional properties can be
+     * passed:
      *
      * If the `callback` function is provided this function uses libuv's threadpool.
      * @since v12.0.0
@@ -2716,8 +2724,10 @@ declare module "node:crypto" {
      * ML-DSA.
      *
      * If `key` is not a `KeyObject`, this function behaves as if `key` had been
-     * passed to {@link createPublicKey}. If it is an object, the following
-     * additional properties can be passed:
+     * passed to `crypto.createPublicKey()`. When `key` is a string, `ArrayBuffer`,
+     * `Buffer`, `TypedArray`, or `DataView`, it must contain PEM-encoded key
+     * material. If it is an object, the following additional properties can be
+     * passed:
      *
      * The `signature` argument is the previously calculated signature for the `data`.
      *

--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -88,6 +88,8 @@ declare module "node:crypto" {
      * behavior. For XOF hash functions such as `'shake256'`, the `outputLength` option
      * can be used to specify the desired output length in bytes.
      *
+     * When the data is small (< 5MB) and readily available, `crypto.hash()` is usually faster.
+     *
      * The `algorithm` is dependent on the available algorithms supported by the
      * version of OpenSSL on the platform. Examples are `'sha256'`, `'sha512'`, etc.
      * On recent releases of OpenSSL, `openssl list -digest-algorithms` will

--- a/types/node/ffi.d.ts
+++ b/types/node/ffi.d.ts
@@ -415,6 +415,20 @@ declare module "node:ffi" {
      * @since v26.1.0
      */
     function getRawPointer(source: ArrayBuffer | NodeJS.ArrayBufferView): bigint;
+    /**
+     * Returns the address of the current thread's `uv_loop_t` as a `bigint`.
+     *
+     * The returned address is for the current Node.js environment. In the main thread,
+     * this is the main thread event loop. In a worker thread, this is that worker's
+     * event loop.
+     *
+     * This is unsafe and dangerous. The returned pointer is only valid for the lifetime
+     * of the current environment. Using it after the environment exits, or from native
+     * code that assumes a different thread or lifetime, can crash the process or
+     * corrupt memory.
+     * @since v26.6.0
+     */
+    function getCurrentEventLoop(): bigint;
     type ReturnType = { [K in keyof DataTypeMap]: K }[keyof DataTypeMap];
     type ArgumentType = Exclude<ReturnType, "void">;
     interface DataTypeMap {

--- a/types/node/http2.d.ts
+++ b/types/node/http2.d.ts
@@ -685,10 +685,11 @@ declare module "node:http2" {
          * Returns a `Proxy` object that acts as a `net.Socket` (or `tls.TLSSocket`) but
          * limits available methods to ones safe to use with HTTP/2.
          *
-         * `destroy`, `emit`, `end`, `pause`, `read`, `resume`, and `write` will throw
+         * `emit`, `end`, `pause`, `read`, `resume`, and `write` will throw
          * an error with code `ERR_HTTP2_NO_SOCKET_MANIPULATION`. See `Http2Session and Sockets` for more information.
          *
-         * `setTimeout` method will be called on this `Http2Session`.
+         * `destroy`, `setTimeout`, `ref`, and `unref` methods will be called on this
+         * `Http2Session`.
          *
          * All other interactions will be routed directly to the socket.
          * @since v8.4.0

--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -379,6 +379,12 @@ declare module "node:net" {
          */
         readonly remotePort: number | undefined;
         /**
+         * Reference to the server that accepted the socket. This is `null` for sockets
+         * that were not accepted by a server.
+         * @since v0.3.4
+         */
+        readonly server: Server | null;
+        /**
          * The socket timeout in milliseconds as set by `socket.setTimeout()`.
          * It is `undefined` if a timeout has not been set.
          * @since v10.7.0

--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -492,6 +492,11 @@ declare module "node:net" {
      * throw `ERR_SOCKET_HANDLE_ADOPTED`. A handle that is never adopted must be
      * closed to avoid leaking the socket.
      *
+     * When an adopted `BoundSocket` connects to a numeric IP literal, `connect(2)` is
+     * issued synchronously, so `socket.localAddress` is resolved once
+     * `socket.connect()` returns. Connection failures are still reported via a
+     * deferred `'error'` event.
+     *
      * ```js
      * import net from 'node:net';
      *

--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -353,10 +353,11 @@ declare module "node:net" {
         /**
          * This property represents the state of the connection as a string.
          *
-         * * If the stream is connecting `socket.readyState` is `opening`.
-         * * If the stream is readable and writable, it is `open`.
-         * * If the stream is readable and not writable, it is `readOnly`.
-         * * If the stream is not readable and writable, it is `writeOnly`.
+         * * If the socket is connecting, `socket.readyState` is `opening`.
+         * * If the socket is readable and writable, it is `open`.
+         * * If the socket is readable and not writable, it is `readOnly`.
+         * * If the socket is not readable and writable, it is `writeOnly`.
+         * * Otherwise, it is `closed`.
          * @since v0.5.0
          */
         readonly readyState: SocketReadyState;

--- a/types/node/node-tests/net.ts
+++ b/types/node/node-tests/net.ts
@@ -1,6 +1,6 @@
-import { Socket } from "node:dgram";
 import { LookupAddress, LookupOptions } from "node:dns";
 import * as net from "node:net";
+import { Worker } from "node:worker_threads";
 
 {
     const abort = new AbortController();
@@ -502,4 +502,15 @@ import * as net from "node:net";
     boundSocket.fd(); // $ExpectType number
 
     new net.Socket({ handle: new net.BoundSocket() });
+}
+
+{
+    // worker.js receives `{ socket }` messages and handles each connection.
+    const worker = new Worker("./worker.js");
+
+    const server = net.createServer((socket) => {
+        // Hand the freshly accepted connection off to the worker thread.
+        worker.postMessage({ socket }, [socket]);
+    });
+    server.listen(8000);
 }

--- a/types/node/node-tests/stream-iter.ts
+++ b/types/node/node-tests/stream-iter.ts
@@ -75,7 +75,7 @@ void async function() {
         },
     });
 
-    await pipeTo(from("hello world"), fromWritable(writable, { backpressure: "block" }));
+    await pipeTo(from("hello world"), fromWritable(writable, { backpressure: "unbounded" }));
 };
 
 {

--- a/types/node/node-tests/test.ts
+++ b/types/node/node-tests/test.ts
@@ -133,6 +133,10 @@ test(undefined, undefined, t => {
     // $ExpectType void
     t.diagnostic("tap diagnostic");
     // $ExpectType void
+    t.log("message");
+    // $ExpectType void
+    t.log("data", [1, 2, 3]);
+    // $ExpectType void
     t.runOnly(true);
     // $ExpectType void
     t.skip("skip reason");
@@ -530,6 +534,8 @@ suite("foo", (context) => {
     context.attempt;
 
     context.diagnostic("diagnostic");
+    context.log("message");
+    context.log("data", [1, 2, 3]);
 });
 
 suite("test tags", () => {
@@ -1013,6 +1019,14 @@ class TestReporter extends Transform {
                 callback(
                     null,
                     tests.map((test) => `${test.name}/${test.nesting}/${test.file}/${test.column}/${test.line}`),
+                );
+                break;
+            }
+            case "test:log": {
+                const { file, column, line, name, message, data } = event.data;
+                callback(
+                    null,
+                    `${name}/${file}/${column}/${line}/${message}/${data}`,
                 );
                 break;
             }

--- a/types/node/package.json
+++ b/types/node/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/node",
-    "version": "26.5.9999",
+    "version": "26.6.9999",
     "nonNpm": "conflict",
     "nonNpmDescription": "Node.js",
     "projects": [

--- a/types/node/process.d.ts
+++ b/types/node/process.d.ts
@@ -110,6 +110,7 @@ declare module "node:process" {
         "node:util/types": typeof import("node:util/types");
         "v8": typeof import("v8");
         "node:v8": typeof import("node:v8");
+        "node:vfs": typeof import("node:vfs");
         "vm": typeof import("vm");
         "node:vm": typeof import("node:vm");
         "wasi": typeof import("wasi");

--- a/types/node/quic.d.ts
+++ b/types/node/quic.d.ts
@@ -4,7 +4,7 @@ declare module "node:quic" {
     import { FileHandle } from "node:fs/promises";
     import { BlockList, SocketAddress } from "node:net";
     import { Writer } from "node:stream/iter";
-    import { EphemeralKeyInfo } from "node:tls";
+    import { CertificateCompressionAlgorithm, EphemeralKeyInfo } from "node:tls";
     /**
      * @since v23.8.0
      */
@@ -277,6 +277,28 @@ declare module "node:quic" {
          * @since v23.8.0
          */
         ca?: ArrayBuffer | NodeJS.ArrayBufferView | ReadonlyArray<ArrayBuffer | NodeJS.ArrayBufferView> | undefined;
+        /**
+         * Enables TLS certificate compression ([RFC 8879](https://www.rfc-editor.org/rfc/rfc8879)) for this session. When
+         * omitted, certificate compression is disabled.
+         *
+         * On the server side, the certificate chain is compressed using the first
+         * listed algorithm that the client advertises support for. On the client side,
+         * the listed algorithms are advertised to the server so that the server may
+         * compress its certificate. When client authentication is in use, the option
+         * also controls compression of the client's certificate.
+         *
+         * Compressing the certificate chain is especially useful for QUIC because it
+         * reduces the size of the server's first flight, which is bounded by the
+         * anti-amplification limit (see [Certificate size and handshake
+         * performance](https://nodejs.org/docs/latest-v26.x/api/quic.html#certificate-size-and-handshake-performance)). Certificate compression requires TLS 1.3, which QUIC always
+         * uses.
+         *
+         * At most three algorithms may be specified. The option is silently ignored if
+         * Node.js was built against a shared OpenSSL that lacks certificate compression
+         * support.
+         * @since v26.6.0
+         */
+        certificateCompression?: readonly CertificateCompressionAlgorithm[] | undefined;
         /**
          * Specifies the congestion control algorithm that will be used.
          * Must be set to one of either `'reno'`, `'cubic'`, or `'bbr'`.

--- a/types/node/quic.d.ts
+++ b/types/node/quic.d.ts
@@ -1461,6 +1461,22 @@ declare module "node:quic" {
             encoding?: BufferEncoding,
         ): Promise<bigint>;
         /**
+         * The SNI (Server Name Indication) host name associated with the session. This is
+         * `null` before the client hello is processed. Once the hello has been
+         * processed, this is either the host name string or `false` if the handshake
+         * had no SNI.
+         * @since v26.6.0
+         */
+        readonly servername: string | false | null;
+        /**
+         * The negotiated ALPN protocol. This is `null` before the client hello is
+         * processed. Once ALPN has been negotiated, this is the protocol string. ALPN
+         * is mandatory in QUIC so this is never `false` on successful connections,
+         * unlike `node:tls` where this is optional.
+         * @since v26.6.0
+         */
+        readonly alpnProtocol: string | null;
+        /**
          * The local certificate as a `crypto.X509Certificate` instance. Server
          * sessions return the certificate configured for the negotiated SNI host.
          * Client sessions return `undefined` unless a client certificate was sent.

--- a/types/node/stream/iter.d.ts
+++ b/types/node/stream/iter.d.ts
@@ -45,14 +45,14 @@ declare module "node:stream/iter" {
         [shareSyncProtocol](options: ShareSyncOptions): SyncShare;
     }
     // IDL dictionaries, enums, typedefs
-    type BackpressurePolicy = "strict" | "block" | "drop-oldest" | "drop-newest";
+    type BackpressurePolicy = "strict" | "unbounded" | "drop-oldest" | "drop-newest";
     type ByteReadableStream = AsyncIterable<Uint8Array[]>;
     type SyncByteReadableStream = Iterable<Uint8Array[]>;
     interface WriteOptions {
         signal?: AbortSignal;
     }
     interface PushStreamOptions {
-        highWaterMark?: number;
+        budget?: number;
         backpressure?: BackpressurePolicy;
         signal?: AbortSignal;
     }
@@ -85,21 +85,21 @@ declare module "node:stream/iter" {
         signal?: AbortSignal;
     }
     interface BroadcastOptions {
-        highWaterMark?: number;
+        budget?: number;
         backpressure?: BackpressurePolicy;
         signal?: AbortSignal;
     }
     interface ShareOptions {
-        highWaterMark?: number;
+        budget?: number;
         backpressure?: BackpressurePolicy;
         signal?: AbortSignal;
     }
     interface ShareSyncOptions {
-        highWaterMark?: number;
+        budget?: number;
         backpressure?: BackpressurePolicy;
     }
     interface DuplexDirectionOptions {
-        highWaterMark?: number;
+        budget?: number;
         backpressure?: BackpressurePolicy;
     }
     interface DuplexOptions {
@@ -142,7 +142,7 @@ declare module "node:stream/iter" {
         broadcast: Broadcast;
     }
     interface Writer extends Disposable, AsyncDisposable {
-        readonly desiredSize: number | null;
+        readonly canWrite: boolean | null;
         write(chunk: Uint8Array | string, options?: WriteOptions): Promise<void>;
         writev(chunks: Array<Uint8Array | string>, options?: WriteOptions): Promise<void>;
         writeSync(chunk: Uint8Array | string): boolean;
@@ -155,7 +155,7 @@ declare module "node:stream/iter" {
         write(chunk: Uint8Array | string, options?: WriteOptions): Promise<void>;
     }
     interface SyncWriter extends Disposable {
-        readonly desiredSize: number | null;
+        readonly canWrite: boolean | null;
         writeSync(chunk: Uint8Array | string): number;
         writevSync(chunks: Array<Uint8Array | string>): number;
         endSync(): number;
@@ -166,19 +166,16 @@ declare module "node:stream/iter" {
     }
     interface Broadcast extends Disposable {
         readonly consumerCount: number;
-        readonly bufferSize: number;
         push(...args: any[]): ByteReadableStream;
         cancel(reason?: any): void;
     }
     interface Share extends Disposable {
         readonly consumerCount: number;
-        readonly bufferSize: number;
         pull(...args: any[]): ByteReadableStream;
         cancel(reason?: any): void;
     }
     interface SyncShare extends Disposable {
         readonly consumerCount: number;
-        readonly bufferSize: number;
         pull(...args: any): SyncByteReadableStream;
         cancel(reason?: any): void;
     }
@@ -329,7 +326,7 @@ declare module "node:stream/iter" {
      * });
      *
      * await pipeTo(from('hello world'),
-     *              fromWritable(writable, { backpressure: 'block' }));
+     *              fromWritable(writable, { backpressure: 'unbounded' }));
      * ```
      * @since v26.1.0
      * @experimental

--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -456,6 +456,13 @@ declare module "node:test" {
                  */
                 column?: number;
                 /**
+                 * The path of the test file that was
+                 * executed as the entry point of the child process that emitted this event.
+                 * Only present when tests run with process isolation. May differ from
+                 * `file` when the test is defined in a module imported by the entry file.
+                 */
+                entryFile?: string;
+                /**
                  * The path of the test file, `undefined` if test was run through the REPL.
                  */
                 file?: string;

--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -375,6 +375,7 @@ declare module "node:test" {
             "test:enqueue": [data: EventData.TestEnqueue];
             "test:fail": [data: EventData.TestFail];
             "test:interrupted": [data: EventData.TestInterrupted];
+            "test:log": [data: EventData.TestLog];
             "test:pass": [data: EventData.TestPass];
             "test:plan": [data: EventData.TestPlan];
             "test:start": [data: EventData.TestStart];
@@ -852,6 +853,36 @@ declare module "node:test" {
                  */
                 tests: TestStart[];
             }
+            interface TestLog extends LocationInfo {
+                /**
+                 * The structured payload passed to `context.log`, or
+                 * `undefined` if none was provided. The test runner does not interpret this
+                 * value.
+                 */
+                data: unknown;
+                /**
+                 * The log message.
+                 */
+                message: string;
+                /**
+                 * The test name.
+                 */
+                name: string;
+                /**
+                 * The nesting level of the test.
+                 */
+                nesting: number;
+                /**
+                 * The `testId` of the enclosing test, or
+                 * `undefined` for top-level tests.
+                 */
+                parentId: number | undefined;
+                /**
+                 * A numeric identifier for the test instance that emitted
+                 * the log message.
+                 */
+                testId: number;
+            }
             interface TestPass extends LocationInfo {
                 /**
                  * Additional execution metadata.
@@ -1137,6 +1168,25 @@ declare module "node:test" {
              * @param message Message to be reported.
              */
             diagnostic(message: string): void;
+            /**
+             * This function is used to write a log message to the output. Unlike
+             * `context.diagnostic`, the resulting `'test:log'` event is emitted
+             * immediately, in the order that the tests execute, rather than being buffered
+             * until the test reports its results. This function does not return a value.
+             *
+             * ```js
+             * test('top level test', (t) => {
+             *   t.log('fetched user', { userId: 42 });
+             *   t.log('retrying flaky endpoint', { attempt: 3 });
+             * });
+             * ```
+             * @since v26.6.0
+             * @param message Message to be reported.
+             * @param data Optional structured payload attached to the message. The test
+             * runner passes it through untouched. When tests run with process isolation,
+             * this value must be compatible with the [HTML structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
+             */
+            log(message: string, data?: unknown): void;
             /**
              * The absolute path of the test file that created the current test. If a test file imports
              * additional modules that generate tests, the imported tests will return the path of the root test file.
@@ -1499,6 +1549,21 @@ declare module "node:test" {
              * @param message A diagnostic message to output.
              */
             diagnostic(message: string): void;
+            /**
+             * Write a log message to the output. The resulting `'test:log'` event is
+             * emitted immediately, in the order that the tests execute.
+             *
+             * ```js
+             * test.describe('my suite', (suite) => {
+             *   suite.log('Suite log message');
+             * });
+             * ```
+             * @since v26.6.0
+             * @param message Message to be reported.
+             * @param data Optional structured payload attached to the message. The test
+             * runner passes it through untouched.
+             */
+            log(message: string, data?: unknown): void;
         }
         interface TestOptions {
             /**

--- a/types/node/test/reporters.d.ts
+++ b/types/node/test/reporters.d.ts
@@ -9,6 +9,7 @@ declare module "node:test/reporters" {
         | { type: "test:enqueue"; data: EventData.TestEnqueue }
         | { type: "test:fail"; data: EventData.TestFail }
         | { type: "test:interrupted"; data: EventData.TestInterrupted }
+        | { type: "test:log"; data: EventData.TestLog }
         | { type: "test:pass"; data: EventData.TestPass }
         | { type: "test:plan"; data: EventData.TestPlan }
         | { type: "test:start"; data: EventData.TestStart }

--- a/types/node/tls.d.ts
+++ b/types/node/tls.d.ts
@@ -220,6 +220,13 @@ declare module "node:tls" {
          */
         authorized: boolean;
         /**
+         * The negotiated ALPN protocol. This is `null` before the handshake completes.
+         * Once the handshake completes, it settles as either the negotiated protocol
+         * name, or `false` if the peers did not negotiate an ALPN protocol.
+         * @since v6.0.0
+         */
+        alpnProtocol: string | false | null;
+        /**
          * Returns the reason why the peer's certificate was not been verified. This
          * property is set only when `tlsSocket.authorized === false`.
          * @since v0.11.4
@@ -230,16 +237,6 @@ declare module "node:tls" {
          * @since v0.11.4
          */
         encrypted: true;
-        /**
-         * String containing the selected ALPN protocol.
-         * Before a handshake has completed, this value is always null.
-         * When a handshake is completed but not ALPN protocol was selected, tlsSocket.alpnProtocol equals false.
-         */
-        alpnProtocol: string | false | null;
-        /**
-         * String containing the server name requested via SNI (Server Name Indication) TLS extension.
-         */
-        servername: string | false | null;
         /**
          * Returns an object representing the local certificate. The returned object has
          * some properties corresponding to the fields of the certificate.
@@ -402,6 +399,13 @@ declare module "node:tls" {
             },
             callback: (err: Error | null) => void,
         ): undefined | boolean;
+        /**
+         * The SNI (Server Name Indication) host name associated with the socket. This is
+         * `null` before the handshake completes. Once the handshake completes it settles
+         * as either the host name string, or `false` if SNI was not used.
+         * @since v0.11.3
+         */
+        servername: string | false | null;
         /**
          * The `tlsSocket.setKeyCert()` method sets the private key and certificate to use for the socket.
          * This is mainly useful if you wish to select a server certificate from a TLS server's `ALPNCallback`.

--- a/types/node/vm.d.ts
+++ b/types/node/vm.d.ts
@@ -886,6 +886,7 @@ declare module "node:vm" {
          * const module = new vm.SourceTextModule(
          *   'Object.getPrototypeOf(import.meta.prop).secret = secret;',
          *   {
+         *     context: contextifiedObject,
          *     initializeImportMeta(meta) {
          *       // Note: this object is created in the top context. As such,
          *       // Object.getPrototypeOf(import.meta.prop) points to the
@@ -904,7 +905,7 @@ declare module "node:vm" {
          * // To fix this problem, replace
          * //     meta.prop = {};
          * // above with
-         * //     meta.prop = vm.runInContext('{}', contextifiedObject);
+         * //     meta.prop = vm.runInContext('({})', contextifiedObject);
          * ```
          * @param code JavaScript Module code to parse
          */

--- a/types/node/worker_threads.d.ts
+++ b/types/node/worker_threads.d.ts
@@ -6,6 +6,7 @@ declare module "node:worker_threads" {
         NodeEventTarget,
     } from "node:events";
     import { FileHandle } from "node:fs/promises";
+    import { Server, Socket } from "node:net";
     import { Performance } from "node:perf_hooks";
     import { Readable, Writable } from "node:stream";
     import { ReadableStream, TransformStream, WritableStream } from "node:stream/web";
@@ -514,7 +515,9 @@ declare module "node:worker_threads" {
         | FileHandle
         | ReadableStream
         | WritableStream
-        | TransformStream;
+        | TransformStream
+        | Server
+        | Socket;
     interface LockGrantedCallback<T> {
         (lock: Lock | null): T;
     }


### PR DESCRIPTION
- doc: document TLS alpnProtocol and servername fields
- doc: document net Socket server property
- ffi: add getCurrentEventLoop
- net: make TCP Server and Socket transferable across worker threads
- quic: add support for TLS certificate compression
- quic: defer server session emit until TLS ClientHello is processed
- stream: update iterable streams to use budget backpressure
- test_runner: add context.log() and test:log event
- test_runner: report entryFile in TestStream events