### PR TITLE
[node-red/util] Remove JSONata runtime dependency

### DIFF
--- a/types/node-red__util/index.d.ts
+++ b/types/node-red__util/index.d.ts
@@ -1,8 +1,55 @@
 import { EventEmitter } from "events";
-import { Expression as JsonataExpression } from "jsonata";
 
 import * as registry from "@node-red/registry";
 import * as runtime from "@node-red/runtime";
+
+// Preserve the existing jsonata 2.0.5 contract without depending on its runtime.
+// https://github.com/jsonata-js/jsonata/blob/v2.0.5/jsonata.d.ts
+declare namespace jsonata {
+    interface ExprNode {
+        type: string;
+        value?: any;
+        position?: number;
+        arguments?: ExprNode[];
+        name?: string;
+        procedure?: ExprNode;
+        steps?: ExprNode[];
+        expressions?: ExprNode[];
+        stages?: ExprNode[];
+        lhs?: ExprNode[];
+        rhs?: ExprNode;
+    }
+
+    interface JsonataError extends Error {
+        code: string;
+        position: number;
+        token: string;
+    }
+
+    interface Environment {
+        bind(name: string, value: any): void;
+        lookup(name: string): any;
+        readonly timestamp: Date;
+        readonly async: boolean;
+    }
+
+    interface Focus {
+        readonly environment: Environment;
+        readonly input: any;
+    }
+
+    interface Expression {
+        evaluate(input: any, bindings?: Record<string, any>): Promise<any>;
+        evaluate(
+            input: any,
+            bindings: Record<string, any> | undefined,
+            callback: (err: JsonataError, resp: any) => void,
+        ): void;
+        assign(name: string, value: any): void;
+        registerFunction(name: string, implementation: (this: Focus, ...args: any[]) => any, signature?: string): void;
+        ast(): ExprNode;
+    }
+}
 
 declare const util: util.UtilModule;
 
@@ -278,7 +325,7 @@ declare namespace util {
          * @param node  - the node evaluating the property
          * @returns The JSONata expression that can be evaluated
          */
-        prepareJSONataExpression(value: string, node: registry.Node): JsonataExpression;
+        prepareJSONataExpression(value: string, node: registry.Node): jsonata.Expression;
         /**
          * Evaluates a JSONata expression.
          * The expression must have been prepared with `prepareJSONataExpression`
@@ -289,7 +336,7 @@ declare namespace util {
          * @param   callback - a callback with the result of the expression
          */
         evaluateJSONataExpression(
-            expr: JsonataExpression,
+            expr: jsonata.Expression,
             msg: registry.NodeMessage,
             callback: (error: Error | null, result: any) => void,
         ): void;

--- a/types/node-red__util/node-red__util-tests.ts
+++ b/types/node-red__util/node-red__util-tests.ts
@@ -126,6 +126,81 @@ function utilTests(someNode: Node) {
     // $ExpectType void
     util.evaluateJSONataExpression(jsonataExpr, {}, (err: Error | null, res: any): void => {});
 
+    // $ExpectType Promise<any>
+    jsonataExpr.evaluate({});
+    // $ExpectType Promise<any>
+    jsonataExpr.evaluate({}, { value: 123 });
+    // $ExpectType void
+    jsonataExpr.evaluate({}, undefined, (err, result) => {
+        // $ExpectType string
+        err.code;
+        // $ExpectType number
+        err.position;
+        // $ExpectType string
+        err.token;
+        // $ExpectType string
+        err.message;
+        // $ExpectType any
+        result;
+    });
+    // $ExpectType void
+    jsonataExpr.evaluate({}, { value: 123 }, (err, result) => {});
+    // $ExpectType void
+    jsonataExpr.assign("value", 123);
+    // $ExpectType void
+    jsonataExpr.registerFunction("double", function(value: number) {
+        // $ExpectType any
+        this.input;
+        // $ExpectType Date
+        this.environment.timestamp;
+        // $ExpectType boolean
+        this.environment.async;
+        // $ExpectType void
+        this.environment.bind("value", value);
+        // $ExpectType any
+        this.environment.lookup("value");
+        // @ts-expect-error
+        this.environment.timestamp = new Date();
+        // @ts-expect-error
+        this.environment.async = false;
+        // @ts-expect-error
+        this.input = {};
+        // @ts-expect-error
+        this.environment = this.environment;
+        return value * 2;
+    }, "<n:n>");
+    // $ExpectType void
+    jsonataExpr.registerFunction("constant", () => 123);
+    // @ts-expect-error
+    jsonataExpr.assign(123, "value");
+    // @ts-expect-error
+    jsonataExpr.registerFunction("invalid", () => 123, 123);
+
+    // $ExpectType ExprNode
+    const ast = jsonataExpr.ast();
+    // $ExpectType string
+    ast.type;
+    // $ExpectType any
+    ast.value;
+    // $ExpectType number | undefined
+    ast.position;
+    // $ExpectType string | undefined
+    ast.name;
+    // $ExpectType ExprNode[] | undefined
+    ast.arguments;
+    // $ExpectType ExprNode[] | undefined
+    ast.steps;
+    // $ExpectType ExprNode[] | undefined
+    ast.expressions;
+    // $ExpectType ExprNode[] | undefined
+    ast.stages;
+    // $ExpectType ExprNode[] | undefined
+    ast.lhs;
+    // $ExpectType ExprNode | undefined
+    ast.procedure;
+    // $ExpectType ExprNode | undefined
+    ast.rhs;
+
     // $ExpectType string
     util.normaliseNodeTypeName("a-random node type");
 

--- a/types/node-red__util/package.json
+++ b/types/node-red__util/package.json
@@ -8,8 +8,7 @@
     ],
     "dependencies": {
         "@types/node-red__registry": "*",
-        "@types/node-red__runtime": "*",
-        "jsonata": "2.0.5"
+        "@types/node-red__runtime": "*"
     },
     "devDependencies": {
         "@types/node-red__util": "workspace:."


### PR DESCRIPTION
This is an alternative to #75419, which works thanks to structural typing.

But, it's already strange, because this package is node-red 1.3 which depends on jsonata v1?

Closes #75419