### PR TITLE
three: fix SVGResult.xml type to SVGSVGElement

### DIFF
--- a/types/three/examples/jsm/loaders/SVGLoader.d.ts
+++ b/types/three/examples/jsm/loaders/SVGLoader.d.ts
@@ -2,7 +2,7 @@ import { BufferGeometry, Loader, LoadingManager, MeshBasicMaterial, Shape, Shape
 
 export interface SVGResult {
     paths: ShapePath[];
-    xml: XMLDocument;
+    xml: SVGSVGElement;
 }
 
 export interface StrokeStyle {

--- a/types/three/test/unit/examples/jsm/loaders/SVGLoader.ts
+++ b/types/three/test/unit/examples/jsm/loaders/SVGLoader.ts
@@ -1,0 +1,7 @@
+import { SVGLoader } from "three/addons/loaders/SVGLoader.js";
+
+const loader = new SVGLoader();
+const result = loader.parse(`<svg xmlns="http://www.w3.org/2000/svg"></svg>`);
+
+// $ExpectType SVGSVGElement
+result.xml;

--- a/types/three/tsconfig.json
+++ b/types/three/tsconfig.json
@@ -33,6 +33,7 @@
         "test/unit/examples/jsm/libs/lil-gui.ts",
         "test/unit/examples/jsm/libs/tween.ts",
         "test/unit/examples/jsm/lines/LineMaterial.ts",
+        "test/unit/examples/jsm/loaders/SVGLoader.ts",
         "test/unit/examples/jsm/postprocessing/EffectComposer.ts",
         "test/unit/examples/jsm/postprocessing/SavePass.ts",
         "test/unit/examples/jsm/shaders/ACESFilmicToneMappingShader.ts",


### PR DESCRIPTION
`SVGLoader.parse()` returns `xml.documentElement` from a `DOMParser` result, which is the parsed SVG root element, not an `XMLDocument`.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [three.js/examples/jsm/loaders/SVGLoader.js](https://github.com/mrdoob/three.js/blob/148ef33ecb6d2502ff796d4554abd1549c95d519/examples/jsm/loaders/SVGLoader.js#L2144-L2161)
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.~~

## Example
```js
// before change:
(new DOMParser().parseFromString(`<svg xmlns="http://www.w3.org/2000/svg"></svg>`, 'image/svg+xml')).documentElement instanceof XMLDocument === false
// after change:
(new DOMParser().parseFromString(`<svg xmlns="http://www.w3.org/2000/svg"></svg>`, 'image/svg+xml')).documentElement instanceof SVGSVGElement === true
```