### PR TITLE
[node] Inherit CommonOptions in ForkOptions to support windowsHide

### DIFF
--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -1136,7 +1136,7 @@ declare module "node:child_process" {
             stderr: string | NonSharedBuffer;
         }>;
     }
-    interface ForkOptions extends ProcessEnvOptions, MessagingOptions, Abortable {
+    interface ForkOptions extends CommonOptions, MessagingOptions, Abortable {
         execPath?: string | undefined;
         execArgv?: string[] | undefined;
         silent?: boolean | undefined;

--- a/types/node/node-tests/child_process.ts
+++ b/types/node/node-tests/child_process.ts
@@ -494,6 +494,7 @@ import { promisify } from "node:util";
 
 {
     const forked = childProcess.fork("./", ["asd"] as readonly string[], {
+        windowsHide: true,
         windowsVerbatimArguments: true,
         silent: false,
         stdio: "inherit",
@@ -526,6 +527,8 @@ import { promisify } from "node:util";
 
 {
     const forked = childProcess.fork("./", {
+        windowsHide: true,
+        timeout: 123,
         windowsVerbatimArguments: true,
         silent: false,
         stdio: ["inherit"],

--- a/types/node/v22/child_process.d.ts
+++ b/types/node/v22/child_process.d.ts
@@ -1253,7 +1253,7 @@ declare module "child_process" {
             stderr: string | NonSharedBuffer;
         }>;
     }
-    interface ForkOptions extends ProcessEnvOptions, MessagingOptions, Abortable {
+    interface ForkOptions extends CommonOptions, MessagingOptions, Abortable {
         execPath?: string | undefined;
         execArgv?: string[] | undefined;
         silent?: boolean | undefined;

--- a/types/node/v22/test/child_process.ts
+++ b/types/node/v22/test/child_process.ts
@@ -494,6 +494,7 @@ import { promisify } from "node:util";
 
 {
     const forked = childProcess.fork("./", ["asd"] as readonly string[], {
+        windowsHide: true,
         windowsVerbatimArguments: true,
         silent: false,
         stdio: "inherit",
@@ -526,6 +527,8 @@ import { promisify } from "node:util";
 
 {
     const forked = childProcess.fork("./", {
+        windowsHide: true,
+        timeout: 123,
         windowsVerbatimArguments: true,
         silent: false,
         stdio: ["inherit"],

--- a/types/node/v24/child_process.d.ts
+++ b/types/node/v24/child_process.d.ts
@@ -1253,7 +1253,7 @@ declare module "child_process" {
             stderr: string | NonSharedBuffer;
         }>;
     }
-    interface ForkOptions extends ProcessEnvOptions, MessagingOptions, Abortable {
+    interface ForkOptions extends CommonOptions, MessagingOptions, Abortable {
         execPath?: string | undefined;
         execArgv?: string[] | undefined;
         silent?: boolean | undefined;

--- a/types/node/v24/test/child_process.ts
+++ b/types/node/v24/test/child_process.ts
@@ -494,6 +494,7 @@ import { promisify } from "node:util";
 
 {
     const forked = childProcess.fork("./", ["asd"] as readonly string[], {
+        windowsHide: true,
         windowsVerbatimArguments: true,
         silent: false,
         stdio: "inherit",
@@ -526,6 +527,8 @@ import { promisify } from "node:util";
 
 {
     const forked = childProcess.fork("./", {
+        windowsHide: true,
+        timeout: 123,
         windowsVerbatimArguments: true,
         silent: false,
         stdio: ["inherit"],

--- a/types/node/v25/child_process.d.ts
+++ b/types/node/v25/child_process.d.ts
@@ -1143,7 +1143,7 @@ declare module "node:child_process" {
             stderr: string | NonSharedBuffer;
         }>;
     }
-    interface ForkOptions extends ProcessEnvOptions, MessagingOptions, Abortable {
+    interface ForkOptions extends CommonOptions, MessagingOptions, Abortable {
         execPath?: string | undefined;
         execArgv?: string[] | undefined;
         silent?: boolean | undefined;

--- a/types/node/v25/node-tests/child_process.ts
+++ b/types/node/v25/node-tests/child_process.ts
@@ -494,6 +494,7 @@ import { promisify } from "node:util";
 
 {
     const forked = childProcess.fork("./", ["asd"] as readonly string[], {
+        windowsHide: true,
         windowsVerbatimArguments: true,
         silent: false,
         stdio: "inherit",
@@ -526,6 +527,8 @@ import { promisify } from "node:util";
 
 {
     const forked = childProcess.fork("./", {
+        windowsHide: true,
+        timeout: 123,
         windowsVerbatimArguments: true,
         silent: false,
         stdio: ["inherit"],


### PR DESCRIPTION
`fork()` rejects `windowsHide` in TypeScript even though Node forwards the option to `spawn()` and uses it when creating cluster workers. Make `ForkOptions` extend `CommonOptions`, as suggested in [discussion #75523](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/75523).

Apply the same one-line correction to the latest, v22, v24, and v25 definitions. Existing child-process tests now exercise `windowsHide` with both fork overloads and retain coverage of `timeout`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. Compiled against the patched definitions and ran both fork overloads with `windowsHide: true`; stdout, IPC messages, and exit status were preserved.
- [x] Add or edit tests to reflect the change. The regression tests rejected `windowsHide` before the declaration change.
- [x] Follow the advice from the readme.
- [x] Avoid common mistakes.
- [x] Run `pnpm test <package to test>`. Passed `pnpm test node`, `pnpm test node/v22`, `pnpm test node/v24`, and `pnpm test node/v25` across their supported TypeScript configurations.

For this existing definition:

- [x] Provide source context: Node's [fork implementation](https://github.com/nodejs/node/blob/main/lib/child_process.js) forwards options to spawn, and its [cluster worker implementation](https://github.com/nodejs/node/blob/main/lib/internal/cluster/primary.js#L119-L129) explicitly passes `windowsHide` to fork.
- No version-number change is needed: this corrects an existing runtime API rather than introducing support for a new Node version.

Repository-wide `test-all` was not run; local validation was scoped to the Node packages in a sparse checkout.

Generated with Codex.
