### PR TITLE
[chrome] fix chrome.printerProvider.onGetCapabilityRequested

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -8335,11 +8335,6 @@ declare namespace chrome {
             INVALID_DATA = "INVALID_DATA",
         }
 
-        interface PrinterCapabilities {
-            /** Device capabilities in CDD format. */
-            capabilities: { [key: string]: unknown };
-        }
-
         interface PrintJob {
             /** ID of the printer which should handle the job. */
             printerId: string;
@@ -8400,7 +8395,13 @@ declare namespace chrome {
 
         /** Event fired when print manager requests printer capabilities. */
         const onGetCapabilityRequested: events.Event<
-            (printerId: string, resultCallback: (capabilities: PrinterCapabilities) => void) => void
+            (
+                printerId: string,
+                resultCallback: (
+                    /** Device capabilities in CDD format. */
+                    capabilities: { [key: string]: unknown },
+                ) => void,
+            ) => void
         >;
 
         /** Event fired when print manager requests printing. */

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -6943,7 +6943,7 @@ function testPrinterProvider() {
 
     checkChromeEvent(chrome.printerProvider.onGetCapabilityRequested, (printerId, resultCallback) => {
         printerId; // $ExpectType string
-        resultCallback({ capabilities: {} }); // $ExpectType void
+        resultCallback({ version: "1.0", printer: { supported_content_type: [{ content_type: "application/pdf" }] } }); // $ExpectType void
     });
 
     checkChromeEvent(chrome.printerProvider.onGetPrintersRequested, (resultCallback) => {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  https://developer.chrome.com/docs/extensions/reference/api/printerProvider#event-onGetCapabilityRequested
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Notes:
- fix `chrome.printerProvider.onGetCapabilityRequested`: `capabilities` is not a `key` of `resultCallback`
  - with `callback({ capabilities: { version: "1.0", printer: { supported_content_type: [{content_type: "application/pdf"}] } } })`
  
    <img width="436" height="337" alt="Capture d&#39;écran 2026-09-13 113154" src="https://github.com/user-attachments/assets/a49b772f-054a-45a8-b716-6347ae9b5c86" />


  - with `callback({ version: "1.0", printer: { supported_content_type: [{content_type: "application/pdf"}] } })`
  
    <img width="442" height="447" alt="Capture d&#39;écran 2026-09-13 113242" src="https://github.com/user-attachments/assets/25ec5423-975c-40e4-92f7-be03b0b30268" />
