### PR TITLE
[n3] add EntityIndex class and StoreOptions.entityIndex

### DIFF
--- a/types/n3/index.d.ts
+++ b/types/n3/index.d.ts
@@ -275,6 +275,11 @@ export class StoreFactory
     dataset(quads?: RDF.BaseQuad[] | RDF.DatasetCore): Store;
 }
 
+export class EntityIndex {
+    constructor(options?: { factory?: RDF.DataFactory });
+    createBlankNode(suggestedName?: string): BlankNode;
+}
+
 export interface Rule {
     premise: RDF.Quad[];
     conclusion: RDF.Quad[];
@@ -376,6 +381,7 @@ export interface extractListOptions {
 
 export interface StoreOptions {
     factory?: RDF.DataFactory | undefined;
+    entityIndex?: EntityIndex | undefined;
 }
 
 export namespace Util {

--- a/types/n3/n3-tests.ts
+++ b/types/n3/n3-tests.ts
@@ -638,5 +638,11 @@ function test_get_rules_from_dataset() {
     const rules: N3.Rule[] = N3.getRulesFromDataset(store);
 }
 
+function test_entity_index() {
+    const entityIndex = new N3.EntityIndex();
+    const bn: N3.BlankNode = entityIndex.createBlankNode("b1");
+    const store = new N3.Store([], { entityIndex });
+}
+
 export const namedNode: ReturnType<RDF.DataFactory["namedNode"]> = N3.DataFactory.namedNode("hello world");
 export const df: RDF.DataFactory = N3.DataFactory;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - Source code: https://github.com/rdfjs/N3.js/blob/master/src/N3Store.js#L111-L165
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---

### Summary of changes:
`src/index.js` exports `N3EntityIndex` (as `EntityIndex`), and `N3Store` accepts an `entityIndex` in its options so multiple stores can share the same blank-node/entity numbering (`src/N3Store.js` L198-L202). Neither the `EntityIndex` class nor the `StoreOptions.entityIndex` field is declared in `@types/n3` today.

This PR:
1. Adds `export class EntityIndex` with its `constructor(options?: { factory?: RDF.DataFactory })` and public `createBlankNode(suggestedName?: string): BlankNode` method.
2. Adds `entityIndex?: EntityIndex | undefined;` to `StoreOptions`.
3. Adds a test case constructing an `EntityIndex`, calling `createBlankNode`, and passing it into a `new N3.Store(...)` in `types/n3/n3-tests.ts`.

---