### PR TITLE
[geobuf] Update types for v4

### DIFF
--- a/types/geobuf/geobuf-tests.ts
+++ b/types/geobuf/geobuf-tests.ts
@@ -1,6 +1,6 @@
 import * as geobuf from "geobuf";
 import { GeoJSON } from "geojson";
-import Pbf = require("pbf");
+import Pbf from "pbf";
 
 geobuf.decode(new Pbf(Uint8Array.from([]))); // $ExpectType GeoJSON || GeoJSON<Geometry, GeoJsonProperties>
 const geojson: GeoJSON = {

--- a/types/geobuf/index.d.ts
+++ b/types/geobuf/index.d.ts
@@ -1,5 +1,5 @@
-import Pbf = require("pbf");
 import { GeoJSON } from "geojson";
+import Pbf from "pbf";
 
 export function decode(pbf: Pbf): GeoJSON;
 export function encode(obj: GeoJSON, pbf: Pbf): Uint8Array;

--- a/types/geobuf/package.json
+++ b/types/geobuf/package.json
@@ -1,13 +1,15 @@
 {
     "private": true,
     "name": "@types/geobuf",
-    "version": "3.0.9999",
+    "version": "4.0.9999",
+    "type": "module",
     "projects": [
         "https://github.com/mapbox/geobuf"
     ],
+    "exports": "./index.d.ts",
     "dependencies": {
         "@types/geojson": "*",
-        "@types/pbf": "*"
+        "pbf": "^4.0.1"
     },
     "devDependencies": {
         "@types/geobuf": "workspace:."
@@ -16,6 +18,10 @@
         {
             "name": "Chad Burt",
             "githubUsername": "underbluewaters"
+        },
+        {
+            "name": "Yue JIN",
+            "githubUsername": "kingyue737"
         }
     ]
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mapbox/geobuf/releases/tag/v4.0.0 and https://github.com/mapbox/geobuf/compare/v3.0.2...v4.0.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---

### What changed in geobuf v4

- The library was modernized and is now **ESM-only** (`"type": "module"`, no CommonJS entry point), so the definitions drop `import Pbf = require("pbf")` in favor of ES imports, and the package gains `"type": "module"` + `"exports"`, matching other ESM-only definitions such as `@types/rbush`.
- geobuf v4 depends on `pbf@^4`, which **bundles its own types** (`export default class Pbf`), so the `@types/pbf` dependency (which describes pbf v3) is replaced with a direct dependency on `pbf`.
- The API surface itself is unchanged: `encode(obj, pbf)` and `decode(pbf)`.

### Dependency note

CI needs `pbf` in the allowed non-`@types` dependency list: https://github.com/microsoft/DefinitelyTyped-tools/pull/1336
