### PR TITLE
[node] add MockModuleOptions.exports to v24 types

### DIFF
--- a/types/node/v24/test.d.ts
+++ b/types/node/v24/test.d.ts
@@ -1494,19 +1494,40 @@ declare module "node:test" {
              */
             cache?: boolean | undefined;
             /**
-             * The value to use as the mocked module's default export.
-             *
-             * If this value is not provided, ESM mocks do not include a default export.
-             * If the mock is a CommonJS or builtin module, this setting is used as the value of `module.exports`.
-             * If this value is not provided, CJS and builtin mocks use an empty object as the value of `module.exports`.
+             * Optional mocked exports. The `default` property, if
+             * provided, is used as the mocked module's default export. All other own
+             * enumerable properties are used as named exports.
+             * **This option cannot be used with `defaultExport` or `namedExports`.**
+             * * If the mock is a CommonJS or builtin module, `exports.default` is used as
+             *   the value of `module.exports`.
+             * * If `exports.default` is not provided for a CommonJS or builtin mock,
+             *   `module.exports` defaults to an empty object.
+             * * If named exports are provided with a non-object default export, the mock
+             *   throws an exception when used as a CommonJS or builtin module.
+             */
+            exports?: object | undefined;
+            /**
+             * An optional value used as the mocked module's default
+             * export. If this value is not provided, ESM mocks do not include a default
+             * export. If the mock is a CommonJS or builtin module, this setting is used as
+             * the value of `module.exports`. If this value is not provided, CJS and builtin
+             * mocks use an empty object as the value of `module.exports`.
+             * **This option cannot be used with `options.exports`.**
+             * This option is deprecated and will be removed in a later version.
+             * Prefer `options.exports.default`.
+             * @deprecated
              */
             defaultExport?: any;
             /**
-             * An object whose keys and values are used to create the named exports of the mock module.
-             *
-             * If the mock is a CommonJS or builtin module, these values are copied onto `module.exports`.
-             * Therefore, if a mock is created with both named exports and a non-object default export,
-             * the mock will throw an exception when used as a CJS or builtin module.
+             * An optional object whose keys and values are used to
+             * create the named exports of the mock module. If the mock is a CommonJS or
+             * builtin module, these values are copied onto `module.exports`. Therefore, if a
+             * mock is created with both named exports and a non-object default export, the
+             * mock will throw an exception when used as a CJS or builtin module.
+             * **This option cannot be used with `options.exports`.**
+             * This option is deprecated and will be removed in a later version.
+             * Prefer `options.exports`.
+             * @deprecated
              */
             namedExports?: object | undefined;
         }

--- a/types/node/v24/test/test.ts
+++ b/types/node/v24/test/test.ts
@@ -801,15 +801,12 @@ test("mocks a module", (t) => {
     // module specifier as a string
     // $ExpectType MockModuleContext
     const mock = t.mock.module("node:readline", {
-        namedExports: {
-            fn() {
+        exports: {
+            default: class Exported {},
+            foo() {
                 return 42;
             },
-        },
-        defaultExport: {
-            foo() {
-                return "bar";
-            },
+            bar: 42,
         },
         cache: true,
     });


### PR DESCRIPTION
## Why

Node 24.21's runtime accepts the consolidated `exports` option on `mock.module()` (nodejs/node#61727, highlighted in the [v25.9.0 release notes](https://nodejs.org/en/blog/release/v25.9.0) as the replacement for `defaultExport`/`namedExports`). The v24 type definitions, however, predate the option, so valid code fails typecheck:

```ts
mock.module("./mod.ts", { exports: { foo: 1 } }); // error TS2353: 'exports' does not exist in type 'MockModuleOptions'
```

`@types/node@24.13.3` (the latest 24.x release) is affected; the v25 and v26 types already carry the option.

## What this changes

- `types/node/v24/test.d.ts`: adds `exports?: object | undefined` to `MockModuleOptions`, and annotates `defaultExport`/`namedExports` as `@deprecated` — all ported **verbatim** from `types/node/v25/test.d.ts`, which documents the same runtime behavior that Node 24.21 exhibits (both options are accepted at runtime; `namedExports` warns via DEP-level deprecation).
- `types/node/v24/test/test.ts`: updates the "mocks a module" dtslint test to the v25 variant, exercising the `exports` option.

Verified against a Node 24.21.0 runtime that `mock.module(..., { exports })` is accepted and `namedExports` produces a DeprecationWarning, i.e. the v25 interface block describes the v24 runtime accurately.

---

- [x] I have reviewed the [authoring guidelines](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md)
- [x] This is a bug fix for an existing package (a minor version bump) — test fix included
- [x] (no new package; modifies existing `node` types under `types/node/v24`)

🤖 Generated with [OpenCode](https://opencode.ai) (Bsp-agent)