### PR TITLE
[aws-lambda] Allow missing JWT authorizer context fields

### DIFF
--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -18,6 +18,7 @@ declare let bool: boolean;
 declare let boolOrUndefined: boolean | undefined;
 declare let boolOrNumOrStr: boolean | number | string;
 declare let numOrUndefined: number | undefined;
+declare let numOrUndefinedOrNull: number | undefined | null;
 declare let strArrayOrUndefined: string[] | undefined;
 declare let nullOrUndefined: null | undefined;
 declare let objectOrUndefined: {} | undefined;
@@ -149,7 +150,7 @@ const untypedCallbackHandler: AWSLambda.Handler = (event, context, cb) => {
 
 /* In node8.10 runtime, handlers may return a promise for the result value, so existing async
  * handlers that return Promise<void> before calling the callback will now have a `null` result.
- * Be safe and make that badly typed with a major verson bump to 8.10 so users expect the breaking change,
+ * Be safe and make that badly typed with a major version bump to 8.10 so users expect the breaking change,
  * since the upgrade effort should be pretty low in most cases, and it points them at a nicer solution.
  */
 

--- a/types/aws-lambda/test/api-gateway-tests.ts
+++ b/types/aws-lambda/test/api-gateway-tests.ts
@@ -358,8 +358,8 @@ const proxyHandlerv2WithJKTAuthorizer: APIGatewayProxyHandlerV2WithJWTAuthorizer
     }
     const nullableScopes: string[] | null = authorizer.jwt.scopes;
     // And these extra properties are added
-    str = authorizer.principalId;
-    num = authorizer.integrationLatency;
+    strOrUndefinedOrNull = authorizer.principalId;
+    numOrUndefinedOrNull = authorizer.integrationLatency;
 
     const result = createProxyResult();
 

--- a/types/aws-lambda/trigger/api-gateway-proxy.d.ts
+++ b/types/aws-lambda/trigger/api-gateway-proxy.d.ts
@@ -254,8 +254,8 @@ export interface APIGatewayEventRequestContextLambdaAuthorizer<TAuthorizerContex
  * JWT Authorizer Payload
  */
 export interface APIGatewayEventRequestContextJWTAuthorizer {
-    principalId: string;
-    integrationLatency: number;
+    principalId?: string | null;
+    integrationLatency?: number | null;
     jwt: {
         claims: { [name: string]: string | number | boolean | string[] };
         scopes: string[] | null;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the
  package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change.
- [x] Follow the advice from the readme.
- [x] Avoid common mistakes.
- [ ] Run `pnpm test aws-lambda`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for
  the suggested changes:
  https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
- [ ] If this PR brings the type definitions up to date with a new version of
  the JS library, update the version number in the `package.json`.

This updates `APIGatewayEventRequestContextJWTAuthorizer` so that
`principalId` and `integrationLatency` are no longer required:

```ts
principalId?: string | null;
integrationLatency?: number | null;
```

I have observed these fields completely omitted from the object my lambda received. Also, the example object in the docs linked above omits them.

I used `key?: string | null` instead of just `key?: string` as a defensive choice because these AWS event typings have already been wrong in multiple ways, including jwt.scopes incorrectly excluding null and these fields incorrectly being required (see #75458), so I did not want to assume AWS will always represent a missing value by omission rather than explicit null.

<details>
<summary>Example object from docs:</summary>

```json
{
  "version": "2.0",
  "routeKey": "$default",
  "rawPath": "/my/path",
  "rawQueryString": "parameter1=value1&parameter1=value2&parameter2=value",
  "cookies": [
    "cookie1",
    "cookie2"
  ],
  "headers": {
    "header1": "value1",
    "header2": "value1,value2"
  },
  "queryStringParameters": {
    "parameter1": "value1,value2",
    "parameter2": "value"
  },
  "requestContext": {
    "accountId": "123456789012",
    "apiId": "api-id",
    "authentication": {
      "clientCert": {
        "clientCertPem": "CERT_CONTENT",
        "subjectDN": "www.example.com",
        "issuerDN": "Example issuer",
        "serialNumber": "a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1",
        "validity": {
          "notBefore": "May 28 12:30:02 2019 GMT",
          "notAfter": "Aug  5 09:36:04 2021 GMT"
        }
      }
    },
    "authorizer": {
      "jwt": {
        "claims": {
          "claim1": "value1",
          "claim2": "value2"
        },
        "scopes": [
          "scope1",
          "scope2"
        ]
      }
    },
    "domainName": "id.execute-api.us-east-1.amazonaws.com",
    "domainPrefix": "id",
    "http": {
      "method": "POST",
      "path": "/my/path",
      "protocol": "HTTP/1.1",
      "sourceIp": "192.0.2.1",
      "userAgent": "agent"
    },
    "requestId": "id",
    "routeKey": "$default",
    "stage": "$default",
    "time": "12/Mar/2020:19:03:58 +0000",
    "timeEpoch": 1583348638390
  },
  "body": "Hello from Lambda",
  "pathParameters": {
    "parameter1": "value1"
  },
  "isBase64Encoded": false,
  "stageVariables": {
    "stageVariable1": "value1",
    "stageVariable2": "value2"
  }
}
```

</details>