### PR TITLE
[plotly.js] Add properties of `PlotData` for linear space

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -1536,6 +1536,10 @@ export interface PlotData {
     x: Datum[] | Datum[][] | TypedArray;
     y: Datum[] | Datum[][] | TypedArray;
     z: Datum[] | Datum[][] | Datum[][][] | TypedArray;
+    x0: string | number;
+    y0: string | number;
+    dx: number;
+    dy: number;
     i: TypedArray;
     j: TypedArray;
     k: TypedArray;

--- a/types/plotly.js/test/core-tests.ts
+++ b/types/plotly.js/test/core-tests.ts
@@ -28,7 +28,15 @@ const trace2 = {
     ],
     type: "scatter",
 } as ScatterData;
-const data = [trace1, trace2];
+const trace3 = {
+    x0: 1999,
+    dx: 1,
+    y0: 0,
+    dy: 5,
+    z: [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]],
+    type: "heatmap",
+} as PlotData;
+const data = [trace1, trace2, trace3];
 const tickangle: "auto" = "auto";
 const layout = {
     title: {

--- a/types/plotly.js/v2/index.d.ts
+++ b/types/plotly.js/v2/index.d.ts
@@ -1542,6 +1542,10 @@ export interface PlotData {
     x: Datum[] | Datum[][] | TypedArray;
     y: Datum[] | Datum[][] | TypedArray;
     z: Datum[] | Datum[][] | Datum[][][] | TypedArray;
+    x0: string | number;
+    y0: string | number;
+    dx: number;
+    dy: number;
     i: TypedArray;
     j: TypedArray;
     k: TypedArray;

--- a/types/plotly.js/v2/test/core-tests.ts
+++ b/types/plotly.js/v2/test/core-tests.ts
@@ -28,7 +28,15 @@ const trace2 = {
     ],
     type: "scatter",
 } as ScatterData;
-const data = [trace1, trace2];
+const trace3 = {
+    x0: 1999,
+    dx: 1,
+    y0: 0,
+    dy: 5,
+    z: [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]],
+    type: "heatmap",
+} as PlotData;
+const data = [trace1, trace2, trace3];
 const tickangle: "auto" = "auto";
 const layout = {
     title: {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://plotly.com/javascript/reference/#scatter-x0
  - https://plotly.com/javascript/reference/#scatter-dx

----

Plotly.js can accept not only _N_-point X-Y pair data but _N_-point Y data evenly spaced on X-axis (and X data on Y-axis) as `scatter`-type data. even-spaced scaling can be used also for `heatmap`, `contour`, and some other plot types. One can find them by typing `dx` or `dy` in the search field in the [official documentation page](https://plotly.com/javascript/reference/).

I added four properties of `PlotData` for the even scaling, `x0`, `dx`, `y0`, and `dy`. I found these properties are also available in old Plotly version 2 (I tested to draw a heatmap with plotly-2.35.2.min.js and succeeded) and so, I also modified files in the `v2` directory.