### PR TITLE
Fix react-native dependents broken by react-native 0.87's bundled types

### DIFF
--- a/types/react-native-material-design-searchbar/index.d.ts
+++ b/types/react-native-material-design-searchbar/index.d.ts
@@ -1,10 +1,10 @@
 import * as React from "react";
-import { ReturnKeyType, ReturnKeyTypeAndroid, ReturnKeyTypeIOS, TextInputProps, TextStyle } from "react-native";
+import { ReturnKeyTypeOptions, TextInputProps, TextStyle } from "react-native";
 
 export interface SearchBarProps {
     height: number;
     autoCorrect?: boolean | undefined;
-    returnKeyType?: ReturnKeyType | ReturnKeyTypeAndroid | ReturnKeyTypeIOS | undefined;
+    returnKeyType?: ReturnKeyTypeOptions | undefined;
     placeholder?: string | undefined;
     padding?: number | undefined;
     inputStyle?: TextStyle | undefined;

--- a/types/react-native-material-ripple/index.d.ts
+++ b/types/react-native-material-ripple/index.d.ts
@@ -1,8 +1,8 @@
 import * as React from "react";
-import { Animated, TouchableWithoutFeedback, ViewProps } from "react-native";
+import { Animated, TouchableWithoutFeedbackProps, ViewProps } from "react-native";
 
 export type RippleProps =
-    & TouchableWithoutFeedback["props"]
+    & TouchableWithoutFeedbackProps
     & Animated.AnimatedProps<ViewProps>
     & {
         rippleColor?: string | undefined;

--- a/types/react-native-material-ripple/react-native-material-ripple-tests.tsx
+++ b/types/react-native-material-ripple/react-native-material-ripple-tests.tsx
@@ -58,10 +58,8 @@ const RippleTest: React.FC = () => {
             delayLongPress={aNumber}
             delayPressIn={aNumber}
             delayPressOut={aNumber}
-            hasTVPreferredFocus
             hitSlop={insets}
             importantForAccessibility="auto"
-            isTVSelectable
             key={aNumber}
             nativeID={aString}
             style={[styles.wrapper]}
@@ -100,21 +98,6 @@ const RippleTest: React.FC = () => {
             removeClippedSubviews
             renderToHardwareTextureAndroid
             shouldRasterizeIOS
-            tvParallaxMagnification={aNumber}
-            // @ts-expect-error -- No longer part of props with latest `react-native` types
-            tvParallaxProperties={{
-                enabled: true,
-                shiftDistanceX: aNumber,
-                shiftDistanceY: aNumber,
-                tiltAngle: aNumber,
-                magnification: aNumber,
-                pressMagnification: aNumber,
-                pressDuration: aNumber,
-                pressDelay: aNumber,
-            }}
-            tvParallaxShiftDistanceX={aNumber}
-            tvParallaxShiftDistanceY={aNumber}
-            tvParallaxTiltAngle={aNumber}
         >
             <View />
         </Ripple>

--- a/types/react-native-modal-filter-picker/react-native-modal-filter-picker-tests.tsx
+++ b/types/react-native-modal-filter-picker/react-native-modal-filter-picker-tests.tsx
@@ -34,7 +34,7 @@ const renderPicker = () => (
         noResultsText="No matches"
         visible
         showFilter
-        modal={{ animated: true }}
+        modal={{ animationType: "slide" }}
         selectedOption="some-option-key"
         flatListProps={{ accessible: true }}
         renderOption={(option, isSelected) => (

--- a/types/react-native-platform-touchable/index.d.ts
+++ b/types/react-native-platform-touchable/index.d.ts
@@ -1,10 +1,20 @@
 import * as React from "react";
-import {
-    BackgroundPropType,
-    RippleBackgroundPropType,
-    ThemeAttributeBackgroundPropType,
-    TouchableWithoutFeedbackProps,
-} from "react-native";
+import { TouchableWithoutFeedbackProps } from "react-native";
+
+// These were removed from react-native's bundled types; they mirror the
+// TouchableNativeFeedback background values this library accepts and returns.
+export interface ThemeAttributeBackgroundPropType {
+    type: "ThemeAttrAndroid";
+    attribute: "selectableItemBackground" | "selectableItemBackgroundBorderless";
+}
+
+export interface RippleBackgroundPropType {
+    type: "RippleAndroid";
+    color?: number | null | undefined;
+    borderless?: boolean | undefined;
+}
+
+export type BackgroundPropType = ThemeAttributeBackgroundPropType | RippleBackgroundPropType;
 
 export interface PlatformTouchableProps extends TouchableWithoutFeedbackProps {
     // TouchableOpacity (default iOS)

--- a/types/react-native-responsive-image/index.d.ts
+++ b/types/react-native-responsive-image/index.d.ts
@@ -2,14 +2,13 @@ import * as React from "react";
 import {
     Image,
     ImageBackground,
-    ImageErrorEventData,
-    ImageLoadEventData,
-    ImageProgressEventDataIOS,
+    ImageErrorEvent,
+    ImageLoadEvent,
+    ImageProgressEventIOS,
     ImageResizeMode,
     ImageSourcePropType,
     ImageStyle,
     ImageURISource,
-    NativeSyntheticEvent,
     StyleProp,
 } from "react-native";
 
@@ -32,13 +31,13 @@ export interface ResponsiveImageProps {
     /**
      * Invoked on load error with {nativeEvent: {error}}
      */
-    onError?: ((error: NativeSyntheticEvent<ImageErrorEventData>) => void) | undefined;
+    onError?: ((error: ImageErrorEvent) => void) | undefined;
 
     /**
      * Invoked when load completes successfully
      * { source: { url, height, width } }.
      */
-    onLoad?: ((event: NativeSyntheticEvent<ImageLoadEventData>) => void) | undefined;
+    onLoad?: ((event: ImageLoadEvent) => void) | undefined;
 
     /**
      * Invoked when load either succeeds or fails
@@ -55,7 +54,7 @@ export interface ResponsiveImageProps {
     /**
      * Invoked on download progress with {nativeEvent: {loaded, total}}
      */
-    onProgress?: ((event: NativeSyntheticEvent<ImageProgressEventDataIOS>) => void) | undefined;
+    onProgress?: ((event: ImageProgressEventIOS) => void) | undefined;
 
     /**
      * The image source (either a remote URL or a local file resource).

--- a/types/react-native-side-menu/index.d.ts
+++ b/types/react-native-side-menu/index.d.ts
@@ -1,6 +1,10 @@
 import { Component, ReactNode } from "react";
 import { Animated, GestureResponderEvent, PanResponderGestureState, ViewStyle } from "react-native";
 
+// Removed from react-native's bundled type exports; matches the shape Animated
+// timing/spring callbacks receive.
+export type EndCallback = (result: { finished: boolean }) => void;
+
 export interface ReactNativeSideMenuProps {
     /**
      * Menu component
@@ -62,7 +66,7 @@ export interface ReactNativeSideMenuProps {
     /**
      * Callback when menu animation has completed.
      */
-    onAnimationComplete?: ((event: Animated.EndCallback) => void) | undefined;
+    onAnimationComplete?: ((event: EndCallback) => void) | undefined;
     /**
      * When true, content view will bounce back to openMenuOffset when dragged further
      * @default true

--- a/types/react-native-snap-carousel/index.d.ts
+++ b/types/react-native-snap-carousel/index.d.ts
@@ -233,7 +233,7 @@ export interface CarouselProps<T> {
      */
     slideInterpolatedStyle?(
         index: number,
-        animatedValue: Animated.AnimatedValue,
+        animatedValue: Animated.Value,
         carouselProps: CarouselProps<any>,
     ): StyleProp<ViewStyle>;
     /**

--- a/types/react-native-typing-animation/index.d.ts
+++ b/types/react-native-typing-animation/index.d.ts
@@ -1,11 +1,11 @@
-import { StyleSheetProperties } from "react-native";
+import { StyleProp, ViewStyle } from "react-native";
 
 import { JSX } from "react";
 
 export interface TypingAnimationProps {
-    style?: StyleSheetProperties;
+    style?: StyleProp<ViewStyle>;
     dotColor?: string;
-    dotStyles?: StyleSheetProperties;
+    dotStyles?: StyleProp<ViewStyle>;
     dotRadius?: number;
     dotMargin?: number;
     dotAmplitude?: number;

--- a/types/react-native-web/index.d.ts
+++ b/types/react-native-web/index.d.ts
@@ -25,7 +25,6 @@ import type {
     FlatList as FlatListRN,
     FlatListProps as FlatListPropsRN,
     GestureResponderEvent,
-    InteractionManager as InteractionManagerRN,
     LayoutAnimation as LayoutAnimationRN,
     MeasureInWindowOnSuccessCallback,
     MeasureLayoutOnSuccessCallback,
@@ -35,8 +34,8 @@ import type {
     SectionListProps as SectionListPropsRN,
     StyleProp,
     StyleSheet as StyleSheetRN,
-    TextStyle,
-    ViewStyle,
+    TextStyle as TextStyleRN,
+    ViewStyle as ViewStyleRN,
     VirtualizedList as VirtualizedListRN,
     VirtualizedListProps as VirtualizedListPropsRN,
 } from "react-native";
@@ -354,7 +353,7 @@ interface WebViewProps extends WebSharedProps {
 export interface WebStyle extends CSSProperties {
     // https://necolas.github.io/react-native-web/docs/styling/#non-standard-properties
     // Exclusive to react-native-web, "pointerEvents" already included on RN
-    animationKeyframes?: string | Record<string, ViewStyle>;
+    animationKeyframes?: string | Record<string, ViewStyleRN>;
     writingDirection?: "auto" | "ltr" | "rtl";
     enableBackground?: string;
 }
@@ -467,7 +466,26 @@ export interface Keyboard {
     removeListener(): void;
 }
 
-export type InteractionManager = typeof InteractionManagerRN;
+// react-native no longer exports InteractionManager types; declared from
+// react-native-web's implementation (exports/InteractionManager/index.js).
+export interface InteractionManager {
+    Events: {
+        interactionStart: string;
+        interactionComplete: string;
+    };
+    runAfterInteractions(task?: (() => void) | null): {
+        then: (...args: any[]) => void;
+        done: (...args: any[]) => void;
+        cancel: () => void;
+    };
+    createInteractionHandle(): number;
+    clearInteractionHandle(handle: number): void;
+    addListener(
+        eventType: "interactionStart" | "interactionComplete",
+        listener: () => void,
+    ): { remove(): void };
+    setDeadline(deadline: number): void;
+}
 
 export type LayoutAnimation = typeof LayoutAnimationRN;
 
@@ -798,6 +816,10 @@ export interface UIManager {
     setLayoutAnimationEnabledExperimental(value: boolean): void;
 }
 
+export const UIManager: UIManager;
+
+export {};
+
 export interface Vibration {
     cancel(): void;
     vibrate(pattern?: VibratePattern): void;
@@ -911,7 +933,7 @@ export interface ImageProps extends ViewProps {
         | "repeat"
         | "stretch";
     source?: number | string | SourceObject | SourceObject[];
-    style?: StyleProp<ViewStyle>;
+    style?: StyleProp<ViewStyleRN>;
     tintColor?: string | null;
 }
 export const Image: FunctionComponent<ImageProps & RefAttributes<typeof View>>;
@@ -919,14 +941,14 @@ export const Image: FunctionComponent<ImageProps & RefAttributes<typeof View>>;
 export interface ImageBackgroundProps extends ViewProps {
     animating?: boolean;
     imageRef?: any;
-    imageStyle?: StyleProp<ViewStyle>;
-    style?: StyleProp<ViewStyle>;
+    imageStyle?: StyleProp<ViewStyleRN>;
+    style?: StyleProp<ViewStyleRN>;
 }
 export const ImageBackground: FunctionComponent<ImageBackgroundProps & RefAttributes<typeof View>>;
 
 export interface KeyboardAvoidingViewProps extends ViewProps {
     behavior?: "height" | "padding" | "position";
-    contentContainerStyle?: StyleProp<ViewStyle>;
+    contentContainerStyle?: StyleProp<ViewStyleRN>;
     keyboardVerticalOffset: number;
 }
 export const KeyboardAvoidingView: ComponentClass<KeyboardAvoidingViewProps>;
@@ -1003,10 +1025,10 @@ export interface PressableProps extends ViewPropsWithoutStyle {
     // Called when the press is deactivated to undo visual feedback.
     onPressOut?: (event: any) => void;
     style?:
-        | StyleProp<ViewStyle>
+        | StyleProp<ViewStyleRN>
         | ((state: {
             pressed: boolean;
-        }) => StyleProp<ViewStyle>);
+        }) => StyleProp<ViewStyleRN>);
 }
 export const Pressable: FunctionComponent<PressableProps & RefAttributes<typeof View>>;
 
@@ -1037,7 +1059,7 @@ export const SafeAreaView: FunctionComponent<SafeAreaViewProps>;
 
 export interface ScrollViewProps extends ViewProps {
     centerContent?: boolean;
-    contentContainerStyle?: ViewStyle;
+    contentContainerStyle?: ViewStyleRN;
     horizontal?: boolean;
     keyboardDismissMode?: "none" | "interactive" | "on-drag";
     onContentSizeChange?: (event: any) => void;
@@ -1079,7 +1101,7 @@ export interface TextProps extends ViewPropsWithoutStyle {
         | "text"
         | "paragraph"
         | AriaRole;
-    style?: StyleProp<TextStyle>;
+    style?: StyleProp<TextStyleRN>;
     testID?: string;
     // @deprecated
     accessibilityRole?:
@@ -1148,7 +1170,7 @@ export interface TextInputProps extends ViewPropsWithoutStyle {
     selectionColor?: string | null;
     showSoftInputOnFocus?: boolean;
     spellCheck?: boolean;
-    style?: StyleProp<TextStyle>;
+    style?: StyleProp<TextStyleRN>;
     value?: string;
     // deprecated
     editable?: boolean;
@@ -1186,7 +1208,7 @@ export interface TouchableHighlightProps extends ViewProps {
     activeOpacity?: number;
     onHideUnderlay?: () => void;
     onShowUnderlay?: () => void;
-    style?: ViewStyle;
+    style?: ViewStyleRN;
     testOnly_pressed?: boolean;
     underlayColor?: string | null;
 }
@@ -1196,7 +1218,7 @@ export const TouchableNativeFeedback: ComponentClass;
 
 export interface TouchableOpacityProps extends ViewProps {
     activeOpacity?: number;
-    style?: StyleProp<ViewStyle>;
+    style?: StyleProp<ViewStyleRN>;
 }
 export const TouchableOpacity: FunctionComponent<TouchableOpacityProps & RefAttributes<typeof View>>;
 
@@ -1217,7 +1239,7 @@ export interface ViewProps extends AccessibilityPropsWeb, EventProps {
     dir?: "ltr" | "rtl";
     id?: string;
     lang?: string;
-    style?: StyleProp<ViewStyle>;
+    style?: StyleProp<ViewStyleRN>;
     tabIndex?: 0 | -1;
     testID?: string;
     // unstable
@@ -1232,7 +1254,7 @@ type ViewPropsWithoutStyle = Omit<ViewProps, "style">;
 
 export const View: FunctionComponent<ActivityIndicatorProps & RefAttributes<HTMLElement>>;
 
-export type VirtualizedListProps<ItemT> = VirtualizedListPropsRN<ItemT>;
+export type VirtualizedListProps<ItemT = unknown> = VirtualizedListPropsRN;
 export const VirtualizedList: typeof VirtualizedListRN;
 
 export const YellowBox: FunctionComponent<object>;
@@ -1266,277 +1288,99 @@ export function useWindowDimensions(): {
 
 export const unstable_createElement: typeof createElement;
 
-export {};
+// Web-specific versions of react-native's prop/style types. These were
+// previously applied to "react-native" via module augmentation, which is no
+// longer possible: react-native 0.87's bundled types declare these names as
+// type aliases, and type aliases cannot be merged with interfaces.
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface AccessibilityProps extends AccessibilityPropsWeb {}
 
-declare module "react-native" {
-    interface AccessibilityProps {
-        "aria-activedescendant"?: idRef;
-        "aria-atomic"?: boolean;
-        "aria-autocomplete"?: "none" | "list" | "inline" | "both";
-        "aria-busy"?: boolean;
-        "aria-checked"?: boolean | "mixed";
-        "aria-colcount"?: number;
-        "aria-colindex"?: number;
-        "aria-colspan"?: number;
-        "aria-controls"?: idRef;
-        "aria-current"?: boolean | "page" | "step" | "location" | "date" | "time";
-        "aria-describedby"?: idRef;
-        "aria-details"?: idRef;
-        "aria-disabled"?: boolean;
-        "aria-errormessage"?: idRef;
-        "aria-expanded"?: boolean;
-        "aria-flowto"?: idRef;
-        "aria-haspopup"?: "dialog" | "grid" | "listbox" | "menu" | "tree" | false;
-        "aria-hidden"?: boolean;
-        "aria-invalid"?: boolean;
-        "aria-keyshortcuts"?: string;
-        "aria-label"?: string;
-        "aria-labelledby"?: idRef;
-        "aria-level"?: number;
-        "aria-live"?: "assertive" | "off" | "polite";
-        "aria-modal"?: boolean;
-        "aria-multiline"?: boolean;
-        "aria-multiselectable"?: boolean;
-        "aria-orientation"?: "horizontal" | "vertical";
-        "aria-owns"?: idRef;
-        "aria-placeholder"?: string;
-        "aria-posinset"?: number;
-        "aria-pressed"?: boolean | "mixed";
-        "aria-readonly"?: boolean;
-        "aria-required"?: boolean;
-        "aria-roledescription"?: string;
-        "aria-rowcount"?: number;
-        "aria-rowindex"?: number;
-        "aria-rowspan"?: number;
-        "aria-selected"?: boolean;
-        "aria-setsize"?: number;
-        "aria-sort"?: "ascending" | "descending" | "none" | "other";
-        "aria-valuemax"?: number;
-        "aria-valuemin"?: number;
-        "aria-valuenow"?: number;
-        "aria-valuetext"?: string;
+// https://necolas.github.io/react-native-web/docs/pressable/#interactionstate
+export interface PressableStateCallbackType {
+    readonly focused: boolean;
+    readonly hovered: boolean;
+    readonly pressed: boolean;
+}
 
-        // @deprecated
-        accessibilityActiveDescendant?: idRef;
-        accessibilityAtomic?: boolean;
-        accessibilityAutoComplete?: "none" | "list" | "inline" | "both";
-        accessibilityBusy?: boolean;
-        accessibilityChecked?: boolean | "mixed";
-        accessibilityColumnCount?: number;
-        accessibilityColumnIndex?: number;
-        accessibilityColumnSpan?: number;
-        accessibilityControls?: idRefList;
-        accessibilityCurrent?: boolean | "page" | "step" | "location" | "date" | "time";
-        accessibilityDescribedBy?: idRefList;
-        accessibilityDetails?: idRef;
-        accessibilityDisabled?: boolean;
-        accessibilityErrorMessage?: idRef;
-        accessibilityExpanded?: boolean;
-        accessibilityFlowTo?: idRefList;
-        accessibilityHasPopup?: "dialog" | "grid" | "listbox" | "menu" | "tree" | false;
-        accessibilityHidden?: boolean;
-        accessibilityInvalid?: boolean;
-        accessibilityKeyShortcuts?: string[];
-        accessibilityLabel?: string;
-        accessibilityLabelledBy?: idRef;
-        accessibilityLevel?: number;
-        accessibilityLiveRegion?: "assertive" | "none" | "polite";
-        accessibilityModal?: boolean;
-        accessibilityMultiline?: boolean;
-        accessibilityMultiSelectable?: boolean;
-        accessibilityOrientation?: "horizontal" | "vertical";
-        accessibilityOwns?: idRefList;
-        accessibilityPlaceholder?: string;
-        accessibilityPosInSet?: number;
-        accessibilityPressed?: boolean | "mixed";
-        accessibilityReadOnly?: boolean;
-        accessibilityRequired?: boolean;
-        accessibilityRoleDescription?: string;
-        accessibilityRowCount?: number;
-        accessibilityRowIndex?: number;
-        accessibilityRowSpan?: number;
-        accessibilitySelected?: boolean;
-        accessibilitySetSize?: number;
-        accessibilitySort?: "ascending" | "descending" | "none" | "other";
-        accessibilityValueMax?: number;
-        accessibilityValueMin?: number;
-        accessibilityValueNow?: number;
-        accessibilityValueText?: string;
-    }
+export interface ViewStyle extends WebStyle {
+    // In order to overwrite properties from RN, we need to redefine them inside ViewStyle.
+    zIndex?: CSSProperties["zIndex"] | undefined;
+    overflow?: CSSProperties["overflow"] | undefined;
+    display?: CSSProperties["display"] | undefined;
+    position?: CSSProperties["position"] | undefined;
+    top?: CSSProperties["top"] | NonNullable<DimensionValue> | undefined;
+    right?: CSSProperties["right"] | NonNullable<DimensionValue> | undefined;
+    bottom?: CSSProperties["bottom"] | NonNullable<DimensionValue> | undefined;
+    left?: CSSProperties["left"] | NonNullable<DimensionValue> | undefined;
+    height?: CSSProperties["height"] | NonNullable<DimensionValue> | undefined;
+    width?: CSSProperties["width"] | NonNullable<DimensionValue> | undefined;
+    maxHeight?: CSSProperties["maxHeight"] | NonNullable<DimensionValue> | undefined;
+    maxWidth?: CSSProperties["maxWidth"] | NonNullable<DimensionValue> | undefined;
+    minHeight?: CSSProperties["minHeight"] | NonNullable<DimensionValue> | undefined;
+    minWidth?: CSSProperties["minWidth"] | NonNullable<DimensionValue> | undefined;
+    margin?: CSSProperties["margin"] | NonNullable<DimensionValue> | undefined;
+    marginTop?: CSSProperties["marginTop"] | NonNullable<DimensionValue> | undefined;
+    marginRight?: CSSProperties["marginRight"] | NonNullable<DimensionValue> | undefined;
+    marginBottom?: CSSProperties["marginBottom"] | NonNullable<DimensionValue> | undefined;
+    marginLeft?: CSSProperties["marginLeft"] | NonNullable<DimensionValue> | undefined;
+    padding?: CSSProperties["padding"] | NonNullable<DimensionValue> | undefined;
+    paddingTop?: CSSProperties["paddingTop"] | NonNullable<DimensionValue> | undefined;
+    paddingRight?: CSSProperties["paddingRight"] | NonNullable<DimensionValue> | undefined;
+    paddingBottom?: CSSProperties["paddingBottom"] | NonNullable<DimensionValue> | undefined;
+    paddingLeft?: CSSProperties["paddingLeft"] | NonNullable<DimensionValue> | undefined;
+}
 
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    interface ViewProps extends WebViewProps {}
+export interface TextStyle extends WebStyle {
+    // In order to overwrite properties from RN, we need to redefine them inside TextStyle.
+    zIndex?: CSSProperties["zIndex"] | undefined;
+    overflow?: CSSProperties["overflow"] | undefined;
+    display?: CSSProperties["display"] | undefined;
+    position?: CSSProperties["position"] | undefined;
+    top?: CSSProperties["top"] | NonNullable<DimensionValue> | undefined;
+    right?: CSSProperties["right"] | NonNullable<DimensionValue> | undefined;
+    bottom?: CSSProperties["bottom"] | NonNullable<DimensionValue> | undefined;
+    left?: CSSProperties["left"] | NonNullable<DimensionValue> | undefined;
+    height?: CSSProperties["height"] | NonNullable<DimensionValue> | undefined;
+    width?: CSSProperties["width"] | NonNullable<DimensionValue> | undefined;
+    maxHeight?: CSSProperties["maxHeight"] | NonNullable<DimensionValue> | undefined;
+    maxWidth?: CSSProperties["maxWidth"] | NonNullable<DimensionValue> | undefined;
+    minHeight?: CSSProperties["minHeight"] | NonNullable<DimensionValue> | undefined;
+    minWidth?: CSSProperties["minWidth"] | NonNullable<DimensionValue> | undefined;
+    margin?: CSSProperties["margin"] | NonNullable<DimensionValue> | undefined;
+    marginTop?: CSSProperties["marginTop"] | NonNullable<DimensionValue> | undefined;
+    marginRight?: CSSProperties["marginRight"] | NonNullable<DimensionValue> | undefined;
+    marginBottom?: CSSProperties["marginBottom"] | NonNullable<DimensionValue> | undefined;
+    marginLeft?: CSSProperties["marginLeft"] | NonNullable<DimensionValue> | undefined;
+    padding?: CSSProperties["padding"] | NonNullable<DimensionValue> | undefined;
+    paddingTop?: CSSProperties["paddingTop"] | NonNullable<DimensionValue> | undefined;
+    paddingRight?: CSSProperties["paddingRight"] | NonNullable<DimensionValue> | undefined;
+    paddingBottom?: CSSProperties["paddingBottom"] | NonNullable<DimensionValue> | undefined;
+    paddingLeft?: CSSProperties["paddingLeft"] | NonNullable<DimensionValue> | undefined;
+}
 
-    /**
-     * Text
-     * Extracted from react-native-web, packages/react-native-web/src/exports/Text/types.js
-     */
-    interface WebTextProps extends WebSharedProps {
-        dir?: "auto" | "ltr" | "rtl";
-    }
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    interface TextProps extends WebTextProps {
-        role?:
-            | "button"
-            | "header"
-            | "heading"
-            | "label"
-            | "link"
-            | "listitem"
-            | "none"
-            | "text"
-            | "paragraph"
-            | AriaRole;
-        // @deprecated
-        accessibilityRole?:
-            | "button"
-            | "header"
-            | "heading"
-            | "label"
-            | "link"
-            | "listitem"
-            | "none"
-            | "text";
-    }
-
-    /**
-     * TextInput
-     * Extracted from react-native-web, packages/react-native-web/src/exports/TextInput/types.js
-     */
-    interface WebTextInputProps extends WebSharedProps {
-        dir?: "auto" | "ltr" | "rtl";
-        disabled?: boolean;
-    }
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    interface TextInputProps extends WebTextInputProps {}
-
-    /**
-     * Image
-     * Extracted from react-native-web, packages/react-native-web/src/exports/Image/types.js
-     */
-    interface WebImageProps extends WebSharedProps {
-        dir?: "ltr" | "rtl";
-        draggable?: boolean;
-    }
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    interface ImageProps extends WebImageProps {}
-
-    /**
-     * ScrollView
-     * Extracted from react-native-web, packages/react-native-web/src/exports/ScrollView/ScrollViewBase.js
-     */
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    interface WebScrollViewProps extends WebSharedProps {}
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    interface ScrollViewProps extends WebScrollViewProps {}
-
-    /**
-     * Pressable
-     */
-    // https://necolas.github.io/react-native-web/docs/pressable/#interactionstate
-    // Extracted from react-native-web, packages/react-native-web/src/exports/Pressable/index.js
-    interface WebPressableStateCallbackType {
-        readonly focused: boolean;
-        readonly hovered: boolean;
-        readonly pressed: boolean;
-    }
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    interface PressableStateCallbackType extends WebPressableStateCallbackType {}
-
-    // Extracted from react-native-web, packages/react-native-web/src/exports/Pressable/index.js
-    interface WebPressableProps extends WebSharedProps {
-        /** Duration (in milliseconds) from `onPressStart` is called after pointerdown. */
-        delayPressIn?: number;
-        /** Duration (in milliseconds) from `onPressEnd` is called after pointerup. */
-        delayPressOut?: number;
-        /** Called when a touch is moving, after `onPressIn`. */
-        onPressMove?: (event: GestureResponderEvent) => void;
-    }
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    interface PressableProps extends WebPressableProps {}
-
-    interface ViewStyle extends WebStyle {
-        // In order to overwrite properties from RN, we need to redefine them inside ViewStyle.
-        zIndex?: CSSProperties["zIndex"] | undefined;
-        overflow?: CSSProperties["overflow"] | undefined;
-        display?: CSSProperties["display"] | undefined;
-        position?: CSSProperties["position"] | undefined;
-        top?: CSSProperties["top"] | DimensionValue | undefined;
-        right?: CSSProperties["right"] | DimensionValue | undefined;
-        bottom?: CSSProperties["bottom"] | DimensionValue | undefined;
-        left?: CSSProperties["left"] | DimensionValue | undefined;
-        height?: CSSProperties["height"] | DimensionValue | undefined;
-        width?: CSSProperties["width"] | DimensionValue | undefined;
-        maxHeight?: CSSProperties["maxHeight"] | DimensionValue | undefined;
-        maxWidth?: CSSProperties["maxWidth"] | DimensionValue | undefined;
-        minHeight?: CSSProperties["minHeight"] | DimensionValue | undefined;
-        minWidth?: CSSProperties["minWidth"] | DimensionValue | undefined;
-        margin?: CSSProperties["margin"] | DimensionValue | undefined;
-        marginTop?: CSSProperties["marginTop"] | DimensionValue | undefined;
-        marginRight?: CSSProperties["marginRight"] | DimensionValue | undefined;
-        marginBottom?: CSSProperties["marginBottom"] | DimensionValue | undefined;
-        marginLeft?: CSSProperties["marginLeft"] | DimensionValue | undefined;
-        padding?: CSSProperties["padding"] | DimensionValue | undefined;
-        paddingTop?: CSSProperties["paddingTop"] | DimensionValue | undefined;
-        paddingRight?: CSSProperties["paddingRight"] | DimensionValue | undefined;
-        paddingBottom?: CSSProperties["paddingBottom"] | DimensionValue | undefined;
-        paddingLeft?: CSSProperties["paddingLeft"] | DimensionValue | undefined;
-    }
-
-    interface TextStyle extends WebStyle {
-        // In order to overwrite properties from RN, we need to redefine them inside TextStyle.
-        zIndex?: CSSProperties["zIndex"] | undefined;
-        overflow?: CSSProperties["overflow"] | undefined;
-        display?: CSSProperties["display"] | undefined;
-        position?: CSSProperties["position"] | undefined;
-        top?: CSSProperties["top"] | DimensionValue | undefined;
-        right?: CSSProperties["right"] | DimensionValue | undefined;
-        bottom?: CSSProperties["bottom"] | DimensionValue | undefined;
-        left?: CSSProperties["left"] | DimensionValue | undefined;
-        height?: CSSProperties["height"] | DimensionValue | undefined;
-        width?: CSSProperties["width"] | DimensionValue | undefined;
-        maxHeight?: CSSProperties["maxHeight"] | DimensionValue | undefined;
-        maxWidth?: CSSProperties["maxWidth"] | DimensionValue | undefined;
-        minHeight?: CSSProperties["minHeight"] | DimensionValue | undefined;
-        minWidth?: CSSProperties["minWidth"] | DimensionValue | undefined;
-        margin?: CSSProperties["margin"] | DimensionValue | undefined;
-        marginTop?: CSSProperties["marginTop"] | DimensionValue | undefined;
-        marginRight?: CSSProperties["marginRight"] | DimensionValue | undefined;
-        marginBottom?: CSSProperties["marginBottom"] | DimensionValue | undefined;
-        marginLeft?: CSSProperties["marginLeft"] | DimensionValue | undefined;
-        padding?: CSSProperties["padding"] | DimensionValue | undefined;
-        paddingTop?: CSSProperties["paddingTop"] | DimensionValue | undefined;
-        paddingRight?: CSSProperties["paddingRight"] | DimensionValue | undefined;
-        paddingBottom?: CSSProperties["paddingBottom"] | DimensionValue | undefined;
-        paddingLeft?: CSSProperties["paddingLeft"] | DimensionValue | undefined;
-    }
-
-    interface ImageStyle extends WebStyle {
-        // In order to overwrite properties from RN, we need to redefine them inside ImageStyle.
-        zIndex?: CSSProperties["zIndex"] | undefined;
-        display?: CSSProperties["display"] | undefined;
-        position?: CSSProperties["position"] | undefined;
-        top?: CSSProperties["top"] | DimensionValue | undefined;
-        right?: CSSProperties["right"] | DimensionValue | undefined;
-        bottom?: CSSProperties["bottom"] | DimensionValue | undefined;
-        left?: CSSProperties["left"] | DimensionValue | undefined;
-        height?: CSSProperties["height"] | DimensionValue | undefined;
-        width?: CSSProperties["width"] | DimensionValue | undefined;
-        maxHeight?: CSSProperties["maxHeight"] | DimensionValue | undefined;
-        maxWidth?: CSSProperties["maxWidth"] | DimensionValue | undefined;
-        minHeight?: CSSProperties["minHeight"] | DimensionValue | undefined;
-        minWidth?: CSSProperties["minWidth"] | DimensionValue | undefined;
-        margin?: CSSProperties["margin"] | DimensionValue | undefined;
-        marginTop?: CSSProperties["marginTop"] | DimensionValue | undefined;
-        marginRight?: CSSProperties["marginRight"] | DimensionValue | undefined;
-        marginBottom?: CSSProperties["marginBottom"] | DimensionValue | undefined;
-        marginLeft?: CSSProperties["marginLeft"] | DimensionValue | undefined;
-        padding?: CSSProperties["padding"] | DimensionValue | undefined;
-        paddingTop?: CSSProperties["paddingTop"] | DimensionValue | undefined;
-        paddingRight?: CSSProperties["paddingRight"] | DimensionValue | undefined;
-        paddingBottom?: CSSProperties["paddingBottom"] | DimensionValue | undefined;
-        paddingLeft?: CSSProperties["paddingLeft"] | DimensionValue | undefined;
-    }
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    interface UIManagerStatic extends UIManager {}
+export interface ImageStyle extends WebStyle {
+    // In order to overwrite properties from RN, we need to redefine them inside ImageStyle.
+    zIndex?: CSSProperties["zIndex"] | undefined;
+    display?: CSSProperties["display"] | undefined;
+    position?: CSSProperties["position"] | undefined;
+    top?: CSSProperties["top"] | NonNullable<DimensionValue> | undefined;
+    right?: CSSProperties["right"] | NonNullable<DimensionValue> | undefined;
+    bottom?: CSSProperties["bottom"] | NonNullable<DimensionValue> | undefined;
+    left?: CSSProperties["left"] | NonNullable<DimensionValue> | undefined;
+    height?: CSSProperties["height"] | NonNullable<DimensionValue> | undefined;
+    width?: CSSProperties["width"] | NonNullable<DimensionValue> | undefined;
+    maxHeight?: CSSProperties["maxHeight"] | NonNullable<DimensionValue> | undefined;
+    maxWidth?: CSSProperties["maxWidth"] | NonNullable<DimensionValue> | undefined;
+    minHeight?: CSSProperties["minHeight"] | NonNullable<DimensionValue> | undefined;
+    minWidth?: CSSProperties["minWidth"] | NonNullable<DimensionValue> | undefined;
+    margin?: CSSProperties["margin"] | NonNullable<DimensionValue> | undefined;
+    marginTop?: CSSProperties["marginTop"] | NonNullable<DimensionValue> | undefined;
+    marginRight?: CSSProperties["marginRight"] | NonNullable<DimensionValue> | undefined;
+    marginBottom?: CSSProperties["marginBottom"] | NonNullable<DimensionValue> | undefined;
+    marginLeft?: CSSProperties["marginLeft"] | NonNullable<DimensionValue> | undefined;
+    padding?: CSSProperties["padding"] | NonNullable<DimensionValue> | undefined;
+    paddingTop?: CSSProperties["paddingTop"] | NonNullable<DimensionValue> | undefined;
+    paddingRight?: CSSProperties["paddingRight"] | NonNullable<DimensionValue> | undefined;
+    paddingBottom?: CSSProperties["paddingBottom"] | NonNullable<DimensionValue> | undefined;
+    paddingLeft?: CSSProperties["paddingLeft"] | NonNullable<DimensionValue> | undefined;
 }

--- a/types/react-native-web/react-native-web-tests.tsx
+++ b/types/react-native-web/react-native-web-tests.tsx
@@ -1,18 +1,6 @@
 import {
+    // web-extended versions of react-native's types
     AccessibilityProps,
-    ImageStyle,
-    PressableProps,
-    PressableStateCallbackType,
-    ScrollViewProps,
-    TextInputProps,
-    TextProps,
-    TextStyle,
-    UIManager,
-    ViewProps,
-    ViewStyle,
-} from "react-native";
-
-import {
     // components
     ActivityIndicator,
     Button,
@@ -24,24 +12,32 @@ import {
     Image,
     ImageBackground,
     ImageProps,
+    ImageStyle,
     KeyboardAvoidingView,
     KeyboardProps,
     Modal,
     Picker,
     Pressable,
+    PressableProps,
+    PressableStateCallbackType,
     ProgressBar,
     RefreshControl,
     SafeAreaView,
     ScrollView,
+    ScrollViewProps,
     SectionList,
     StatusBar,
     Switch,
     Text,
     TextInput,
+    TextInputProps,
+    TextProps,
+    TextStyle,
     TouchableHighlight,
     TouchableNativeFeedback,
     TouchableOpacity,
     TouchableWithoutFeedback,
+    UIManager,
     // unstable APIs
     unstable_createElement,
     // hooks
@@ -49,6 +45,8 @@ import {
     useLocaleContext,
     useWindowDimensions,
     View,
+    ViewProps,
+    ViewStyle,
     VirtualizedList,
     YellowBox,
 } from "react-native-web";
@@ -100,6 +98,7 @@ const scrollViewProps: ScrollViewProps = {
 };
 
 const pressableProps: PressableProps = {
+    children: null,
     delayPressIn: 1,
     delayPressOut: 1,
     onPressMove: (event) => {
@@ -379,6 +378,8 @@ const virtualizedList = (
             console.log(item);
             return "key";
         }}
+        getItem={(data, index) => data[index]}
+        getItemCount={(data) => data.length}
     />
 );
 const yellowBox = <YellowBox />;

--- a/types/react-router-navigation-core/package.json
+++ b/types/react-router-navigation-core/package.json
@@ -7,7 +7,7 @@
     ],
     "dependencies": {
         "@types/history": "^4.7.11",
-        "@types/react": "^17",
+        "@types/react": "*",
         "react-native": "*",
         "@types/react-native-tab-view": "^1.0.6",
         "@types/react-router": "^5.1.0"

--- a/types/react-router-navigation-core/tsconfig.json
+++ b/types/react-router-navigation-core/tsconfig.json
@@ -11,12 +11,7 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "forceConsistentCasingInFileNames": true,
-        "noEmit": true,
-        "paths": {
-            "react": [
-                "../react/v17/index.d.ts"
-            ]
-        }
+        "noEmit": true
     },
     "files": [
         "index.d.ts",

--- a/types/react-router-navigation/package.json
+++ b/types/react-router-navigation/package.json
@@ -6,7 +6,7 @@
         "https://github.com/LeoLeBras/react-router-navigation#readme"
     ],
     "dependencies": {
-        "@types/react": "^17",
+        "@types/react": "*",
         "react-native": "*",
         "@types/react-navigation": "3.0.8",
         "@types/react-router-navigation-core": "*"

--- a/types/react-router-navigation/tsconfig.json
+++ b/types/react-router-navigation/tsconfig.json
@@ -11,12 +11,7 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "forceConsistentCasingInFileNames": true,
-        "noEmit": true,
-        "paths": {
-            "react": [
-                "../react/v17/index.d.ts"
-            ]
-        }
+        "noEmit": true
     },
     "files": [
         "index.d.ts",

--- a/types/rn-material-ui-textfield/index.d.ts
+++ b/types/rn-material-ui-textfield/index.d.ts
@@ -1,14 +1,5 @@
 import * as React from "react";
-import {
-    ColorValue,
-    NativeSyntheticEvent,
-    StyleProp,
-    TextInputChangeEventData,
-    TextInputFocusEventData,
-    TextInputProps,
-    TextStyle,
-    ViewStyle,
-} from "react-native";
+import { ColorValue, NativeSyntheticEvent, StyleProp, TextInputProps, TextStyle, ViewStyle } from "react-native";
 
 export interface ContentInset {
     top?: number | undefined;


### PR DESCRIPTION
Fixes the react-native-dependent packages whose tests broke when react-native 0.87 (latest since 2026-08-26 via 0.87.1) shipped regenerated bundled types. The failures surface on any PR that retests the whole `@types/react` dependent graph, e.g. the React 19.3 PR's CI: https://github.com/DefinitelyTyped/DefinitelyTyped/actions/runs/34244856835.

react-native 0.87 removed or renamed several long-standing exported types: `AnimatedValue`, `Animated.EndCallback`, the `*EventData` event payloads (now full `*Event` types), `ReturnKeyType`/`ReturnKeyTypeAndroid`/`ReturnKeyTypeIOS` (now `ReturnKeyTypeOptions`), the `TouchableNativeFeedback` background types, `StyleSheetProperties`, and `InteractionManager`. It also removed `ModalProps.animated`, dropped the Apple TV props from `ViewProps`/`TouchableWithoutFeedbackProps`, made `VirtualizedListProps` non-generic, typed built-in components as function components returning `ReactNode`, and added `null` to `DimensionValue`.

The updates per package: renamed types are swapped for their modern equivalents (`react-native-snap-carousel`, `rn-material-ui-textfield`, `react-native-material-design-searchbar`, `react-native-responsive-image`, `react-native-material-ripple`, `react-native-typing-animation`). Removed types that the libraries still mirror at runtime are declared locally (`react-native-platform-touchable`, `react-native-side-menu`). Tests stop passing props that no longer exist upstream (`react-native-modal-filter-picker`, `react-native-material-ripple`). The two `react-router-navigation` packages drop their tsconfig pin to the react/v17 types, which cannot typecheck react-native 0.87's React 19-style components, and move to `@types/react` `*`. For `react-native-web`, the `declare module "react-native"` augmentation is removed because interfaces cannot merge into the type aliases react-native now ships; the web-extended prop and style types are exported from `react-native-web` directly instead, and `UIManager` and `InteractionManager` are declared locally since react-native no longer exports their types.
