### PR TITLE
[k6] Add TLS certificate fetching types for v2.3

### DIFF
--- a/types/k6/options/index.d.ts
+++ b/types/k6/options/index.d.ts
@@ -119,6 +119,12 @@ export interface Options {
     /** Throw error on failed HTTP request. */
     throw?: boolean;
 
+    /**
+     * Fetch missing intermediate TLS certificates through Authority Information Access (AIA).
+     * Disabled by default. Has no effect when `insecureSkipTLSVerify` is true.
+     */
+    tlsAIAFetch?: boolean;
+
     /** TLS client certificates. */
     tlsAuth?: Certificate[];
 

--- a/types/k6/options/index.d.ts
+++ b/types/k6/options/index.d.ts
@@ -120,7 +120,9 @@ export interface Options {
     throw?: boolean;
 
     /**
-     * Fetch missing intermediate TLS certificates through Authority Information Access (AIA).
+     * Fetch missing intermediate certificates through Authority Information Access (AIA)
+     * when a server sends an incomplete TLS certificate chain, while keeping certificate
+     * and hostname verification enabled. Requires hostname targets rather than IP addresses.
      * Disabled by default. Has no effect when `insecureSkipTLSVerify` is true.
      */
     tlsAIAFetch?: boolean;

--- a/types/k6/package.json
+++ b/types/k6/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/k6",
-    "version": "2.2.9999",
+    "version": "2.3.9999",
     "type": "module",
     "projects": [
         "https://grafana.com/docs/k6/latest/"

--- a/types/k6/test/options.ts
+++ b/types/k6/test/options.ts
@@ -59,6 +59,7 @@ const scenarioExample: Options = {
 };
 
 const tlsOptions1: Options = {
+    tlsAIAFetch: true,
     tlsAuth: [
         {
             domains: ["example.com"],
@@ -70,6 +71,7 @@ const tlsOptions1: Options = {
 };
 
 const tlsOptions2: Options = {
+    tlsAIAFetch: false,
     tlsAuth: [
         {
             domains: ["example.com"],
@@ -80,6 +82,8 @@ const tlsOptions2: Options = {
 };
 
 const tlsOptions3: Options = {
+    // @ts-expect-error
+    tlsAIAFetch: "true",
     tlsAuth: [
         // @ts-expect-error
         {


### PR DESCRIPTION
Adds TLS certificate-fetching types and the version bump for k6 v2.3.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/grafana/k6/pull/6137 (source), https://github.com/grafana/k6-DefinitelyTyped/pull/121 (types and tests)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Validation: `pnpm test k6` and the dprint check for the changed files pass. The test runner reports the existing, ignored npm-version mismatch warning for k6.
