### PR TITLE
[n3] add emptyFormulaAsTrue to ParserOptions

### DIFF
--- a/types/n3/index.d.ts
+++ b/types/n3/index.d.ts
@@ -201,10 +201,12 @@ export interface ParserOptions {
     baseIRI?: string | undefined;
     blankNodePrefix?: string | undefined;
     isImpliedBy?: boolean | undefined;
+    emptyFormulaAsTrue?: boolean | undefined;
 }
 
 export interface StreamParserOptions extends ParserOptions {
     options?: boolean | undefined;
+    comments?: boolean | undefined;
 }
 
 export type ParseCallback<Q extends BaseQuad = Quad> = (error: Error, quad: Q, prefixes: Prefixes) => void;

--- a/types/n3/n3-tests.ts
+++ b/types/n3/n3-tests.ts
@@ -522,6 +522,16 @@ function test_parser_options() {
         format: "text/Turtle*",
         blankNodePrefix: "",
     });
+    const parser7 = new N3.Parser({
+        baseIRI: "http://example.org/",
+        factory: N3.DataFactory,
+        format: "text/n3",
+        blankNodePrefix: "",
+        emptyFormulaAsTrue: true,
+    });
+    const streamParser = new N3.StreamParser({
+        comments: true,
+    });
 }
 
 function test_term_to_and_from_id() {


### PR DESCRIPTION
#### PR Description:

* [x] Use a meaningful title for the pull request. Include the name of the package modified.
* [x] Test the change in your own code. (Compile and run.)
* [x] [[Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs)](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
* [x] Follow the advice from the [[readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request)](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
* [x] Avoid [[common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes)](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
* [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

* [x] Provide a URL to documentation or source code which provides context for the suggested changes:

  * `emptyFormulaAsTrue`: https://github.com/rdfjs/N3.js#from-a-representation-to-quads (line 199 in README)
  * `comments`: https://github.com/rdfjs/N3.js#from-an-rdf-stream-to-quads (line 234 in README) and source in https://github.com/rdfjs/N3.js/blob/master/src/N3StreamParser.js#L22-L23
* [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---

### Summary of changes:

The `N3.Parser` constructor accepts an `emptyFormulaAsTrue` boolean flag to parse empty formulas `{}` as boolean literal `true` (as per the N3 spec tests), and `N3.StreamParser` accepts a `comments` boolean flag to emit dedicated comment events. Both options are documented in the official N3.js README.

This PR:

1. Adds `emptyFormulaAsTrue?: boolean | undefined;` to `ParserOptions`.
2. Adds `comments?: boolean | undefined;` to `StreamParserOptions`.
3. Adds test cases exercising both options in `types/n3/n3-tests.ts`.